### PR TITLE
Make ReadOnlyAddressBook truly read-only #190

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -14,7 +14,7 @@ public class ClearCommand extends Command {
     @Override
     public CommandResult execute() {
         assert model != null;
-        model.resetData(AddressBook.getEmptyAddressBook());
+        model.resetData(new AddressBook());
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -9,6 +9,8 @@ import seedu.address.model.tag.UniqueTagList;
 
 import java.util.*;
 
+import javafx.collections.ObservableList;
+
 /**
  * Wraps all data at the address-book level
  * Duplicates are not allowed (by .equals comparison)
@@ -41,10 +43,6 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
 //// list overwrite operations
-
-    public UnmodifiableObservableList<Person> getPersons() {
-        return new UnmodifiableObservableList<>(persons.asObservableList());
-    }
 
     public void setPersons(List<? extends ReadOnlyPerson> persons)
             throws UniquePersonList.DuplicatePersonException {
@@ -137,8 +135,8 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     @Override
-    public List<ReadOnlyPerson> getPersonList() {
-        return Collections.unmodifiableList(persons.asObservableList());
+    public ObservableList<ReadOnlyPerson> getPersonList() {
+        return new UnmodifiableObservableList<>(persons.asObservableList());
     }
 
     @Override

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -140,8 +140,8 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     @Override
-    public List<Tag> getTagList() {
-        return Collections.unmodifiableList(tags.asObservableList());
+    public ObservableList<Tag> getTagList() {
+        return new UnmodifiableObservableList<>(tags.asObservableList());
     }
 
     @Override

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -46,10 +46,6 @@ public class AddressBook implements ReadOnlyAddressBook {
         resetData(persons, tags);
     }
 
-    public static ReadOnlyAddressBook getEmptyAddressBook() {
-        return new AddressBook();
-    }
-
 //// list overwrite operations
 
     public UnmodifiableObservableList<Person> getPersons() {

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -23,7 +23,7 @@ public class ModelManager extends ComponentManager implements Model {
     private static final Logger logger = LogsCenter.getLogger(ModelManager.class);
 
     private final AddressBook addressBook;
-    private final FilteredList<Person> filteredPersons;
+    private final FilteredList<ReadOnlyPerson> filteredPersons;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -35,7 +35,7 @@ public class ModelManager extends ComponentManager implements Model {
         logger.fine("Initializing with address book: " + addressBook + " and user prefs " + userPrefs);
 
         this.addressBook = new AddressBook(addressBook);
-        filteredPersons = new FilteredList<>(this.addressBook.getPersons());
+        filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
     }
 
     public ModelManager() {

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -3,6 +3,7 @@ package seedu.address.model;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.core.UnmodifiableObservableList;
+import seedu.address.commons.util.CollectionUtil;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.commons.events.model.AddressBookChangedEvent;
 import seedu.address.commons.core.ComponentManager;
@@ -25,27 +26,20 @@ public class ModelManager extends ComponentManager implements Model {
     private final FilteredList<Person> filteredPersons;
 
     /**
-     * Initializes a ModelManager with the given AddressBook
-     * AddressBook and its variables should not be null
+     * Initializes a ModelManager with the given addressBook and userPrefs.
      */
-    public ModelManager(AddressBook src, UserPrefs userPrefs) {
+    public ModelManager(ReadOnlyAddressBook addressBook, UserPrefs userPrefs) {
         super();
-        assert src != null;
-        assert userPrefs != null;
+        assert !CollectionUtil.isAnyNull(addressBook, userPrefs);
 
-        logger.fine("Initializing with address book: " + src + " and user prefs " + userPrefs);
+        logger.fine("Initializing with address book: " + addressBook + " and user prefs " + userPrefs);
 
-        addressBook = new AddressBook(src);
-        filteredPersons = new FilteredList<>(addressBook.getPersons());
+        this.addressBook = new AddressBook(addressBook);
+        filteredPersons = new FilteredList<>(this.addressBook.getPersons());
     }
 
     public ModelManager() {
         this(new AddressBook(), new UserPrefs());
-    }
-
-    public ModelManager(ReadOnlyAddressBook initialData, UserPrefs userPrefs) {
-        addressBook = new AddressBook(initialData);
-        filteredPersons = new FilteredList<>(addressBook.getPersons());
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
+++ b/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
@@ -2,10 +2,7 @@ package seedu.address.model;
 
 
 import seedu.address.model.person.ReadOnlyPerson;
-import seedu.address.model.person.UniquePersonList;
 import seedu.address.model.tag.Tag;
-import seedu.address.model.tag.UniqueTagList;
-
 import java.util.List;
 
 /**
@@ -13,17 +10,15 @@ import java.util.List;
  */
 public interface ReadOnlyAddressBook {
 
-    UniqueTagList getUniqueTagList();
-
-    UniquePersonList getUniquePersonList();
-
     /**
-     * Returns an unmodifiable view of persons list
+     * Returns an unmodifiable view of the persons list.
+     * This list will not contain any duplicate persons.
      */
     List<ReadOnlyPerson> getPersonList();
 
     /**
-     * Returns an unmodifiable view of tags list
+     * Returns an unmodifiable view of the tags list.
+     * This list will not contain any duplicate tags.
      */
     List<Tag> getTagList();
 

--- a/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
+++ b/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
@@ -5,6 +5,8 @@ import seedu.address.model.person.ReadOnlyPerson;
 import seedu.address.model.tag.Tag;
 import java.util.List;
 
+import javafx.collections.ObservableList;
+
 /**
  * Unmodifiable view of an address book
  */
@@ -14,7 +16,7 @@ public interface ReadOnlyAddressBook {
      * Returns an unmodifiable view of the persons list.
      * This list will not contain any duplicate persons.
      */
-    List<ReadOnlyPerson> getPersonList();
+    ObservableList<ReadOnlyPerson> getPersonList();
 
     /**
      * Returns an unmodifiable view of the tags list.

--- a/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
+++ b/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
@@ -3,8 +3,6 @@ package seedu.address.model;
 
 import seedu.address.model.person.ReadOnlyPerson;
 import seedu.address.model.tag.Tag;
-import java.util.List;
-
 import javafx.collections.ObservableList;
 
 /**
@@ -22,6 +20,6 @@ public interface ReadOnlyAddressBook {
      * Returns an unmodifiable view of the tags list.
      * This list will not contain any duplicate tags.
      */
-    List<Tag> getTagList();
+    ObservableList<Tag> getTagList();
 
 }

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -59,6 +59,14 @@ public class UniquePersonList implements Iterable<Person> {
         this.internalList.setAll(replacement.internalList);
     }
 
+    public void setPersons(List<? extends ReadOnlyPerson> persons) throws DuplicatePersonException {
+        final UniquePersonList replacement = new UniquePersonList();
+        for (final ReadOnlyPerson person : persons) {
+            replacement.add(new Person(person));
+        }
+        setPersons(replacement);
+    }
+
     public UnmodifiableObservableList<Person> asObservableList() {
         return new UnmodifiableObservableList<>(internalList);
     }

--- a/src/main/java/seedu/address/model/tag/UniqueTagList.java
+++ b/src/main/java/seedu/address/model/tag/UniqueTagList.java
@@ -43,11 +43,8 @@ public class UniqueTagList implements Iterable<Tag> {
      * Enforces no null or duplicate elements.
      */
     public UniqueTagList(Collection<Tag> tags) throws DuplicateTagException {
-        CollectionUtil.assertNoNullElements(tags);
-        if (!CollectionUtil.elementsAreUnique(tags)) {
-            throw new DuplicateTagException();
-        }
-        internalList.addAll(tags);
+        this();
+        setTags(tags);
     }
 
     /**
@@ -80,6 +77,14 @@ public class UniqueTagList implements Iterable<Tag> {
      */
     public void setTags(UniqueTagList replacement) {
         this.internalList.setAll(replacement.internalList);
+    }
+
+    public void setTags(Collection<Tag> tags) throws DuplicateTagException {
+        CollectionUtil.assertNoNullElements(tags);
+        if (!CollectionUtil.elementsAreUnique(tags)) {
+            throw new DuplicateTagException();
+        }
+        internalList.setAll(tags);
     }
 
     /**

--- a/src/main/java/seedu/address/storage/XmlSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/XmlSerializableAddressBook.java
@@ -2,11 +2,8 @@ package seedu.address.storage;
 
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.tag.Tag;
-import seedu.address.model.tag.UniqueTagList;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.ReadOnlyPerson;
-import seedu.address.model.person.UniquePersonList;
-
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import java.util.ArrayList;
@@ -40,32 +37,6 @@ public class XmlSerializableAddressBook implements ReadOnlyAddressBook {
         this();
         persons.addAll(src.getPersonList().stream().map(XmlAdaptedPerson::new).collect(Collectors.toList()));
         tags.addAll(src.getTagList().stream().map(XmlAdaptedTag::new).collect(Collectors.toList()));
-    }
-
-    @Override
-    public UniqueTagList getUniqueTagList() {
-        UniqueTagList lists = new UniqueTagList();
-        for (XmlAdaptedTag t : tags) {
-            try {
-                lists.add(t.toModelType());
-            } catch (IllegalValueException e) {
-                //TODO: better error handling
-            }
-        }
-        return lists;
-    }
-
-    @Override
-    public UniquePersonList getUniquePersonList() {
-        UniquePersonList lists = new UniquePersonList();
-        for (XmlAdaptedPerson p : persons) {
-            try {
-                lists.add(p.toModelType());
-            } catch (IllegalValueException e) {
-                //TODO: better error handling
-            }
-        }
-        return lists;
     }
 
     @Override

--- a/src/main/java/seedu/address/storage/XmlSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/XmlSerializableAddressBook.java
@@ -60,8 +60,8 @@ public class XmlSerializableAddressBook implements ReadOnlyAddressBook {
     }
 
     @Override
-    public List<Tag> getTagList() {
-        return tags.stream().map(t -> {
+    public ObservableList<Tag> getTagList() {
+        final ObservableList<Tag> tags = this.tags.stream().map(t -> {
             try {
                 return t.toModelType();
             } catch (IllegalValueException e) {
@@ -69,7 +69,8 @@ public class XmlSerializableAddressBook implements ReadOnlyAddressBook {
                 //TODO: better error handling
                 return null;
             }
-        }).collect(Collectors.toCollection(ArrayList::new));
+        }).collect(Collectors.toCollection(FXCollections::observableArrayList));
+        return new UnmodifiableObservableList<>(tags);
     }
 
 }

--- a/src/main/java/seedu/address/storage/XmlSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/XmlSerializableAddressBook.java
@@ -1,11 +1,17 @@
 package seedu.address.storage;
 
+import seedu.address.commons.core.UnmodifiableObservableList;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.person.Person;
 import seedu.address.model.person.ReadOnlyPerson;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -40,8 +46,8 @@ public class XmlSerializableAddressBook implements ReadOnlyAddressBook {
     }
 
     @Override
-    public List<ReadOnlyPerson> getPersonList() {
-        return persons.stream().map(p -> {
+    public ObservableList<ReadOnlyPerson> getPersonList() {
+        final ObservableList<Person> persons = this.persons.stream().map(p -> {
             try {
                 return p.toModelType();
             } catch (IllegalValueException e) {
@@ -49,7 +55,8 @@ public class XmlSerializableAddressBook implements ReadOnlyAddressBook {
                 //TODO: better error handling
                 return null;
             }
-        }).collect(Collectors.toCollection(ArrayList::new));
+        }).collect(Collectors.toCollection(FXCollections::observableArrayList));
+        return new UnmodifiableObservableList<>(persons);
     }
 
     @Override

--- a/src/test/java/guitests/AddressBookGuiTest.java
+++ b/src/test/java/guitests/AddressBookGuiTest.java
@@ -80,7 +80,7 @@ public abstract class AddressBookGuiTest {
      * Return null to use the data in the file specified in {@link #getDataFileLocation()}
      */
     protected AddressBook getInitialData() {
-        AddressBook ab = TestUtil.generateEmptyAddressBook();
+        AddressBook ab = new AddressBook();
         TypicalTestPersons.loadAddressBookWithSampleData(ab);
         return ab;
     }

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -70,6 +70,9 @@ public class AddressBookTest {
         addressBook.resetData(newData);
     }
 
+    /**
+     * A stub ReadOnlyAddressBook whose persons and tags lists can violate interface constraints.
+     */
     private static class AddressBookStub implements ReadOnlyAddressBook {
         private final ObservableList<ReadOnlyPerson> persons = FXCollections.observableArrayList();
         private final ObservableList<Tag> tags = FXCollections.observableArrayList();

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -1,0 +1,93 @@
+package seedu.address.model;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.ReadOnlyPerson;
+import seedu.address.model.tag.Tag;
+import seedu.address.testutil.TypicalTestPersons;
+
+public class AddressBookTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private final AddressBook addressBook = new AddressBook();
+
+    @Test
+    public void constructor() {
+        assertEquals(Collections.emptyList(), addressBook.getPersonList());
+        assertEquals(Collections.emptyList(), addressBook.getTagList());
+    }
+
+    @Test
+    public void resetData_null_throwsAssertionError() {
+        thrown.expect(AssertionError.class);
+        addressBook.resetData(null);
+    }
+
+    @Test
+    public void resetData_withValidReadOnlyAddressBook_replacesData() {
+        AddressBook newData = new TypicalTestPersons().getTypicalAddressBook();
+        addressBook.resetData(newData);
+        assertEquals(newData, addressBook);
+    }
+
+    @Test
+    public void resetData_withDuplicatePersons_throwsAssertionError() {
+        TypicalTestPersons td = new TypicalTestPersons();
+        // Repeat td.alice twice
+        List<Person> newPersons = Arrays.asList(new Person(td.alice), new Person(td.alice));
+        List<Tag> newTags = td.alice.getTags().asObservableList();
+        AddressBookStub newData = new AddressBookStub(newPersons, newTags);
+
+        thrown.expect(AssertionError.class);
+        addressBook.resetData(newData);
+    }
+
+    @Test
+    public void resetData_withDuplicateTags_throwsAssertionError() {
+        AddressBook typicalAddressBook = new TypicalTestPersons().getTypicalAddressBook();
+        List<ReadOnlyPerson> newPersons = typicalAddressBook.getPersonList();
+        // Repeat the first tag twice
+        List<Tag> newTags = new ArrayList<>(typicalAddressBook.getTagList());
+        newTags.add(newTags.get(0));
+        AddressBookStub newData = new AddressBookStub(newPersons, newTags);
+
+        thrown.expect(AssertionError.class);
+        addressBook.resetData(newData);
+    }
+
+    private static class AddressBookStub implements ReadOnlyAddressBook {
+        private final ObservableList<ReadOnlyPerson> persons = FXCollections.observableArrayList();
+        private final ObservableList<Tag> tags = FXCollections.observableArrayList();
+
+        AddressBookStub(Collection<? extends ReadOnlyPerson> persons, Collection<? extends Tag> tags) {
+            this.persons.setAll(persons);
+            this.tags.setAll(tags);
+        }
+
+        @Override
+        public ObservableList<ReadOnlyPerson> getPersonList() {
+            return persons;
+        }
+
+        @Override
+        public ObservableList<Tag> getTagList() {
+            return tags;
+        }
+    }
+
+}

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -61,8 +61,8 @@ public class AddressBookTest {
     public void resetData_withDuplicateTags_throwsAssertionError() {
         AddressBook typicalAddressBook = new TypicalTestPersons().getTypicalAddressBook();
         List<ReadOnlyPerson> newPersons = typicalAddressBook.getPersonList();
-        // Repeat the first tag twice
         List<Tag> newTags = new ArrayList<>(typicalAddressBook.getTagList());
+        // Repeat the first tag twice
         newTags.add(newTags.get(0));
         AddressBookStub newData = new AddressBookStub(newPersons, newTags);
 

--- a/src/test/java/seedu/address/testutil/TestUtil.java
+++ b/src/test/java/seedu/address/testutil/TestUtil.java
@@ -137,12 +137,8 @@ public class TestUtil {
         createDataFileWithSampleData(TestApp.SAVE_LOCATION_FOR_TESTING);
     }
 
-    public static AddressBook generateEmptyAddressBook() {
-        return new AddressBook(new UniquePersonList(), new UniqueTagList());
-    }
-
     public static XmlSerializableAddressBook generateSampleStorageAddressBook() {
-        return new XmlSerializableAddressBook(generateEmptyAddressBook());
+        return new XmlSerializableAddressBook(new AddressBook());
     }
 
     /**


### PR DESCRIPTION
Fixes #190 

[ReadOnlyAddressBook](https://github.com/se-edu/addressbook-level4/blob/61b1f6fa5d259677efcd8df61b73b7569b7d5715/src/main/java/seedu/address/model/ReadOnlyAddressBook.java#L16-L18) currently exposes its underlying `UniqueTagList` and `UniquePersonList` objects via `getUniqueTagList()` and `getUniquePersonList()` respectively. Problem is, [UniqueTagList](https://github.com/se-edu/addressbook-level4/blob/61b1f6fa5d259677efcd8df61b73b7569b7d5715/src/main/java/seedu/address/model/tag/UniqueTagList.java#L73-L109) and [UniquePersonList](https://github.com/se-edu/addressbook-level4/blob/61b1f6fa5d259677efcd8df61b73b7569b7d5715/src/main/java/seedu/address/model/person/UniquePersonList.java#L31-L60) both contain mutating methods, so `ReadOnlyAddressBook` is not actually read-only.

Furthermore, these methods seem to be redundant as we already have `getPersonList()` and `getTagList()`.

To add on, `AddressBook` has a [getPersons](https://github.com/se-edu/addressbook-level4/blob/61b1f6fa5d259677efcd8df61b73b7569b7d5715/src/main/java/seedu/address/model/AddressBook.java#L55-L57) method which does almost the same thing as `getPersonList()`.

So, let's clean up the `ReadOnlyAddressBook` interface a little.