### PR TITLE
build.gradle: add `run` and `runShadow` tasks #177

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,11 @@
 plugins {
     id "com.github.kt3k.coveralls" version "2.4.0"
     id "com.github.johnrengelman.shadow" version '1.2.3'
+    id 'application'
 }
+
+// Specifies the entry point of the application
+mainClassName = 'seedu.address.MainApp'
 
 allprojects {
     apply plugin: 'idea'
@@ -82,10 +86,6 @@ allprojects {
 
     shadowJar {
         archiveName = "addressbook.jar"
-
-        manifest {
-            attributes "Main-Class": "seedu.address.MainApp"
-        }
 
         destinationDir = file("${buildDir}/jar/")
     }

--- a/docs/UsingGradle.md
+++ b/docs/UsingGradle.md
@@ -47,6 +47,14 @@ If we package only our own class files into the JAR file, it will not work prope
   Therefore, we package all dependencies into a single JAR files, creating what is also known as a _fat_ JAR file. 
   To create a fat JAR fil, we use the Gradle plugin [shadow jar](https://github.com/johnrengelman/shadow).
 
+## Running the application
+
+* **`run`** <br>
+  Builds and runs the application.
+
+* **`runShadow`** <br>
+  Builds the application as a fat JAR, and then runs it.
+
 ## Running code style checks
 
 * **`checkstyleMain`**<br>


### PR DESCRIPTION
Fixes #177 

The `run` and `runShadow` tasks provide a convenient way for developers
to run the built application from its *.class files or the built fat JAR
respectively.

This is accomplished using the application plugin[1] which implements
the 'run' task.

The shadow plugin, which we already use, will automatically detect the
`application` plugin and will integrate with it[2], providing the
`runShadow` task. It also knows that `mainClassName` should be used
as the "Main-Class" of the JAR manifest, so we don't need to specify
that anymore.

[1] https://docs.gradle.org/current/userguide/application_plugin.html
[2] http://imperceptiblethoughts.com/shadow/#integrating_with_application_plugin