### PR TITLE
checkstyle: ensure curly brackets have whitespace around them #181

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -215,11 +215,21 @@
       -->
       <property name="tokens" value="ASSIGN, BAND, BAND_ASSIGN, BOR,
         BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN,
-        EQUAL, GE, GT, LAND, LE, LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE,
+        EQUAL, GE, GT, LAND, LCURLY, LE, LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE,
         LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF, LITERAL_RETURN,
         LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, LOR, LT, MINUS,
         MINUS_ASSIGN, MOD, MOD_ASSIGN, NOT_EQUAL, PLUS, PLUS_ASSIGN, QUESTION,
-        SL, SL_ASSIGN, SR_ASSIGN, STAR, STAR_ASSIGN"/>
+        RCURLY, SL, SLIST, SL_ASSIGN, SR_ASSIGN, STAR, STAR_ASSIGN"/>
+      <!-- Allow empty constructors e.g. MyClass() {} -->
+      <property name="allowEmptyConstructors" value="true" />
+      <!-- Allow empty methods e.g. void func() {} -->
+      <property name="allowEmptyMethods" value="true" />
+      <!-- Allow empty types e.g. class Foo {}, enum Foo {} -->
+      <property name="allowEmptyTypes" value="true" />
+      <!-- Allow empty loops e.g. for (int i = 1; i > 1; i++) {} -->
+      <property name="allowEmptyLoops" value="true" />
+      <!-- Allow empty lambdas e.g. () -> {} -->
+      <property name="allowEmptyLambdas" value="true" />
       <property name="severity" value="error"/>
     </module>
 

--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -62,7 +62,7 @@ public class MainApp extends Application {
         initEventsCenter();
     }
 
-    private String getApplicationParameter(String parameterName){
+    private String getApplicationParameter(String parameterName) {
         Map<String, String> applicationParameters = getParameters().getNamed();
         return applicationParameters.get(parameterName);
     }

--- a/src/main/java/seedu/address/commons/core/ComponentManager.java
+++ b/src/main/java/seedu/address/commons/core/ComponentManager.java
@@ -13,7 +13,7 @@ public abstract class ComponentManager {
     /**
      * Uses default {@link EventsCenter}
      */
-    public ComponentManager(){
+    public ComponentManager() {
         this(EventsCenter.getInstance());
     }
 
@@ -22,7 +22,7 @@ public abstract class ComponentManager {
         eventsCenter.registerHandler(this);
     }
 
-    protected void raise(BaseEvent event){
+    protected void raise(BaseEvent event) {
         eventsCenter.post(event);
     }
 }

--- a/src/main/java/seedu/address/commons/core/Config.java
+++ b/src/main/java/seedu/address/commons/core/Config.java
@@ -61,10 +61,10 @@ public class Config {
 
     @Override
     public boolean equals(Object other) {
-        if (other == this){
+        if (other == this) {
             return true;
         }
-        if (!(other instanceof Config)){ //this handles null as well.
+        if (!(other instanceof Config)) { //this handles null as well.
             return false;
         }
 
@@ -83,7 +83,7 @@ public class Config {
     }
 
     @Override
-    public String toString(){
+    public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append("App title : " + appTitle);
         sb.append("\nCurrent log level : " + logLevel);

--- a/src/main/java/seedu/address/commons/core/GuiSettings.java
+++ b/src/main/java/seedu/address/commons/core/GuiSettings.java
@@ -42,10 +42,10 @@ public class GuiSettings implements Serializable {
 
     @Override
     public boolean equals(Object other) {
-        if (other == this){
+        if (other == this) {
             return true;
         }
-        if (!(other instanceof GuiSettings)){ //this handles null as well.
+        if (!(other instanceof GuiSettings)) { //this handles null as well.
             return false;
         }
 
@@ -63,7 +63,7 @@ public class GuiSettings implements Serializable {
     }
 
     @Override
-    public String toString(){
+    public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append("Width : " + windowWidth + "\n");
         sb.append("Height : " + windowHeight + "\n");

--- a/src/main/java/seedu/address/commons/events/model/AddressBookChangedEvent.java
+++ b/src/main/java/seedu/address/commons/events/model/AddressBookChangedEvent.java
@@ -8,7 +8,7 @@ public class AddressBookChangedEvent extends BaseEvent {
 
     public final ReadOnlyAddressBook data;
 
-    public AddressBookChangedEvent(ReadOnlyAddressBook data){
+    public AddressBookChangedEvent(ReadOnlyAddressBook data) {
         this.data = data;
     }
 

--- a/src/main/java/seedu/address/commons/events/storage/DataSavingExceptionEvent.java
+++ b/src/main/java/seedu/address/commons/events/storage/DataSavingExceptionEvent.java
@@ -14,7 +14,7 @@ public class DataSavingExceptionEvent extends BaseEvent {
     }
 
     @Override
-    public String toString(){
+    public String toString() {
         return exception.toString();
     }
 

--- a/src/main/java/seedu/address/commons/events/ui/PersonPanelSelectionChangedEvent.java
+++ b/src/main/java/seedu/address/commons/events/ui/PersonPanelSelectionChangedEvent.java
@@ -11,7 +11,7 @@ public class PersonPanelSelectionChangedEvent extends BaseEvent {
 
     private final ReadOnlyPerson newSelection;
 
-    public PersonPanelSelectionChangedEvent(ReadOnlyPerson newSelection){
+    public PersonPanelSelectionChangedEvent(ReadOnlyPerson newSelection) {
         this.newSelection = newSelection;
     }
 

--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -30,7 +30,7 @@ public class StringUtil {
         String preppedSentence = sentence;
         String[] wordsInPreppedSentence = preppedSentence.split("\\s+");
 
-        for (String wordInSentence: wordsInPreppedSentence){
+        for (String wordInSentence: wordsInPreppedSentence) {
             if (wordInSentence.equalsIgnoreCase(preppedWord)) return true;
         }
         return false;
@@ -39,7 +39,7 @@ public class StringUtil {
     /**
      * Returns a detailed message of the t, including the stack trace.
      */
-    public static String getDetails(Throwable t){
+    public static String getDetails(Throwable t) {
         assert t != null;
         StringWriter sw = new StringWriter();
         t.printStackTrace(new PrintWriter(sw));
@@ -52,7 +52,7 @@ public class StringUtil {
      * null, empty string, "-1", "0", "+1", and " 2 " (untrimmed) "3 0" (contains whitespace).
      * @param s Should be trimmed.
      */
-    public static boolean isUnsignedInteger(String s){
+    public static boolean isUnsignedInteger(String s) {
         return s != null && s.matches("^0*[1-9]\\d*$");
     }
 }

--- a/src/main/java/seedu/address/logic/commands/IncorrectCommand.java
+++ b/src/main/java/seedu/address/logic/commands/IncorrectCommand.java
@@ -8,7 +8,7 @@ public class IncorrectCommand extends Command {
 
     public final String feedbackToUser;
 
-    public IncorrectCommand(String feedbackToUser){
+    public IncorrectCommand(String feedbackToUser) {
         this.feedbackToUser = feedbackToUser;
     }
 

--- a/src/main/java/seedu/address/logic/parser/Parser.java
+++ b/src/main/java/seedu/address/logic/parser/Parser.java
@@ -82,7 +82,7 @@ public class Parser {
      * @param args full command args string
      * @return the prepared command
      */
-    private Command prepareAdd(String args){
+    private Command prepareAdd(String args) {
         ArgumentTokenizer argsTokenizer = new ArgumentTokenizer(phoneNumberPrefix, emailPrefix,
                                                                 addressPrefix, tagsPrefix);
         argsTokenizer.tokenize(args);

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -90,7 +90,7 @@ public class ModelManager extends ComponentManager implements Model {
     }
 
     @Override
-    public void updateFilteredPersonList(Set<String> keywords){
+    public void updateFilteredPersonList(Set<String> keywords) {
         updateFilteredPersonList(new PredicateExpression(new NameQualifier(keywords)));
     }
 

--- a/src/main/java/seedu/address/model/UserPrefs.java
+++ b/src/main/java/seedu/address/model/UserPrefs.java
@@ -19,7 +19,7 @@ public class UserPrefs {
         this.guiSettings = guiSettings;
     }
 
-    public UserPrefs(){
+    public UserPrefs() {
         this.setGuiSettings(500, 500, 0, 0);
     }
 
@@ -47,7 +47,7 @@ public class UserPrefs {
     }
 
     @Override
-    public String toString(){
+    public String toString() {
         return guiSettings.toString();
     }
 

--- a/src/main/java/seedu/address/storage/JsonUserPrefsStorage.java
+++ b/src/main/java/seedu/address/storage/JsonUserPrefsStorage.java
@@ -14,7 +14,7 @@ public class JsonUserPrefsStorage implements UserPrefsStorage {
 
     private String filePath;
 
-    public JsonUserPrefsStorage(String filePath){
+    public JsonUserPrefsStorage(String filePath) {
         this.filePath = filePath;
     }
 

--- a/src/main/java/seedu/address/storage/XmlAddressBookStorage.java
+++ b/src/main/java/seedu/address/storage/XmlAddressBookStorage.java
@@ -20,11 +20,11 @@ public class XmlAddressBookStorage implements AddressBookStorage {
 
     private String filePath;
 
-    public XmlAddressBookStorage(String filePath){
+    public XmlAddressBookStorage(String filePath) {
         this.filePath = filePath;
     }
 
-    public String getAddressBookFilePath(){
+    public String getAddressBookFilePath() {
         return filePath;
     }
 

--- a/src/main/java/seedu/address/ui/BrowserPanel.java
+++ b/src/main/java/seedu/address/ui/BrowserPanel.java
@@ -13,7 +13,7 @@ import java.util.logging.Logger;
 /**
  * The Browser Panel of the App.
  */
-public class BrowserPanel extends UiPart{
+public class BrowserPanel extends UiPart {
 
     private static Logger logger = LogsCenter.getLogger(BrowserPanel.class);
     private WebView browser;
@@ -40,7 +40,7 @@ public class BrowserPanel extends UiPart{
      * This method should be called after the FX runtime is initialized and in FX application thread.
      * @param placeholder The AnchorPane where the BrowserPanel must be inserted
      */
-    public static BrowserPanel load(AnchorPane placeholder){
+    public static BrowserPanel load(AnchorPane placeholder) {
         logger.info("Initializing browser");
         BrowserPanel browserPanel = new BrowserPanel();
         browserPanel.browser = new WebView();
@@ -55,7 +55,7 @@ public class BrowserPanel extends UiPart{
         loadPage("https://www.google.com.sg/#safe=off&q=" + person.getName().fullName.replaceAll(" ", "+"));
     }
 
-    public void loadPage(String url){
+    public void loadPage(String url) {
         browser.getEngine().load(url);
     }
 

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -88,7 +88,7 @@ public class CommandBox extends UiPart {
     }
 
     @Subscribe
-    private void handleIncorrectCommandAttempted(IncorrectCommandAttemptedEvent event){
+    private void handleIncorrectCommandAttempted(IncorrectCommandAttemptedEvent event) {
         logger.info(LogsCenter.getEventHandlingLogMessage(event, "Invalid command: " + previousCommandText));
         setStyleToIndicateIncorrectCommand();
         restoreCommandText();

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -43,7 +43,7 @@ public class HelpWindow extends UiPart {
         return FXML;
     }
 
-    private void configure(){
+    private void configure() {
         Scene scene = new Scene(mainPane);
         //Null passed as the parent stage to make it non-modal.
         dialogStage = createDialogStage(TITLE, null, scene);

--- a/src/main/java/seedu/address/ui/UiPart.java
+++ b/src/main/java/seedu/address/ui/UiPart.java
@@ -25,7 +25,7 @@ public abstract class UiPart {
      * Raises the event via {@link EventsCenter#post(BaseEvent)}
      * @param event
      */
-    protected void raise(BaseEvent event){
+    protected void raise(BaseEvent event) {
         EventsCenter.getInstance().post(event);
     }
 

--- a/src/test/java/guitests/CommandBoxTest.java
+++ b/src/test/java/guitests/CommandBoxTest.java
@@ -13,7 +13,7 @@ public class CommandBoxTest extends AddressBookGuiTest {
     }
 
     @Test
-    public void commandBox_commandFails_textStays(){
+    public void commandBox_commandFails_textStays() {
         commandBox.runCommand("invalid command");
         assertEquals(commandBox.getCommandInput(), "invalid command");
         //TODO: confirm the text box color turns to red

--- a/src/test/java/guitests/ErrorDialogGuiTest.java
+++ b/src/test/java/guitests/ErrorDialogGuiTest.java
@@ -8,7 +8,7 @@ import java.io.IOException;
 
 import static junit.framework.TestCase.assertTrue;
 
-public class ErrorDialogGuiTest extends AddressBookGuiTest{
+public class ErrorDialogGuiTest extends AddressBookGuiTest {
 
     @Test
     public void showErrorDialogs() throws InterruptedException {

--- a/src/test/java/guitests/FindCommandTest.java
+++ b/src/test/java/guitests/FindCommandTest.java
@@ -19,7 +19,7 @@ public class FindCommandTest extends AddressBookGuiTest {
     }
 
     @Test
-    public void find_emptyList(){
+    public void find_emptyList() {
         commandBox.runCommand("clear");
         assertFindResult("find Jean"); // no results
     }

--- a/src/test/java/guitests/GuiRobot.java
+++ b/src/test/java/guitests/GuiRobot.java
@@ -10,7 +10,7 @@ import seedu.address.testutil.TestUtil;
  */
 public class GuiRobot extends FxRobot {
 
-    public GuiRobot push(KeyCodeCombination keyCodeCombination){
+    public GuiRobot push(KeyCodeCombination keyCodeCombination) {
         return (GuiRobot) super.push(TestUtil.scrub(keyCodeCombination));
     }
 

--- a/src/test/java/guitests/SelectCommandTest.java
+++ b/src/test/java/guitests/SelectCommandTest.java
@@ -27,7 +27,7 @@ public class SelectCommandTest extends AddressBookGuiTest {
     }
 
     @Test
-    public void selectPerson_emptyList(){
+    public void selectPerson_emptyList() {
         commandBox.runCommand("clear");
         assertListSize(0);
         assertSelectionInvalid(1); //invalid index

--- a/src/test/java/guitests/guihandles/CommandBoxHandle.java
+++ b/src/test/java/guitests/guihandles/CommandBoxHandle.java
@@ -6,7 +6,7 @@ import javafx.stage.Stage;
 /**
  * A handle to the Command Box in the GUI.
  */
-public class CommandBoxHandle extends GuiHandle{
+public class CommandBoxHandle extends GuiHandle {
 
     private static final String COMMAND_INPUT_FIELD_ID = "#commandTextField";
 

--- a/src/test/java/guitests/guihandles/PersonCardHandle.java
+++ b/src/test/java/guitests/guihandles/PersonCardHandle.java
@@ -16,7 +16,7 @@ public class PersonCardHandle extends GuiHandle {
 
     private Node node;
 
-    public PersonCardHandle(GuiRobot guiRobot, Stage primaryStage, Node node){
+    public PersonCardHandle(GuiRobot guiRobot, Stage primaryStage, Node node) {
         super(guiRobot, primaryStage, null);
         this.node = node;
     }

--- a/src/test/java/guitests/guihandles/PersonListPanelHandle.java
+++ b/src/test/java/guitests/guihandles/PersonListPanelHandle.java
@@ -47,7 +47,7 @@ public class PersonListPanelHandle extends GuiHandle {
     public boolean isListMatching(ReadOnlyPerson... persons) {
         return this.isListMatching(0, persons);
     }
-    
+
     /**
      * Clicks on the ListView.
      */
@@ -63,7 +63,7 @@ public class PersonListPanelHandle extends GuiHandle {
         List<ReadOnlyPerson> personsInList = getListView().getItems();
 
         // Return false if the list in panel is too short to contain the given list
-        if (startPosition + persons.length > personsInList.size()){
+        if (startPosition + persons.length > personsInList.size()) {
             return false;
         }
 

--- a/src/test/java/seedu/address/commons/core/ConfigTest.java
+++ b/src/test/java/seedu/address/commons/core/ConfigTest.java
@@ -22,7 +22,7 @@ public class ConfigTest {
     }
 
     @Test
-    public void equalsMethod(){
+    public void equalsMethod() {
         Config defaultConfig = new Config();
         assertNotNull(defaultConfig);
         assertTrue(defaultConfig.equals(defaultConfig));

--- a/src/test/java/seedu/address/commons/util/AppUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/AppUtilTest.java
@@ -14,13 +14,13 @@ public class AppUtilTest {
 
 
     @Test
-    public void getImage_exitingImage(){
+    public void getImage_exitingImage() {
         assertNotNull(AppUtil.getImage("/images/address_book_32.png"));
     }
 
 
     @Test
-    public void getImage_nullGiven_assertionError(){
+    public void getImage_nullGiven_assertionError() {
         thrown.expect(AssertionError.class);
         AppUtil.getImage(null);
     }

--- a/src/test/java/seedu/address/commons/util/FileUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/FileUtilTest.java
@@ -15,7 +15,7 @@ public class FileUtilTest {
     public ExpectedException thrown = ExpectedException.none();
 
     @Test
-    public void getPath(){
+    public void getPath() {
 
         // valid case
         assertEquals("folder" + File.separator + "sub-folder", FileUtil.getPath("folder/sub-folder"));

--- a/src/test/java/seedu/address/commons/util/StringUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/StringUtilTest.java
@@ -58,7 +58,7 @@ public class StringUtilTest {
      */
 
     @Test
-    public void containsWordIgnoreCase_nullWord_exceptionThrown(){
+    public void containsWordIgnoreCase_nullWord_exceptionThrown() {
         assertExceptionThrown("typical sentence", null, "Word parameter cannot be null");
     }
 
@@ -69,17 +69,17 @@ public class StringUtilTest {
     }
 
     @Test
-    public void containsWordIgnoreCase_emptyWord_exceptionThrown(){
+    public void containsWordIgnoreCase_emptyWord_exceptionThrown() {
         assertExceptionThrown("typical sentence", "  ", "Word parameter cannot be empty");
     }
 
     @Test
-    public void containsWordIgnoreCase_multipleWords_exceptionThrown(){
+    public void containsWordIgnoreCase_multipleWords_exceptionThrown() {
         assertExceptionThrown("typical sentence", "aaa BBB", "Word parameter should be a single word");
     }
 
     @Test
-    public void containsWordIgnoreCase_nullSentence_exceptionThrown(){
+    public void containsWordIgnoreCase_nullSentence_exceptionThrown() {
         assertExceptionThrown(null, "abc", "Sentence parameter cannot be null");
     }
 
@@ -109,7 +109,7 @@ public class StringUtilTest {
      */
 
     @Test
-    public void containsWordIgnoreCase_validInputs_correctResult(){
+    public void containsWordIgnoreCase_validInputs_correctResult() {
 
         // Empty sentence
         assertFalse(StringUtil.containsWordIgnoreCase("", "abc")); // Boundary case
@@ -137,13 +137,13 @@ public class StringUtilTest {
      */
 
     @Test
-    public void getDetails_exceptionGiven(){
+    public void getDetails_exceptionGiven() {
         assertThat(StringUtil.getDetails(new FileNotFoundException("file not found")),
                    containsString("java.io.FileNotFoundException: file not found"));
     }
 
     @Test
-    public void getDetails_nullGiven_assertionError(){
+    public void getDetails_nullGiven_assertionError() {
         thrown.expect(AssertionError.class);
         StringUtil.getDetails(null);
     }

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -378,7 +378,7 @@ public class LogicManagerTest {
     /**
      * A utility class to generate test data.
      */
-    class TestDataHelper{
+    class TestDataHelper {
 
         Person adam() throws Exception {
             Name name = new Name("Adam Brown");
@@ -430,7 +430,7 @@ public class LogicManagerTest {
         /**
          * Generates an AddressBook with auto-generated persons.
          */
-        AddressBook generateAddressBook(int numGenerated) throws Exception{
+        AddressBook generateAddressBook(int numGenerated) throws Exception {
             AddressBook addressBook = new AddressBook();
             addToAddressBook(addressBook, numGenerated);
             return addressBook;
@@ -439,7 +439,7 @@ public class LogicManagerTest {
         /**
          * Generates an AddressBook based on the list of Persons given.
          */
-        AddressBook generateAddressBook(List<Person> persons) throws Exception{
+        AddressBook generateAddressBook(List<Person> persons) throws Exception {
             AddressBook addressBook = new AddressBook();
             addToAddressBook(addressBook, persons);
             return addressBook;
@@ -466,14 +466,14 @@ public class LogicManagerTest {
          * Adds auto-generated Person objects to the given model
          * @param model The model to which the Persons will be added
          */
-        void addToModel(Model model, int numGenerated) throws Exception{
+        void addToModel(Model model, int numGenerated) throws Exception {
             addToModel(model, generatePersonList(numGenerated));
         }
 
         /**
          * Adds the given list of Persons to the given model
          */
-        void addToModel(Model model, List<Person> personsToAdd) throws Exception{
+        void addToModel(Model model, List<Person> personsToAdd) throws Exception {
             for (Person p: personsToAdd) {
                 model.addPerson(p);
             }
@@ -482,7 +482,7 @@ public class LogicManagerTest {
         /**
          * Generates a list of Persons based on the flags.
          */
-        List<Person> generatePersonList(int numGenerated) throws Exception{
+        List<Person> generatePersonList(int numGenerated) throws Exception {
             List<Person> persons = new ArrayList<>();
             for (int i = 1; i <= numGenerated; i++) {
                 persons.add(generatePerson(i));

--- a/src/test/java/seedu/address/storage/StorageManagerTest.java
+++ b/src/test/java/seedu/address/storage/StorageManagerTest.java
@@ -66,7 +66,7 @@ public class StorageManagerTest {
     }
 
     @Test
-    public void getAddressBookFilePath(){
+    public void getAddressBookFilePath() {
         assertNotNull(storageManager.getAddressBookFilePath());
     }
 
@@ -84,7 +84,7 @@ public class StorageManagerTest {
     /**
      * A Stub class to throw an exception when the save method is called
      */
-    class XmlAddressBookStorageExceptionThrowingStub extends XmlAddressBookStorage{
+    class XmlAddressBookStorageExceptionThrowingStub extends XmlAddressBookStorage {
 
         public XmlAddressBookStorageExceptionThrowingStub(String filePath) {
             super(filePath);

--- a/src/test/java/seedu/address/testutil/AddressBookBuilder.java
+++ b/src/test/java/seedu/address/testutil/AddressBookBuilder.java
@@ -15,7 +15,7 @@ public class AddressBookBuilder {
 
     private AddressBook addressBook;
 
-    public AddressBookBuilder(AddressBook addressBook){
+    public AddressBookBuilder(AddressBook addressBook) {
         this.addressBook = addressBook;
     }
 
@@ -29,7 +29,7 @@ public class AddressBookBuilder {
         return this;
     }
 
-    public AddressBook build(){
+    public AddressBook build() {
         return addressBook;
     }
 }

--- a/src/test/java/seedu/address/testutil/EventsCollector.java
+++ b/src/test/java/seedu/address/testutil/EventsCollector.java
@@ -10,10 +10,10 @@ import java.util.List;
 /**
  * A class that collects events raised by other classes.
  */
-public class EventsCollector{
+public class EventsCollector {
     private List<BaseEvent> events = new ArrayList<BaseEvent>();
 
-    public EventsCollector(){
+    public EventsCollector() {
         EventsCenter.getInstance().registerHandler(this);
     }
 
@@ -21,21 +21,21 @@ public class EventsCollector{
      * Collects any event raised by any class
      */
     @Subscribe
-    public void collectEvent(BaseEvent event){
+    public void collectEvent(BaseEvent event) {
         events.add(event);
     }
 
     /**
      * Removes collected events from the collected list
      */
-    public void reset(){
+    public void reset() {
         events.clear();
     }
 
     /**
      * Returns the event at the specified index
      */
-    public BaseEvent get(int index){
+    public BaseEvent get(int index) {
         return events.get(index);
     }
 }


### PR DESCRIPTION
Fixes #181 

The Java coding standard[1] requires that curly brackets ({}) be
surrounded by whitespace.

However, there are several violations of this requirement in the code
base. e.g.

    protected void raise(BaseEvent event){
    -------------------------------------^
                        Space required before '{'

Fix all of these code style violations.

Our checkstyle configuration failed to catch these errors because we did
not tell checkstyle to check for the LCURLY, RCURLY and SLIST (statement
list) tokens. Fix this in the checkstyle config file so that such code
style violations will not happen again.

[1] https://oss-generic.github.io/process/codingstandards/coding-standards-java.html#methods