### PR TITLE
Support F1 accelerator even when the focus is not in the list #149

### DIFF
--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -1,10 +1,13 @@
 package seedu.address.ui;
 
+import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.control.MenuItem;
+import javafx.scene.control.TextInputControl;
 import javafx.scene.input.KeyCombination;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
@@ -104,7 +107,37 @@ public class MainWindow extends UiPart {
     }
 
     private void setAccelerators() {
-        helpMenuItem.setAccelerator(KeyCombination.valueOf("F1"));
+        setAccelerator(helpMenuItem, KeyCombination.valueOf("F1"));
+    }
+
+    /**
+     * Sets the accelerator of a MenuItem.
+     * @param keyCombination the KeyCombination value of the accelerator
+     */
+    private void setAccelerator(MenuItem menuItem, KeyCombination keyCombination) {
+        menuItem.setAccelerator(keyCombination);
+
+        /*
+         * TODO: the code below can be removed once the bug reported here
+         * https://bugs.openjdk.java.net/browse/JDK-8131666
+         * is fixed in later version of SDK.
+         *
+         * According to the bug report, TextInputControl (TextField, TextArea) will
+         * consume function-key events. Because CommandBox contains a TextField, and
+         * ResultDisplay contains a TextArea, thus some accelerators (e.g F1) will
+         * not work when the focus is in them because the key event is consumed by
+         * the TextInputControl(s).
+         *
+         * For now, we add following event filter to capture such key events and open
+         * help window purposely so to support accelerators even when focus is
+         * in CommandBox or ResultDisplay.
+         */
+        rootLayout.addEventFilter(KeyEvent.KEY_PRESSED, event -> {
+            if (event.getTarget() instanceof TextInputControl && keyCombination.match(event)) {
+                menuItem.getOnAction().handle(new ActionEvent());
+                event.consume();
+            }
+        });
     }
 
     void fillInnerParts() {

--- a/src/test/java/guitests/AddressBookGuiTest.java
+++ b/src/test/java/guitests/AddressBookGuiTest.java
@@ -44,6 +44,7 @@ public abstract class AddressBookGuiTest {
     protected PersonListPanelHandle personListPanel;
     protected ResultDisplayHandle resultDisplay;
     protected CommandBoxHandle commandBox;
+    protected BrowserPanelHandle browserPanel;
     private Stage stage;
 
     @BeforeClass
@@ -64,6 +65,7 @@ public abstract class AddressBookGuiTest {
             personListPanel = mainGui.getPersonListPanel();
             resultDisplay = mainGui.getResultDisplay();
             commandBox = mainGui.getCommandBox();
+            browserPanel = mainGui.getBrowserPanel();
             this.stage = stage;
         });
         EventsCenter.clearSubscribers();

--- a/src/test/java/guitests/HelpWindowTest.java
+++ b/src/test/java/guitests/HelpWindowTest.java
@@ -4,12 +4,13 @@ import guitests.guihandles.HelpWindowHandle;
 import org.junit.Test;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 public class HelpWindowTest extends AddressBookGuiTest {
 
     @Test
     public void openHelpWindow() {
-
+        //use accelerator
         commandBox.clickOnTextField();
         assertHelpWindowOpen(mainMenu.openHelpWindowUsingAccelerator());
 
@@ -19,14 +20,23 @@ public class HelpWindowTest extends AddressBookGuiTest {
         personListPanel.clickOnListView();
         assertHelpWindowOpen(mainMenu.openHelpWindowUsingAccelerator());
 
+        browserPanel.clickOnWebView();
+        assertHelpWindowNotOpen(mainMenu.openHelpWindowUsingAccelerator());
+
+        //use menu button
         assertHelpWindowOpen(mainMenu.openHelpWindowUsingMenu());
 
+        //use command
         assertHelpWindowOpen(commandBox.runHelpCommand());
-
     }
 
     private void assertHelpWindowOpen(HelpWindowHandle helpWindowHandle) {
         assertTrue(helpWindowHandle.isWindowOpen());
         helpWindowHandle.closeWindow();
     }
+
+    private void assertHelpWindowNotOpen(HelpWindowHandle helpWindowHandle) {
+        assertFalse(helpWindowHandle.isWindowOpen());
+    }
+
 }

--- a/src/test/java/guitests/HelpWindowTest.java
+++ b/src/test/java/guitests/HelpWindowTest.java
@@ -10,8 +10,13 @@ public class HelpWindowTest extends AddressBookGuiTest {
     @Test
     public void openHelpWindow() {
 
-        personListPanel.clickOnListView();
+        commandBox.clickOnTextField();
+        assertHelpWindowOpen(mainMenu.openHelpWindowUsingAccelerator());
 
+        resultDisplay.clickOnTextArea();
+        assertHelpWindowOpen(mainMenu.openHelpWindowUsingAccelerator());
+
+        personListPanel.clickOnListView();
         assertHelpWindowOpen(mainMenu.openHelpWindowUsingAccelerator());
 
         assertHelpWindowOpen(mainMenu.openHelpWindowUsingMenu());

--- a/src/test/java/guitests/guihandles/BrowserPanelHandle.java
+++ b/src/test/java/guitests/guihandles/BrowserPanelHandle.java
@@ -1,0 +1,25 @@
+package guitests.guihandles;
+
+import guitests.GuiRobot;
+import javafx.stage.Stage;
+import seedu.address.TestApp;
+
+/**
+ * A handler for the BrowserPanel of the UI
+ */
+public class BrowserPanelHandle extends GuiHandle {
+
+    private static final String BROWSER_ID = "#browser";
+
+    public BrowserPanelHandle(GuiRobot guiRobot, Stage primaryStage) {
+        super(guiRobot, primaryStage, TestApp.APP_TITLE);
+    }
+
+    /**
+     * Clicks on the WebView.
+     */
+    public void clickOnWebView() {
+        guiRobot.clickOn(BROWSER_ID);
+    }
+
+}

--- a/src/test/java/guitests/guihandles/CommandBoxHandle.java
+++ b/src/test/java/guitests/guihandles/CommandBoxHandle.java
@@ -14,6 +14,13 @@ public class CommandBoxHandle extends GuiHandle {
         super(guiRobot, primaryStage, stageTitle);
     }
 
+    /**
+     * Clicks on the TextField.
+     */
+    public void clickOnTextField() {
+        guiRobot.clickOn(COMMAND_INPUT_FIELD_ID);
+    }
+
     public void enterCommand(String command) {
         setTextField(COMMAND_INPUT_FIELD_ID, command);
     }

--- a/src/test/java/guitests/guihandles/HelpWindowHandle.java
+++ b/src/test/java/guitests/guihandles/HelpWindowHandle.java
@@ -17,7 +17,7 @@ public class HelpWindowHandle extends GuiHandle {
     }
 
     public boolean isWindowOpen() {
-        return getNode(HELP_WINDOW_ROOT_FIELD_ID) != null;
+        return guiRobot.lookup(HELP_WINDOW_ROOT_FIELD_ID).tryQuery().isPresent();
     }
 
     public void closeWindow() {

--- a/src/test/java/guitests/guihandles/MainGuiHandle.java
+++ b/src/test/java/guitests/guihandles/MainGuiHandle.java
@@ -29,6 +29,10 @@ public class MainGuiHandle extends GuiHandle {
         return new MainMenuHandle(guiRobot, primaryStage);
     }
 
+    public BrowserPanelHandle getBrowserPanel() {
+        return new BrowserPanelHandle(guiRobot, primaryStage);
+    }
+
     public AlertDialogHandle getAlertDialog(String title) {
         guiRobot.sleep(1000);
         return new AlertDialogHandle(guiRobot, primaryStage, title);

--- a/src/test/java/guitests/guihandles/ResultDisplayHandle.java
+++ b/src/test/java/guitests/guihandles/ResultDisplayHandle.java
@@ -16,6 +16,13 @@ public class ResultDisplayHandle extends GuiHandle {
         super(guiRobot, primaryStage, TestApp.APP_TITLE);
     }
 
+    /**
+     * Clicks on the TextArea.
+     */
+    public void clickOnTextArea() {
+        guiRobot.clickOn(RESULT_DISPLAY_ID);
+    }
+
     public String getText() {
         return getResultDisplay().getText();
     }


### PR DESCRIPTION
Fixes #149 

This issue may be caused by a JavaFX bug, as suggested here https://bugs.openjdk.java.net/browse/JDK-8131666.

It's because TextField and TextAreas in CommandBox and ResultDisplay will consume F1 keyevents. As a result, the accelerators will not be fired up.

The discussion in the post shows that the bug will only be fixed in later version of JDK (though it's openJDK but I guess it should be similar case for JDK itself.)

Thus in this PR, what I implemented is just a workaround.

- Explicitly bind F1 keyevents to open help window for CommandBox TextField and ResultDisplay TextArea using `addEventFilter`
- Remove `personListPanel.clickOnListView()` in `HelpWindowTest` because now the focus doesn't have to be in the person list for F1 accelerator to work.

Ready for review