### PR TITLE
User can edit a person's details #141

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -64,7 +64,28 @@ Examples:
 Shows a list of all persons in the address book.<br>
 Format: `list`
 
-### 2.4. Finding all persons containing any keyword in their name: `find`
+### 2.4. Editing a person : `edit`
+
+Edits an existing person in the address book.<br>
+Format: `edit INDEX [NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG]...`
+
+> * Edits the person at the specified `INDEX`.
+    The index refers to the index number shown in the last person listing.<br>
+    The index **must be a positive integer** 1, 2, 3, ...
+> * At least one of the optional fields must be provided.
+> * Existing values will be updated to the input values.
+> * When editing tags, the existing tags of the person will be removed i.e adding of tags is not cumulative.
+> * You can remove all the person's tags by typing `t/` without specifying any tags after it. 
+
+Examples:
+
+* `edit 1 p/91234567 e/johndoe@yahoo.com`<br>
+  Edits the phone number and email address of the 1st person to be `91234567` and `johndoe@yahoo.com` respectively.
+
+* `edit 2 Betsy Crower t/`<br>
+  Edits the name of the 2nd person to be `Betsy Crower` and clears all existing tags.
+
+### 2.5. Finding all persons containing any keyword in their name: `find`
 
 Finds persons whose names contain any of the given keywords.<br>
 Format: `find KEYWORD [MORE_KEYWORDS]`
@@ -83,7 +104,7 @@ Examples:
 * `find Betsy Tim John`<br>
   Returns Any person having names `Betsy`, `Tim`, or `John`
 
-### 2.5. Deleting a person : `delete`
+### 2.6. Deleting a person : `delete`
 
 Deletes the specified person from the address book. Irreversible.<br>
 Format: `delete INDEX`
@@ -101,7 +122,7 @@ Examples:
   `delete 1`<br>
   Deletes the 1st person in the results of the `find` command.
 
-### 2.6. Select a person : `select`
+### 2.7. Select a person : `select`
 
 Selects the person identified by the index number used in the last person listing.<br>
 Format: `select INDEX`
@@ -119,17 +140,17 @@ Examples:
   `select 1`<br>
   Selects the 1st person in the results of the `find` command.
 
-### 2.7. Clearing all entries : `clear`
+### 2.8. Clearing all entries : `clear`
 
 Clears all entries from the address book.<br>
 Format: `clear`
 
-### 2.8. Exiting the program : `exit`
+### 2.9. Exiting the program : `exit`
 
 Exits the program.<br>
 Format: `exit`
 
-### 2.9. Saving the data
+### 2.10. Saving the data
 
 Address book data are saved in the hard disk automatically after any command that changes the data.<br>
 There is no need to save manually.

--- a/src/main/java/seedu/address/commons/util/CollectionUtil.java
+++ b/src/main/java/seedu/address/commons/util/CollectionUtil.java
@@ -2,7 +2,9 @@ package seedu.address.commons.util;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 
 /**
  * Utility methods related to Collections
@@ -21,7 +23,12 @@ public class CollectionUtil {
         return false;
     }
 
-
+    /**
+     * Returns true is any of the given items are present.
+     */
+    public static boolean isAnyPresent(Optional<?>... items) {
+        return Stream.of(items).anyMatch(Optional::isPresent);
+    }
 
     /**
      * Throws an assertion error if the collection or any item in it is null.

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -1,0 +1,163 @@
+package seedu.address.logic.commands;
+
+import java.util.List;
+import java.util.Optional;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.util.CollectionUtil;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
+import seedu.address.model.person.ReadOnlyPerson;
+import seedu.address.model.person.UniquePersonList;
+import seedu.address.model.tag.UniqueTagList;
+
+/**
+ * Edits the details of an existing person in the address book.
+ */
+public class EditCommand extends Command {
+
+    public static final String COMMAND_WORD = "edit";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the person identified "
+            + "by the index number used in the last person listing. "
+            + "Existing values will be overwritten by the input values.\n"
+            + "Parameters: INDEX (must be a positive integer) [NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS ] [t/TAG]...\n"
+            + "Example: " + COMMAND_WORD + " 1 p/91234567 e/johndoe@yahoo.com";
+
+    public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
+    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book.";
+
+    private final int filteredPersonListIndex;
+    private final EditPersonDescriptor editPersonDescriptor;
+
+    /**
+     * @param filteredPersonListIndex the index of the person in the filtered person list to edit
+     * @param editPersonDescriptor details to edit the person with
+     */
+    public EditCommand(int filteredPersonListIndex, EditPersonDescriptor editPersonDescriptor) {
+        assert filteredPersonListIndex > 0;
+        assert editPersonDescriptor != null;
+
+        // converts filteredPersonListIndex from one-based to zero-based.
+        this.filteredPersonListIndex = filteredPersonListIndex - 1;
+
+        this.editPersonDescriptor = new EditPersonDescriptor(editPersonDescriptor);
+    }
+
+    @Override
+    public CommandResult execute() {
+        List<ReadOnlyPerson> lastShownList = model.getFilteredPersonList();
+
+        if (filteredPersonListIndex >= lastShownList.size()) {
+            indicateAttemptToExecuteIncorrectCommand();
+            return new CommandResult(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        ReadOnlyPerson personToEdit = lastShownList.get(filteredPersonListIndex);
+        Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
+
+        try {
+            model.updatePerson(filteredPersonListIndex, editedPerson);
+        } catch (UniquePersonList.DuplicatePersonException dpe) {
+            indicateAttemptToExecuteIncorrectCommand();
+            return new CommandResult(MESSAGE_DUPLICATE_PERSON);
+        }
+        model.updateFilteredListToShowAll();
+        return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, personToEdit));
+    }
+
+    /**
+     * Creates and returns a {@code Person} with the details of {@code personToEdit}
+     * edited with {@code editPersonDescriptor}.
+     */
+    private static Person createEditedPerson(ReadOnlyPerson personToEdit,
+                                             EditPersonDescriptor editPersonDescriptor) {
+        assert personToEdit != null;
+
+        Name updatedName = editPersonDescriptor.getName().orElseGet(personToEdit::getName);
+        Phone updatedPhone = editPersonDescriptor.getPhone().orElseGet(personToEdit::getPhone);
+        Email updatedEmail = editPersonDescriptor.getEmail().orElseGet(personToEdit::getEmail);
+        Address updatedAddress = editPersonDescriptor.getAddress().orElseGet(personToEdit::getAddress);
+        UniqueTagList updatedTags = editPersonDescriptor.getTags().orElseGet(personToEdit::getTags);
+
+        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags);
+    }
+
+    /**
+     * Stores the details to edit the person with. Each non-empty field value will replace the
+     * corresponding field value of the person.
+     */
+    public static class EditPersonDescriptor {
+        private Optional<Name> name = Optional.empty();
+        private Optional<Phone> phone = Optional.empty();
+        private Optional<Email> email = Optional.empty();
+        private Optional<Address> address = Optional.empty();
+        private Optional<UniqueTagList> tags = Optional.empty();
+
+        public EditPersonDescriptor() {}
+
+        public EditPersonDescriptor(EditPersonDescriptor toCopy) {
+            this.name = toCopy.getName();
+            this.phone = toCopy.getPhone();
+            this.email = toCopy.getEmail();
+            this.address = toCopy.getAddress();
+            this.tags = toCopy.getTags();
+        }
+
+        /**
+         * Returns true if at least one field is edited.
+         */
+        public boolean isAnyFieldEdited() {
+            return CollectionUtil.isAnyPresent(this.name, this.phone, this.email, this.address, this.tags);
+        }
+
+        public void setName(Optional<Name> name) {
+            assert name != null;
+            this.name = name;
+        }
+
+        public Optional<Name> getName() {
+            return name;
+        }
+
+        public void setPhone(Optional<Phone> phone) {
+            assert phone != null;
+            this.phone = phone;
+        }
+
+        public Optional<Phone> getPhone() {
+            return phone;
+        }
+
+        public void setEmail(Optional<Email> email) {
+            assert email != null;
+            this.email = email;
+        }
+
+        public Optional<Email> getEmail() {
+            return email;
+        }
+
+        public void setAddress(Optional<Address> address) {
+            assert address != null;
+            this.address = address;
+        }
+
+        public Optional<Address> getAddress() {
+            return address;
+        }
+
+        public void setTags(Optional<UniqueTagList> tags) {
+            assert tags != null;
+            this.tags = tags;
+        }
+
+        public Optional<UniqueTagList> getTags() {
+            return tags;
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/Parser.java
+++ b/src/main/java/seedu/address/logic/parser/Parser.java
@@ -3,11 +3,19 @@ package seedu.address.logic.parser;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.commands.*;
+import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.parser.ArgumentTokenizer.*;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Phone;
+import seedu.address.model.tag.Tag;
+import seedu.address.model.tag.UniqueTagList;
 
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
@@ -49,6 +57,9 @@ public class Parser {
 
         case AddCommand.COMMAND_WORD:
             return prepareAdd(arguments);
+
+        case EditCommand.COMMAND_WORD:
+            return prepareEdit(arguments);
 
         case SelectCommand.COMMAND_WORD:
             return prepareSelect(arguments);
@@ -104,6 +115,112 @@ public class Parser {
     private Set<String> toSet(Optional<List<String>> tagsOptional) {
         List<String> tags = tagsOptional.orElse(Collections.emptyList());
         return new HashSet<>(tags);
+    }
+
+    /**
+    * Splits a preamble string into ordered fields.
+    * @return A list of size {@code numFields} where the ith element is the ith field value if specified in
+    *         the input, {@code Optional.empty()} otherwise.
+    */
+    private List<Optional<String>> splitPreamble(String preamble, int numFields) {
+        return Arrays.stream(Arrays.copyOf(preamble.split("\\s+", numFields), numFields))
+                .map(Optional::ofNullable)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Parses arguments in the context of the edit person command.
+     *
+     * @param args full command args string
+     * @return the prepared command
+     */
+    private Command prepareEdit(String args) {
+        assert args != null;
+        ArgumentTokenizer argsTokenizer = new ArgumentTokenizer(phoneNumberPrefix, emailPrefix,
+                                                                addressPrefix, tagsPrefix);
+        argsTokenizer.tokenize(args);
+        List<Optional<String>> preambleFields = splitPreamble(argsTokenizer.getPreamble().orElse(""), 2);
+
+        Optional<Integer> index = preambleFields.get(0).flatMap(this::parseIndex);
+        if (!index.isPresent()) {
+            return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
+        }
+
+        EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
+        try {
+            editPersonDescriptor.setName(parseName(preambleFields.get(1)));
+            editPersonDescriptor.setPhone(parsePhone(argsTokenizer.getValue(phoneNumberPrefix)));
+            editPersonDescriptor.setEmail(parseEmail(argsTokenizer.getValue(emailPrefix)));
+            editPersonDescriptor.setAddress(parseAddress(argsTokenizer.getValue(addressPrefix)));
+            editPersonDescriptor.setTags(parseTagsForEdit(toSet(argsTokenizer.getAllValues(tagsPrefix))));
+        } catch (IllegalValueException ive) {
+            return new IncorrectCommand(ive.getMessage());
+        }
+
+        if (!editPersonDescriptor.isAnyFieldEdited()) {
+            return new IncorrectCommand(EditCommand.MESSAGE_NOT_EDITED);
+        }
+
+        return new EditCommand(index.get(), editPersonDescriptor);
+    }
+
+    /**
+     * Parses a {@code Optional<String> name} into an {@code Optional<Name>} if {@code name} is present.
+     */
+    private Optional<Name> parseName(Optional<String> name) throws IllegalValueException {
+        assert name != null;
+        return name.isPresent() ? Optional.of(new Name(name.get())) : Optional.empty();
+    }
+
+    /**
+     * Parses a {@code Optional<String> phone} into an {@code Optional<Phone>} if {@code phone} is present.
+     */
+    private Optional<Phone> parsePhone(Optional<String> phone) throws IllegalValueException {
+        assert phone != null;
+        return phone.isPresent() ? Optional.of(new Phone(phone.get())) : Optional.empty();
+    }
+
+    /**
+     * Parses a {@code Optional<String> address} into an {@code Optional<Address>} if {@code address} is present.
+     */
+    private Optional<Address> parseAddress(Optional<String> address) throws IllegalValueException {
+        assert address != null;
+        return address.isPresent() ? Optional.of(new Address(address.get())) : Optional.empty();
+    }
+
+    /**
+     * Parses a {@code Optional<String> email} into an {@code Optional<Email>} if {@code email} is present.
+     */
+    private Optional<Email> parseEmail(Optional<String> email) throws IllegalValueException {
+        assert email != null;
+        return email.isPresent() ? Optional.of(new Email(email.get())) : Optional.empty();
+    }
+
+    /**
+     * Parses {@code Collection<String> tags} into an {@code Optional<UniqueTagList>} if {@code tags} is non-empty.
+     * If {@code tags} contain only one element which is an empty string, it will be parsed into a
+     * {@code Optional<UniqueTagList>} containing zero tags.
+     */
+    private Optional<UniqueTagList> parseTagsForEdit(Collection<String> tags) throws IllegalValueException {
+        assert tags != null;
+
+        if (tags.isEmpty()) {
+            return Optional.empty();
+        }
+        Collection<String> tagSet = tags.size() == 1 && tags.contains("") ? Collections.emptySet() : tags;
+        return Optional.of(parseTags(tagSet));
+    }
+
+    /**
+     * Parses {@code Collection<String> tags} into an {@code UniqueTagList}.
+     */
+    private UniqueTagList parseTags(Collection<String> tags) throws IllegalValueException {
+        assert tags != null;
+        final Set<Tag> tagSet = new HashSet<>();
+        for (String tagName : tags) {
+            tagSet.add(new Tag(tagName));
+        }
+        return new UniqueTagList(tagSet);
     }
 
     /**

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -4,6 +4,7 @@ import seedu.address.commons.core.UnmodifiableObservableList;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.ReadOnlyPerson;
 import seedu.address.model.person.UniquePersonList;
+import seedu.address.model.person.UniquePersonList.DuplicatePersonException;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.tag.UniqueTagList;
 
@@ -80,6 +81,27 @@ public class AddressBook implements ReadOnlyAddressBook {
     public void addPerson(Person p) throws UniquePersonList.DuplicatePersonException {
         syncMasterTagListWith(p);
         persons.add(p);
+    }
+
+    /**
+     * Updates the person in the list at position {@code index} with {@code editedReadOnlyPerson}.
+     * {@code AddressBook}'s tag list will be updated with the tags of {@code editedReadOnlyPerson}.
+     * @see #syncMasterTagListWith(Person)
+     *
+     * @throws DuplicatePersonException if updating the person's details causes the person to be equivalent to
+     *      another existing person in the list.
+     * @throws IndexOutOfBoundsException if {@code index} < 0 or >= the size of the list.
+     */
+    public void updatePerson(int index, ReadOnlyPerson editedReadOnlyPerson)
+            throws UniquePersonList.DuplicatePersonException {
+        assert editedReadOnlyPerson != null;
+
+        Person editedPerson = new Person(editedReadOnlyPerson);
+        syncMasterTagListWith(editedPerson);
+        // TODO: the tags master list will be updated even though the below line fails.
+        // This can cause the tags master list to have additional tags that are not tagged to any person
+        // in the person list.
+        persons.updatePerson(index, editedPerson);
     }
 
     /**

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -4,6 +4,7 @@ import seedu.address.commons.core.UnmodifiableObservableList;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.ReadOnlyPerson;
 import seedu.address.model.person.UniquePersonList;
+import seedu.address.model.person.UniquePersonList.DuplicatePersonException;
 
 import java.util.Set;
 
@@ -22,6 +23,16 @@ public interface Model {
 
     /** Adds the given person */
     void addPerson(Person person) throws UniquePersonList.DuplicatePersonException;
+
+    /**
+     * Updates the person located at {@code filteredPersonListIndex} with {@code editedPerson}.
+     *
+     * @throws DuplicatePersonException if updating the person's details causes the person to be equivalent to
+     *      another existing person in the list.
+     * @throws IndexOutOfBoundsException if {@code filteredPersonListIndex} < 0 or >= the size of the filtered list.
+     */
+    void updatePerson(int filteredPersonListIndex, ReadOnlyPerson editedPerson)
+            throws UniquePersonList.DuplicatePersonException;
 
     /** Returns the filtered person list as an {@code UnmodifiableObservableList<ReadOnlyPerson>} */
     UnmodifiableObservableList<ReadOnlyPerson> getFilteredPersonList();

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -71,6 +71,16 @@ public class ModelManager extends ComponentManager implements Model {
         indicateAddressBookChanged();
     }
 
+    @Override
+    public void updatePerson(int filteredPersonListIndex, ReadOnlyPerson editedPerson)
+            throws UniquePersonList.DuplicatePersonException {
+        assert editedPerson != null;
+
+        int addressBookIndex = filteredPersons.getSourceIndex(filteredPersonListIndex);
+        addressBook.updatePerson(addressBookIndex, editedPerson);
+        indicateAddressBookChanged();
+    }
+
     //=========== Filtered Person List Accessors =============================================================
 
     @Override

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -37,9 +37,19 @@ public class Person implements ReadOnlyPerson {
         this(source.getName(), source.getPhone(), source.getEmail(), source.getAddress(), source.getTags());
     }
 
+    public void setName(Name name) {
+        assert name != null;
+        this.name = name;
+    }
+
     @Override
     public Name getName() {
         return name;
+    }
+
+    public void setPhone(Phone phone) {
+        assert phone != null;
+        this.phone = phone;
     }
 
     @Override
@@ -47,9 +57,19 @@ public class Person implements ReadOnlyPerson {
         return phone;
     }
 
+    public void setEmail(Email email) {
+        assert email != null;
+        this.email = email;
+    }
+
     @Override
     public Email getEmail() {
         return email;
+    }
+
+    public void setAddress(Address address) {
+        assert address != null;
+        this.address = address;
     }
 
     @Override
@@ -67,6 +87,19 @@ public class Person implements ReadOnlyPerson {
      */
     public void setTags(UniqueTagList replacement) {
         tags.setTags(replacement);
+    }
+
+    /**
+     * Updates this person with the details of {@code replacement}.
+     */
+    public void resetData(ReadOnlyPerson replacement) {
+        assert replacement != null;
+
+        this.setName(replacement.getName());
+        this.setPhone(replacement.getPhone());
+        this.setEmail(replacement.getEmail());
+        this.setAddress(replacement.getAddress());
+        this.setTags(replacement.getTags());
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -42,6 +42,28 @@ public class UniquePersonList implements Iterable<Person> {
     }
 
     /**
+     * Updates the person in the list at position {@code index} with {@code editedPerson}.
+     *
+     * @throws DuplicatePersonException if updating the person's details causes the person to be equivalent to
+     *      another existing person in the list.
+     * @throws IndexOutOfBoundsException if {@code index} < 0 or >= the size of the list.
+     */
+    public void updatePerson(int index, ReadOnlyPerson editedPerson) throws DuplicatePersonException {
+        assert editedPerson != null;
+
+        Person personToUpdate = internalList.get(index);
+        if (!personToUpdate.equals(editedPerson) && internalList.contains(editedPerson)) {
+            throw new DuplicatePersonException();
+        }
+
+        personToUpdate.resetData(editedPerson);
+        // TODO: The code below is just a workaround to notify observers of the updated person.
+        // The right way is to implement observable properties in the Person class.
+        // Then, PersonCard should then bind its text labels to those observable properties.
+        internalList.set(index, personToUpdate);
+    }
+
+    /**
      * Removes the equivalent person from the list.
      *
      * @throws PersonNotFoundException if no such person could be found in the list.

--- a/src/test/java/guitests/EditCommandTest.java
+++ b/src/test/java/guitests/EditCommandTest.java
@@ -1,0 +1,138 @@
+package guitests;
+
+import static org.junit.Assert.assertTrue;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import org.junit.Test;
+
+import guitests.guihandles.PersonCardHandle;
+import seedu.address.commons.core.Messages;
+import seedu.address.logic.commands.EditCommand;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Phone;
+import seedu.address.model.tag.Tag;
+import seedu.address.testutil.PersonBuilder;
+import seedu.address.testutil.TestPerson;
+
+// TODO: reduce GUI tests by transferring some tests to be covered by lower level tests.
+public class EditCommandTest extends AddressBookGuiTest {
+
+    // The list of persons in the person list panel is expected to match this list.
+    // This list is updated with every successful call to assertEditSuccess().
+    TestPerson[] expectedPersonsList = td.getTypicalPersons();
+
+    @Test
+    public void edit_allFieldsSpecified_success() throws Exception {
+        String detailsToEdit = "Bobby p/91234567 e/bobby@gmail.com a/Block 123, Bobby Street 3 t/husband";
+        int addressBookIndex = 1;
+
+        TestPerson editedPerson = new PersonBuilder().withName("Bobby").withPhone("91234567")
+                .withEmail("bobby@gmail.com").withAddress("Block 123, Bobby Street 3").withTags("husband").build();
+
+        assertEditSuccess(addressBookIndex, addressBookIndex, detailsToEdit, editedPerson);
+    }
+
+    @Test
+    public void edit_notAllFieldsSpecified_success() throws Exception {
+        String detailsToEdit = "t/sweetie t/bestie";
+        int addressBookIndex = 2;
+
+        TestPerson personToEdit = expectedPersonsList[addressBookIndex - 1];
+        TestPerson editedPerson = new PersonBuilder(personToEdit).withTags("sweetie", "bestie").build();
+
+        assertEditSuccess(addressBookIndex, addressBookIndex, detailsToEdit, editedPerson);
+    }
+
+    @Test
+    public void edit_clearTags_success() throws Exception {
+        String detailsToEdit = "t/";
+        int addressBookIndex = 2;
+
+        TestPerson personToEdit = expectedPersonsList[addressBookIndex - 1];
+        TestPerson editedPerson = new PersonBuilder(personToEdit).withTags().build();
+
+        assertEditSuccess(addressBookIndex, addressBookIndex, detailsToEdit, editedPerson);
+    }
+
+    @Test
+    public void edit_findThenEdit_success() throws Exception {
+        commandBox.runCommand("find Elle");
+
+        String detailsToEdit = "Belle";
+        int filteredPersonListIndex = 1;
+        int addressBookIndex = 5;
+
+        TestPerson personToEdit = expectedPersonsList[addressBookIndex - 1];
+        TestPerson editedPerson = new PersonBuilder(personToEdit).withName("Belle").build();
+
+        assertEditSuccess(filteredPersonListIndex, addressBookIndex, detailsToEdit, editedPerson);
+    }
+
+    @Test
+    public void edit_missingPersonIndex_failure() {
+        commandBox.runCommand("edit Bobby");
+        assertResultMessage(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void edit_invalidPersonIndex_failure() {
+        commandBox.runCommand("edit 8 Bobby");
+        assertResultMessage(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void edit_noFieldsSpecified_failure() {
+        commandBox.runCommand("edit 1");
+        assertResultMessage(EditCommand.MESSAGE_NOT_EDITED);
+    }
+
+    @Test
+    public void edit_invalidValues_failure() {
+        commandBox.runCommand("edit 1 *&");
+        assertResultMessage(Name.MESSAGE_NAME_CONSTRAINTS);
+
+        commandBox.runCommand("edit 1 p/abcd");
+        assertResultMessage(Phone.MESSAGE_PHONE_CONSTRAINTS);
+
+        commandBox.runCommand("edit 1 e/yahoo!!!");
+        assertResultMessage(Email.MESSAGE_EMAIL_CONSTRAINTS);
+
+        commandBox.runCommand("edit 1 a/");
+        assertResultMessage(Address.MESSAGE_ADDRESS_CONSTRAINTS);
+
+        commandBox.runCommand("edit 1 t/*&");
+        assertResultMessage(Tag.MESSAGE_TAG_CONSTRAINTS);
+    }
+
+    @Test
+    public void edit_duplicatePerson_failure() {
+        commandBox.runCommand("edit 3 Alice Pauline p/85355255 e/alice@gmail.com "
+                                + "a/123, Jurong West Ave 6, #08-111 t/friends");
+        assertResultMessage(EditCommand.MESSAGE_DUPLICATE_PERSON);
+    }
+
+    /**
+     * Checks whether the edited person has the correct updated details.
+     *
+     * @param filteredPersonListIndex index of person to edit in filtered list
+     * @param addressBookIndex index of person to edit in the address book.
+     *      Must refer to the same person as {@code filteredPersonListIndex}
+     * @param detailsToEdit details to edit the person with as input to the edit command
+     * @param editedPerson the expected person after editing the person's details
+     */
+    private void assertEditSuccess(int filteredPersonListIndex, int addressBookIndex,
+                                    String detailsToEdit, TestPerson editedPerson) {
+        commandBox.runCommand("edit " + filteredPersonListIndex + " " + detailsToEdit);
+
+        // confirm the new card contains the right data
+        PersonCardHandle editedCard = personListPanel.navigateToPerson(editedPerson.getName().fullName);
+        assertMatching(editedPerson, editedCard);
+
+        // confirm the list now contains all previous persons plus the person with updated details
+        expectedPersonsList[addressBookIndex - 1] = editedPerson;
+        assertTrue(personListPanel.isListMatching(expectedPersonsList));
+        assertResultMessage(String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson));
+    }
+}

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -2,6 +2,7 @@ package seedu.address.testutil;
 
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.tag.Tag;
+import seedu.address.model.tag.UniqueTagList;
 import seedu.address.model.person.*;
 
 /**
@@ -15,12 +16,20 @@ public class PersonBuilder {
         this.person = new TestPerson();
     }
 
+    /**
+     * Initializes the PersonBuilder with the data of {@code personToCopy}.
+     */
+    public PersonBuilder(TestPerson personToCopy) {
+        this.person = new TestPerson(personToCopy);
+    }
+
     public PersonBuilder withName(String name) throws IllegalValueException {
         this.person.setName(new Name(name));
         return this;
     }
 
     public PersonBuilder withTags(String ... tags) throws IllegalValueException {
+        person.setTags(new UniqueTagList());
         for (String tag: tags) {
             person.getTags().add(new Tag(tag));
         }

--- a/src/test/java/seedu/address/testutil/TestPerson.java
+++ b/src/test/java/seedu/address/testutil/TestPerson.java
@@ -18,6 +18,17 @@ public class TestPerson implements ReadOnlyPerson {
         tags = new UniqueTagList();
     }
 
+    /**
+     * Creates a copy of {@code personToCopy}.
+     */
+    public TestPerson(TestPerson personToCopy) {
+        this.name = personToCopy.getName();
+        this.phone = personToCopy.getPhone();
+        this.email = personToCopy.getEmail();
+        this.address = personToCopy.getAddress();
+        this.tags = personToCopy.getTags();
+    }
+
     public void setName(Name name) {
         this.name = name;
     }
@@ -32,6 +43,10 @@ public class TestPerson implements ReadOnlyPerson {
 
     public void setPhone(Phone phone) {
         this.phone = phone;
+    }
+
+    public void setTags(UniqueTagList tags) {
+        this.tags = tags;
     }
 
     @Override


### PR DESCRIPTION
Fixes #141 

Ready for review.

* [1/6] [create constants for keys (to be used in HashMap for EditCommand) and make Person mutable.](https://github.com/se-edu/addressbook-level4/pull/209/commits/2df9e1b9427c95c334680f19c553c9755be14bf7)
* [2/6] [create EditCommand & update Parser and ArgumentTokenizer.](https://github.com/se-edu/addressbook-level4/pull/209/commits/24daab843f7baee1378612e049d2076038d61e13)
* [3/6] [update Model package (ModelManager, Model, AddressBook, UniquePersonList) to allowing editing.](https://github.com/se-edu/addressbook-level4/pull/209/commits/1270bdb4998f36e39bb1670b12384b6d61db1a55)
* [4/6] [create NoArgumentException](https://github.com/se-edu/addressbook-level4/pull/209/commits/029cd8779cb0dca7874c3c711f0ca70078925a4c)
* [5/6] [update User Guide to include edit.](https://github.com/se-edu/addressbook-level4/pull/209/commits/30a5c309ae36ad47b1e3dcf78b0da768ad6f3217)
* [6/6] [create EditCommandTest](https://github.com/se-edu/addressbook-level4/pull/209/commits/aa14f2354368ddd9ba44e4fd2eaef99b1d3b336d)

Functionalities:
1. User can remove existing tags by typing "t/" without any tags behind it.
2. User can edit existing fields. Syntax of edit is similar to that of add (refer to UG), but you do not have to necessarily edit all the fields.

