### PR TITLE
Set Up AppVeyor CI #192

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,24 @@
+init:
+    - git config --global core.autocrlf true
+
+# Call on gradle to build and run tests
+# --no-daemon: Prevent the daemon from launching to prevent file-in-use errors
+#     when we cache the ~/.gradle directory
+
+build_script:
+    - gradlew.bat --no-daemon assemble
+
+test_script:
+    - gradlew.bat --no-daemon headless checkstyleMain checkstyleTest allTests
+
+environment:
+    matrix:
+        - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+        - JAVA_HOME: C:\Program Files (x86)\Java\jdk1.8.0
+
+# Files/folders to preserve between builds to speed them up
+cache:
+    - C:\Users\appveyor\.gradle
+
+matrix:
+    fast_finish: true  # Finish build once any job fails


### PR DESCRIPTION
Fixes #192 

AppVeyor[1] is a continuous integration service used to build and test
projects on a Windows VM. Adding AppVeyor support to this project will
allow us to easily ensure that our tests do not break on Windows.

Add an appveyor.yml file that will teach AppVeyor how to build this
project and run its tests.

[1] https://www.appveyor.com/

Work in progress, will ping when it is ready.