### PR TITLE
Construct StatusBarFooter in FXML fully #188

### DIFF
--- a/src/main/java/seedu/address/ui/StatusBarFooter.java
+++ b/src/main/java/seedu/address/ui/StatusBarFooter.java
@@ -19,16 +19,13 @@ import java.util.logging.Logger;
  */
 public class StatusBarFooter extends UiPart {
     private static final Logger logger = LogsCenter.getLogger(StatusBarFooter.class);
+
+    @FXML
     private StatusBar syncStatus;
+    @FXML
     private StatusBar saveLocationStatus;
 
     private GridPane mainPane;
-
-    @FXML
-    private AnchorPane saveLocStatusBarPane;
-
-    @FXML
-    private AnchorPane syncStatusBarPane;
 
     private AnchorPane placeHolder;
 
@@ -42,9 +39,7 @@ public class StatusBarFooter extends UiPart {
 
     public void configure(String saveLocation) {
         addMainPane();
-        addSyncStatus();
         setSyncStatus("Not updated yet in this session");
-        addSaveLocation();
         setSaveLocation("./" + saveLocation);
         registerAsAnEventHandler(this);
     }
@@ -58,20 +53,8 @@ public class StatusBarFooter extends UiPart {
         this.saveLocationStatus.setText(location);
     }
 
-    private void addSaveLocation() {
-        this.saveLocationStatus = new StatusBar();
-        FxViewUtil.applyAnchorBoundaryParameters(saveLocationStatus, 0.0, 0.0, 0.0, 0.0);
-        saveLocStatusBarPane.getChildren().add(saveLocationStatus);
-    }
-
     private void setSyncStatus(String status) {
         this.syncStatus.setText(status);
-    }
-
-    private void addSyncStatus() {
-        this.syncStatus = new StatusBar();
-        FxViewUtil.applyAnchorBoundaryParameters(syncStatus, 0.0, 0.0, 0.0, 0.0);
-        syncStatusBarPane.getChildren().add(syncStatus);
     }
 
     @Override

--- a/src/main/resources/view/StatusBarFooter.fxml
+++ b/src/main/resources/view/StatusBarFooter.fxml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <?import javafx.scene.layout.*?>
+<?import org.controlsfx.control.StatusBar?>
 <GridPane styleClass="grid-pane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1" fx:controller="seedu.address.ui.StatusBarFooter" stylesheets="@DarkTheme.css">
 <columnConstraints>
   <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
   <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
 </columnConstraints>
  <children>
-      <AnchorPane styleClass="anchor-pane" id="syncStatusBarPane" fx:id="syncStatusBarPane" minWidth="0.0" />
-      <AnchorPane styleClass="anchor-pane" id="saveLocStatusBarPane" fx:id="saveLocStatusBarPane" minWidth="0.0" GridPane.columnIndex="1" />
+      <StatusBar styleClass="anchor-pane" fx:id="syncStatus" minWidth="0.0"/>
+      <StatusBar styleClass="anchor-pane" fx:id="saveLocationStatus" minWidth="0.0" GridPane.columnIndex="1"/>
  </children>
 </GridPane>


### PR DESCRIPTION
Fixes #188 

StatusBarFooter currently constructs and sets up its StatusBar controls
using pure code.

The StatusBar control is actually a real control that can be initialized
directly in the FXML file. We can avoid placeholder elements and make
things simpler by just doing that.

Now, one may think: "This means Scene Builder cannot edit this FXML file
any more!", since the StatusBar control comes from controlsfx, which is
not supported by Scene Builder by default. However,

1. Scene Builder can actually be configured[1] to support the custom
   controls from controlsfx, allowing it to edit the FXML file.

2. Having too many placeholder nodes, and constructing the actual scene
   graph in code, kind of defeats the advantage of FXML which is to
   construct the scene graph declaratively without code.

[1] http://stackoverflow.com/a/30078204

Coverage decrease is due to the overall line count of the code base decreasing.