### PR TITLE
checkstyle: NewlineAtEndOfFile errors with vanilla Git config on Windows #191

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -14,7 +14,10 @@
     <!-- Checks that there are no tab characters in the file. -->
   </module>
 
-  <module name="NewlineAtEndOfFile"/>
+  <module name="NewlineAtEndOfFile">
+    <!-- Accept LF, CR or CRLF to accomodate devs who prefer different line endings -->
+    <property name="lineSeparator" value="lf_cr_crlf"/>
+  </module>
 
   <module name="RegexpSingleline">
     <!-- Checks that FIXME is not used in comments.  TODO is preferred. -->


### PR DESCRIPTION
Fixes #191 

Checking out this repo on a Windows machine with a vanilla Git config,
then running `gradlew.bat checkstyleMain` gives the following errors:

    [ant:checkstyle] [ERROR] C:\Users\pyokagan\pyk\addressbook-level4\src\main\java\
    seedu\address\MainApp.java:0: File does not end with a newline. [NewlineAtEndOfF
    ile]
    [ant:checkstyle] [ERROR] C:\Users\pyokagan\pyk\addressbook-level4\src\main\java\
    seedu\address\commons\core\ComponentManager.java:0: File does not end with a new
    line. [NewlineAtEndOfFile]
    [ant:checkstyle] [ERROR] C:\Users\pyokagan\pyk\addressbook-level4\src\main\java\
    seedu\address\commons\core\Config.java:0: File does not end with a newline. [New
    lineAtEndOfFile]
    [ant:checkstyle] [ERROR] C:\Users\pyokagan\pyk\addressbook-level4\src\main\java\
    seedu\address\commons\core\EventsCenter.java:0: File does not end with a newline
    . [NewlineAtEndOfFile]
    [ant:checkstyle] [ERROR] C:\Users\pyokagan\pyk\addressbook-level4\src\main\java\
    seedu\address\commons\core\GuiSettings.java:0: File does not end with a newline.
     [NewlineAtEndOfFile]
    [ant:checkstyle] [ERROR] C:\Users\pyokagan\pyk\addressbook-level4\src\main\java\
    seedu\address\commons\core\LogsCenter.java:0: File does not end with a newline.
    [NewlineAtEndOfFile]
    [ant:checkstyle] [ERROR] C:\Users\pyokagan\pyk\addressbook-level4\src\main\java\
    seedu\address\commons\core\Messages.java:0: File does not end with a newline. [N
    ewlineAtEndOfFile]
    [ant:checkstyle] [ERROR] C:\Users\pyokagan\pyk\addressbook-level4\src\main\java\
    seedu\address\commons\core\UnmodifiableObservableList.java:0: File does not end
    with a newline. [NewlineAtEndOfFile]
    ...etc

This goes on for every single Java file.

This is because this repo's files uses LF as the line separator.
However, the default "lineSeparator" value of the "NewlineAtEndOfFile"
check is CRLF on Windows[1], hence these errors.

One may argue that we could switch on `core.autocrlf` in Git, which
would tell Git to automatically convert all LF line endings to CRLF,
thus avoiding this problem. However, this not only places an additional
burden on Windows users to configure Git properly, it also does not
handle the use cases where a developer is not using Git. The developer
may, for example, instead get hold of the repo by downloading the ZIP
file using Github's "Download as ZIP"[2] functionality, and will thus
still have this problem as the downloaded ZIP contents will still
contain LF line endings.

Thus, we should either switch the "lineSeparator" property to "lf",
accepting only LF line endings, or "lf_cr_crlf", accepting LF, CR or
CRLF line endings. (Checkstyle does not support just LF and CRLF only)

However, some developers may have `core.autocrlf` accidentally set, or
may even prefer to use CRLF line endings in their working copy. As such,
let's go the route of allowing LF, CR or CRLF as line endings.

[1] http://checkstyle.sourceforge.net/config_misc.html#NewlineAtEndOfFile
[2] https://github.com/se-edu/addressbook-level4/archive/master.zip

cc @m133225 