### PR TITLE
Remove non-static initializers

### DIFF
--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -16,15 +16,14 @@ import java.util.stream.Collectors;
  */
 public class AddressBook implements ReadOnlyAddressBook {
 
-    private final UniquePersonList persons;
-    private final UniqueTagList tags;
+    private UniquePersonList persons;
+    private UniqueTagList tags;
 
-    {
+
+    public AddressBook() {
         persons = new UniquePersonList();
         tags = new UniqueTagList();
     }
-
-    public AddressBook() {}
 
     /**
      * Persons and Tags are copied into this addressbook
@@ -37,6 +36,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      * Persons and Tags are copied into this addressbook
      */
     public AddressBook(UniquePersonList persons, UniqueTagList tags) {
+        this();
         resetData(persons.getInternalList(), tags.getInternalList());
     }
 

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -16,14 +16,22 @@ import java.util.stream.Collectors;
  */
 public class AddressBook implements ReadOnlyAddressBook {
 
-    private UniquePersonList persons;
-    private UniqueTagList tags;
+    private final UniquePersonList persons;
+    private final UniqueTagList tags;
 
-
-    public AddressBook() {
+    /*
+     * The 'unusual' code block below is an non-static initialization block, sometimes used to avoid duplication
+     * between constructors. See https://docs.oracle.com/javase/tutorial/java/javaOO/initial.html
+     *
+     * Note that non-static init blocks are not recommended to use. There are other ways to avoid duplication
+     *   among constructors.
+     */
+    {
         persons = new UniquePersonList();
         tags = new UniqueTagList();
     }
+
+    public AddressBook() {}
 
     /**
      * Persons and Tags are copied into this addressbook
@@ -36,7 +44,6 @@ public class AddressBook implements ReadOnlyAddressBook {
      * Persons and Tags are copied into this addressbook
      */
     public AddressBook(UniquePersonList persons, UniqueTagList tags) {
-        this();
         resetData(persons.getInternalList(), tags.getInternalList());
     }
 

--- a/src/main/java/seedu/address/storage/XmlSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/XmlSerializableAddressBook.java
@@ -25,20 +25,19 @@ public class XmlSerializableAddressBook implements ReadOnlyAddressBook {
     @XmlElement
     private List<Tag> tags;
 
-    {
+    /**
+     * Empty constructor required for marshalling
+     */
+    public XmlSerializableAddressBook() {
         persons = new ArrayList<>();
         tags = new ArrayList<>();
     }
 
     /**
-     * Empty constructor required for marshalling
-     */
-    public XmlSerializableAddressBook() {}
-
-    /**
      * Conversion
      */
     public XmlSerializableAddressBook(ReadOnlyAddressBook src) {
+        this();
         persons.addAll(src.getPersonList().stream().map(XmlAdaptedPerson::new).collect(Collectors.toList()));
         tags = src.getTagList();
     }


### PR DESCRIPTION
PMD discourages use of non-static initializer blocks as they are 'rarely used and confusing to the reader'