### PR TITLE
Allow updating addressBookPath and addressBookName at runtime. #213

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -26,8 +26,12 @@ import seedu.address.model.ModelManager;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.util.SampleDataUtil;
+import seedu.address.storage.AddressBookStorage;
+import seedu.address.storage.JsonUserPrefsStorage;
 import seedu.address.storage.Storage;
 import seedu.address.storage.StorageManager;
+import seedu.address.storage.UserPrefsStorage;
+import seedu.address.storage.XmlAddressBookStorage;
 import seedu.address.ui.Ui;
 import seedu.address.ui.UiManager;
 
@@ -53,7 +57,10 @@ public class MainApp extends Application {
         super.init();
 
         config = initConfig(getApplicationParameter("config"));
-        storage = new StorageManager(config.getAddressBookFilePath(), config.getUserPrefsFilePath());
+
+        AddressBookStorage addressBookStorage = new XmlAddressBookStorage(config.getAddressBookFilePath());
+        UserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(config.getUserPrefsFilePath());
+        storage = new StorageManager(addressBookStorage, userPrefsStorage);
 
         userPrefs = initPrefs(config);
 

--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -58,11 +58,10 @@ public class MainApp extends Application {
 
         config = initConfig(getApplicationParameter("config"));
 
-        AddressBookStorage addressBookStorage = new XmlAddressBookStorage(config.getAddressBookFilePath());
         UserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(config.getUserPrefsFilePath());
+        userPrefs = initPrefs(userPrefsStorage);
+        AddressBookStorage addressBookStorage = new XmlAddressBookStorage(userPrefs.getAddressBookFilePath());
         storage = new StorageManager(addressBookStorage, userPrefsStorage);
-
-        userPrefs = initPrefs(config);
 
         initLogging(config);
 
@@ -135,10 +134,8 @@ public class MainApp extends Application {
         return initializedConfig;
     }
 
-    protected UserPrefs initPrefs(Config config) {
-        assert config != null;
-
-        String prefsFilePath = config.getUserPrefsFilePath();
+    protected UserPrefs initPrefs(UserPrefsStorage storage) {
+        String prefsFilePath = storage.getUserPrefsFilePath();
         logger.info("Using prefs file : " + prefsFilePath);
 
         UserPrefs initializedPrefs;

--- a/src/main/java/seedu/address/commons/core/Config.java
+++ b/src/main/java/seedu/address/commons/core/Config.java
@@ -14,9 +14,6 @@ public class Config {
     private String appTitle = "Address App";
     private Level logLevel = Level.INFO;
     private String userPrefsFilePath = "preferences.json";
-    private String addressBookFilePath = "data/addressbook.xml";
-    private String addressBookName = "MyAddressBook";
-
 
     public String getAppTitle() {
         return appTitle;
@@ -42,23 +39,6 @@ public class Config {
         this.userPrefsFilePath = userPrefsFilePath;
     }
 
-    public String getAddressBookFilePath() {
-        return addressBookFilePath;
-    }
-
-    public void setAddressBookFilePath(String addressBookFilePath) {
-        this.addressBookFilePath = addressBookFilePath;
-    }
-
-    public String getAddressBookName() {
-        return addressBookName;
-    }
-
-    public void setAddressBookName(String addressBookName) {
-        this.addressBookName = addressBookName;
-    }
-
-
     @Override
     public boolean equals(Object other) {
         if (other == this) {
@@ -72,14 +52,12 @@ public class Config {
 
         return Objects.equals(appTitle, o.appTitle)
                 && Objects.equals(logLevel, o.logLevel)
-                && Objects.equals(userPrefsFilePath, o.userPrefsFilePath)
-                && Objects.equals(addressBookFilePath, o.addressBookFilePath)
-                && Objects.equals(addressBookName, o.addressBookName);
+                && Objects.equals(userPrefsFilePath, o.userPrefsFilePath);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(appTitle, logLevel, userPrefsFilePath, addressBookFilePath, addressBookName);
+        return Objects.hash(appTitle, logLevel, userPrefsFilePath);
     }
 
     @Override
@@ -88,8 +66,6 @@ public class Config {
         sb.append("App title : " + appTitle);
         sb.append("\nCurrent log level : " + logLevel);
         sb.append("\nPreference file Location : " + userPrefsFilePath);
-        sb.append("\nLocal data file location : " + addressBookFilePath);
-        sb.append("\nAddressBook name : " + addressBookName);
         return sb.toString();
     }
 

--- a/src/main/java/seedu/address/model/UserPrefs.java
+++ b/src/main/java/seedu/address/model/UserPrefs.java
@@ -10,6 +10,8 @@ import seedu.address.commons.core.GuiSettings;
 public class UserPrefs {
 
     public GuiSettings guiSettings;
+    private String addressBookFilePath = "data/addressbook.xml";
+    private String addressBookName = "MyAddressBook";
 
     public GuiSettings getGuiSettings() {
         return guiSettings == null ? new GuiSettings() : guiSettings;
@@ -27,6 +29,22 @@ public class UserPrefs {
         guiSettings = new GuiSettings(width, height, x, y);
     }
 
+    public String getAddressBookFilePath() {
+        return addressBookFilePath;
+    }
+
+    public void setAddressBookFilePath(String addressBookFilePath) {
+        this.addressBookFilePath = addressBookFilePath;
+    }
+
+    public String getAddressBookName() {
+        return addressBookName;
+    }
+
+    public void setAddressBookName(String addressBookName) {
+        this.addressBookName = addressBookName;
+    }
+
     @Override
     public boolean equals(Object other) {
         if (other == this) {
@@ -38,17 +56,23 @@ public class UserPrefs {
 
         UserPrefs o = (UserPrefs) other;
 
-        return Objects.equals(guiSettings, o.guiSettings);
+        return Objects.equals(guiSettings, o.guiSettings)
+                && Objects.equals(addressBookFilePath, o.addressBookFilePath)
+                && Objects.equals(addressBookName, o.addressBookName);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(guiSettings);
+        return Objects.hash(guiSettings, addressBookFilePath, addressBookName);
     }
 
     @Override
     public String toString() {
-        return guiSettings.toString();
+        StringBuilder sb = new StringBuilder();
+        sb.append("Gui Settings : " + guiSettings.toString());
+        sb.append("\nLocal data file location : " + addressBookFilePath);
+        sb.append("\nAddressBook name : " + addressBookName);
+        return sb.toString();
     }
 
 }

--- a/src/main/java/seedu/address/storage/JsonUserPrefsStorage.java
+++ b/src/main/java/seedu/address/storage/JsonUserPrefsStorage.java
@@ -19,6 +19,11 @@ public class JsonUserPrefsStorage implements UserPrefsStorage {
     }
 
     @Override
+    public String getUserPrefsFilePath() {
+        return filePath;
+    }
+
+    @Override
     public Optional<UserPrefs> readUserPrefs() throws DataConversionException, IOException {
         return readUserPrefs(filePath);
     }

--- a/src/main/java/seedu/address/storage/StorageManager.java
+++ b/src/main/java/seedu/address/storage/StorageManager.java
@@ -30,10 +30,6 @@ public class StorageManager extends ComponentManager implements Storage {
         this.userPrefsStorage = userPrefsStorage;
     }
 
-    public StorageManager(String addressBookFilePath, String userPrefsFilePath) {
-        this(new XmlAddressBookStorage(addressBookFilePath), new JsonUserPrefsStorage(userPrefsFilePath));
-    }
-
     // ================ UserPrefs methods ==============================
 
     @Override

--- a/src/main/java/seedu/address/storage/StorageManager.java
+++ b/src/main/java/seedu/address/storage/StorageManager.java
@@ -37,6 +37,11 @@ public class StorageManager extends ComponentManager implements Storage {
     // ================ UserPrefs methods ==============================
 
     @Override
+    public String getUserPrefsFilePath() {
+        return userPrefsStorage.getUserPrefsFilePath();
+    }
+
+    @Override
     public Optional<UserPrefs> readUserPrefs() throws DataConversionException, IOException {
         return userPrefsStorage.readUserPrefs();
     }

--- a/src/main/java/seedu/address/storage/UserPrefsStorage.java
+++ b/src/main/java/seedu/address/storage/UserPrefsStorage.java
@@ -12,6 +12,11 @@ import seedu.address.model.UserPrefs;
 public interface UserPrefsStorage {
 
     /**
+     * Returns the file path of the UserPrefs data file.
+     */
+    String getUserPrefsFilePath();
+
+    /**
      * Returns UserPrefs data from storage.
      *   Returns {@code Optional.empty()} if storage file is not found.
      * @throws DataConversionException if the data in storage is not in the expected format.

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -36,6 +36,7 @@ public class MainWindow extends UiPart<Region> {
     private BrowserPanel browserPanel;
     private PersonListPanel personListPanel;
     private Config config;
+    private UserPrefs prefs;
 
     @FXML
     private AnchorPane browserPlaceholder;
@@ -62,6 +63,7 @@ public class MainWindow extends UiPart<Region> {
         this.primaryStage = primaryStage;
         this.logic = logic;
         this.config = config;
+        this.prefs = prefs;
 
         // Configure the UI
         setTitle(config.getAppTitle());
@@ -116,7 +118,7 @@ public class MainWindow extends UiPart<Region> {
         browserPanel = new BrowserPanel(browserPlaceholder);
         personListPanel = new PersonListPanel(getPersonListPlaceholder(), logic.getFilteredPersonList());
         new ResultDisplay(getResultDisplayPlaceholder());
-        new StatusBarFooter(getStatusbarPlaceholder(), config.getAddressBookFilePath());
+        new StatusBarFooter(getStatusbarPlaceholder(), prefs.getAddressBookFilePath());
         new CommandBox(getCommandBoxPlaceholder(), logic);
     }
 

--- a/src/test/data/ConfigUtilTest/ExtraValuesConfig.json
+++ b/src/test/data/ConfigUtilTest/ExtraValuesConfig.json
@@ -2,7 +2,5 @@
   "appTitle" : "Typical App Title",
   "logLevel" : "INFO",
   "userPrefsFilePath" : "C:\\preferences.json",
-  "addressBookFilePath" : "addressbook.xml",
-  "addressBookName" : "TypicalAddressBookName",
   "extra" : "extra value"
 }

--- a/src/test/data/ConfigUtilTest/TypicalConfig.json
+++ b/src/test/data/ConfigUtilTest/TypicalConfig.json
@@ -1,7 +1,5 @@
 {
   "appTitle" : "Typical App Title",
   "logLevel" : "INFO",
-  "userPrefsFilePath" : "C:\\preferences.json",
-  "addressBookFilePath" : "addressbook.xml",
-  "addressBookName" : "TypicalAddressBookName"
+  "userPrefsFilePath" : "C:\\preferences.json"
 }

--- a/src/test/data/JsonUserPrefsStorageTest/ExtraValuesUserPref.json
+++ b/src/test/data/JsonUserPrefsStorageTest/ExtraValuesUserPref.json
@@ -8,5 +8,7 @@
       "y" : 100,
       "z" : 99
     }
-  }
+  },
+  "addressBookFilePath" : "addressbook.xml",
+  "addressBookName" : "TypicalAddressBookName"
 }

--- a/src/test/data/JsonUserPrefsStorageTest/TypicalUserPref.json
+++ b/src/test/data/JsonUserPrefsStorageTest/TypicalUserPref.json
@@ -6,5 +6,7 @@
       "x" : 300,
       "y" : 100
     }
-  }
+  },
+  "addressBookFilePath" : "addressbook.xml",
+  "addressBookName" : "TypicalAddressBookName"
 }

--- a/src/test/java/seedu/address/TestApp.java
+++ b/src/test/java/seedu/address/TestApp.java
@@ -8,6 +8,7 @@ import seedu.address.commons.core.Config;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.UserPrefs;
+import seedu.address.storage.UserPrefsStorage;
 import seedu.address.storage.XmlSerializableAddressBook;
 import seedu.address.testutil.TestUtil;
 
@@ -45,18 +46,18 @@ public class TestApp extends MainApp {
     protected Config initConfig(String configFilePath) {
         Config config = super.initConfig(configFilePath);
         config.setAppTitle(APP_TITLE);
-        config.setAddressBookFilePath(saveFileLocation);
         config.setUserPrefsFilePath(DEFAULT_PREF_FILE_LOCATION_FOR_TESTING);
-        config.setAddressBookName(ADDRESS_BOOK_NAME);
         return config;
     }
 
     @Override
-    protected UserPrefs initPrefs(Config config) {
-        UserPrefs userPrefs = super.initPrefs(config);
+    protected UserPrefs initPrefs(UserPrefsStorage storage) {
+        UserPrefs userPrefs = super.initPrefs(storage);
         double x = Screen.getPrimary().getVisualBounds().getMinX();
         double y = Screen.getPrimary().getVisualBounds().getMinY();
         userPrefs.updateLastUsedGuiSetting(new GuiSettings(600.0, 600.0, (int) x, (int) y));
+        userPrefs.setAddressBookFilePath(saveFileLocation);
+        userPrefs.setAddressBookName(ADDRESS_BOOK_NAME);
         return userPrefs;
     }
 

--- a/src/test/java/seedu/address/commons/core/ConfigTest.java
+++ b/src/test/java/seedu/address/commons/core/ConfigTest.java
@@ -16,9 +16,7 @@ public class ConfigTest {
     public void toString_defaultObject_stringReturned() {
         String defaultConfigAsString = "App title : Address App\n" +
                 "Current log level : INFO\n" +
-                "Preference file Location : preferences.json\n" +
-                "Local data file location : data/addressbook.xml\n" +
-                "AddressBook name : MyAddressBook";
+                "Preference file Location : preferences.json";
 
         assertEquals(defaultConfigAsString, new Config().toString());
     }

--- a/src/test/java/seedu/address/commons/util/ConfigUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/ConfigUtilTest.java
@@ -76,8 +76,6 @@ public class ConfigUtilTest {
         config.setAppTitle("Typical App Title");
         config.setLogLevel(Level.INFO);
         config.setUserPrefsFilePath("C:\\preferences.json");
-        config.setAddressBookFilePath("addressbook.xml");
-        config.setAddressBookName("TypicalAddressBookName");
         return config;
     }
 

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -47,7 +47,9 @@ import seedu.address.model.person.Phone;
 import seedu.address.model.person.ReadOnlyPerson;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.tag.UniqueTagList;
+import seedu.address.storage.JsonUserPrefsStorage;
 import seedu.address.storage.StorageManager;
+import seedu.address.storage.XmlAddressBookStorage;
 
 
 public class LogicManagerTest {
@@ -86,7 +88,10 @@ public class LogicManagerTest {
         model = new ModelManager();
         String tempAddressBookFile = saveFolder.getRoot().getPath() + "TempAddressBook.xml";
         String tempPreferencesFile = saveFolder.getRoot().getPath() + "TempPreferences.json";
-        logic = new LogicManager(model, new StorageManager(tempAddressBookFile, tempPreferencesFile));
+        XmlAddressBookStorage addressBookStorage = new XmlAddressBookStorage(tempAddressBookFile);
+        JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(tempPreferencesFile);
+        StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage);
+        logic = new LogicManager(model, storage);
         EventsCenter.getInstance().registerHandler(this);
 
         latestSavedAddressBook = new AddressBook(model.getAddressBook()); // last saved assumed to be up to date

--- a/src/test/java/seedu/address/storage/JsonUserPrefsStorageTest.java
+++ b/src/test/java/seedu/address/storage/JsonUserPrefsStorageTest.java
@@ -61,8 +61,7 @@ public class JsonUserPrefsStorageTest {
 
     @Test
     public void readUserPrefs_fileInOrder_successfullyRead() throws DataConversionException {
-        UserPrefs expected = new UserPrefs();
-        expected.setGuiSettings(1000, 500, 300, 100);
+        UserPrefs expected = getTypicalUserPrefs();
         UserPrefs actual = readUserPrefs("TypicalUserPref.json").get();
         assertEquals(expected, actual);
     }
@@ -75,11 +74,18 @@ public class JsonUserPrefsStorageTest {
 
     @Test
     public void readUserPrefs_extraValuesInFile_extraValuesIgnored() throws DataConversionException {
-        UserPrefs expected = new UserPrefs();
-        expected.setGuiSettings(1000, 500, 300, 100);
+        UserPrefs expected = getTypicalUserPrefs();
         UserPrefs actual = readUserPrefs("ExtraValuesUserPref.json").get();
 
         assertEquals(expected, actual);
+    }
+
+    private UserPrefs getTypicalUserPrefs() {
+        UserPrefs userPrefs = new UserPrefs();
+        userPrefs.setGuiSettings(1000, 500, 300, 100);
+        userPrefs.setAddressBookFilePath("addressbook.xml");
+        userPrefs.setAddressBookName("TypicalAddressBookName");
+        return userPrefs;
     }
 
     @Test

--- a/src/test/java/seedu/address/storage/StorageManagerTest.java
+++ b/src/test/java/seedu/address/storage/StorageManagerTest.java
@@ -30,7 +30,9 @@ public class StorageManagerTest {
 
     @Before
     public void setUp() {
-        storageManager = new StorageManager(getTempFilePath("ab"), getTempFilePath("prefs"));
+        XmlAddressBookStorage addressBookStorage = new XmlAddressBookStorage(getTempFilePath("ab"));
+        JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(getTempFilePath("prefs"));
+        storageManager = new StorageManager(addressBookStorage, userPrefsStorage);
     }
 
 


### PR DESCRIPTION
Fixes #213 

~Replace `ConfigUtil` with `ConfigStorage` whose functionality is similar to `JsonUserPrefsStorage` for `UserPrefs`.~

~`ConfigStorage` knows what is the current file path of the config, and provides methods for read and save the config, thus it supports updating config at runtime by calling `configStorage.saveConfig(config);` before app exits. (see `MainApp.java`)~

Changes:
- Move addressBookFilePath and addressBookName from` Config` to `UserPrefs`
- Fix JSON test data.
- Fix tests. `ConfigTest`, `ConfigUtilTest` and `JsonUserPrefsStorageTest`
- Add `setAddressBookPath(String addressBookPath)` to `Storage` interface.
- Implement the new interface method in `StorageManager`.
- Fix the initialization steps (e.g. setup `UserPrefs`, use `UserPrefs` to get addressBookFilePath instead of `Config`) in `MainApp` and `TestApp` and `MainWindow`

Ready for review.

Proposed merge commit message:
```
Users are not able to update addressBookName and addressBookPath,
which are stored in Config, because data in Config are not meant to be
changed at runtime.

To allow modifying addressBookName and addressBookPath at runtime,
let's move them from Config to UserPrefs.
```