### PR TITLE
Update GUI tests to verify 'last updated' feature #114

### DIFF
--- a/src/main/java/seedu/address/ui/StatusBarFooter.java
+++ b/src/main/java/seedu/address/ui/StatusBarFooter.java
@@ -20,6 +20,9 @@ import seedu.address.commons.util.FxViewUtil;
  */
 public class StatusBarFooter extends UiPart<Region> {
 
+    public static final String SYNC_STATUS_INITIAL = "Not updated yet in this session";
+    public static final String SYNC_STATUS_UPDATED = "Last Updated: %s";
+
     /**
      * Used to generate time stamps.
      *
@@ -56,7 +59,7 @@ public class StatusBarFooter extends UiPart<Region> {
     public StatusBarFooter(AnchorPane placeHolder, String saveLocation) {
         super(FXML);
         addToPlaceholder(placeHolder);
-        setSyncStatus("Not updated yet in this session");
+        setSyncStatus(SYNC_STATUS_INITIAL);
         setSaveLocation("./" + saveLocation);
         registerAsAnEventHandler(this);
     }
@@ -79,6 +82,6 @@ public class StatusBarFooter extends UiPart<Region> {
         long now = clock.millis();
         String lastUpdated = new Date(now).toString();
         logger.info(LogsCenter.getEventHandlingLogMessage(abce, "Setting last updated status to " + lastUpdated));
-        setSyncStatus("Last Updated: " + lastUpdated);
+        setSyncStatus(String.format(SYNC_STATUS_UPDATED, lastUpdated));
     }
 }

--- a/src/main/java/seedu/address/ui/StatusBarFooter.java
+++ b/src/main/java/seedu/address/ui/StatusBarFooter.java
@@ -1,5 +1,6 @@
 package seedu.address.ui;
 
+import java.time.Clock;
 import java.util.Date;
 import java.util.logging.Logger;
 
@@ -18,6 +19,17 @@ import seedu.address.commons.util.FxViewUtil;
  * A ui for the status bar that is displayed at the footer of the application.
  */
 public class StatusBarFooter extends UiPart<Region> {
+
+    /**
+     * Used to generate time stamps.
+     *
+     * TODO: change clock to an instance variable.
+     * We leave it as a static variable because manual dependency injection
+     * will require passing down the clock reference all the way from MainApp,
+     * but it should be easier once we have factories/DI frameworks.
+     */
+    private static Clock clock = Clock.systemDefaultZone();
+
     private static final Logger logger = LogsCenter.getLogger(StatusBarFooter.class);
 
     @FXML
@@ -26,6 +38,20 @@ public class StatusBarFooter extends UiPart<Region> {
     private StatusBar saveLocationStatus;
 
     private static final String FXML = "StatusBarFooter.fxml";
+
+    /**
+     * Sets the clock used to determine the current time.
+     */
+    public static void setClock(Clock clock) {
+        StatusBarFooter.clock = clock;
+    }
+
+    /**
+     * Returns the clock currently in use.
+     */
+    public static Clock getClock() {
+        return clock;
+    }
 
     public StatusBarFooter(AnchorPane placeHolder, String saveLocation) {
         super(FXML);
@@ -50,7 +76,8 @@ public class StatusBarFooter extends UiPart<Region> {
 
     @Subscribe
     public void handleAddressBookChangedEvent(AddressBookChangedEvent abce) {
-        String lastUpdated = (new Date()).toString();
+        long now = clock.millis();
+        String lastUpdated = new Date(now).toString();
         logger.info(LogsCenter.getEventHandlingLogMessage(abce, "Setting last updated status to " + lastUpdated));
         setSyncStatus("Last Updated: " + lastUpdated);
     }

--- a/src/test/java/guitests/AddressBookGuiTest.java
+++ b/src/test/java/guitests/AddressBookGuiTest.java
@@ -19,6 +19,7 @@ import guitests.guihandles.MainMenuHandle;
 import guitests.guihandles.PersonCardHandle;
 import guitests.guihandles.PersonListPanelHandle;
 import guitests.guihandles.ResultDisplayHandle;
+import guitests.guihandles.StatusBarFooterHandle;
 import javafx.application.Platform;
 import javafx.stage.Stage;
 import seedu.address.TestApp;
@@ -52,6 +53,7 @@ public abstract class AddressBookGuiTest {
     protected ResultDisplayHandle resultDisplay;
     protected CommandBoxHandle commandBox;
     protected BrowserPanelHandle browserPanel;
+    protected StatusBarFooterHandle statusBarFooter;
     private Stage stage;
 
     @BeforeClass
@@ -73,6 +75,7 @@ public abstract class AddressBookGuiTest {
             resultDisplay = mainGui.getResultDisplay();
             commandBox = mainGui.getCommandBox();
             browserPanel = mainGui.getBrowserPanel();
+            statusBarFooter = mainGui.getStatusBarFooter();
             this.stage = stage;
         });
         EventsCenter.clearSubscribers();

--- a/src/test/java/guitests/CommandBoxTest.java
+++ b/src/test/java/guitests/CommandBoxTest.java
@@ -2,6 +2,7 @@ package guitests;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 
@@ -48,23 +49,25 @@ public class CommandBoxTest extends AddressBookGuiTest {
     }
 
     /**
-     * Runs a command that fails, then verifies that text remains
-     * and that command box has only one ERROR_STYLE_CLASS, with other style classes untouched.
+     * Runs a command that fails, then verifies that
+     * - the return value of runCommand(...) is false,
+     * - the text remains,
+     * - the command box has only one ERROR_STYLE_CLASS, with other style classes untouched.
      */
     private void assertBehaviorForFailedCommand() {
-        commandBox.runCommand(COMMAND_THAT_FAILS);
-
+        assertFalse(commandBox.runCommand(COMMAND_THAT_FAILS));
         assertEquals(COMMAND_THAT_FAILS, commandBox.getCommandInput());
         assertEquals(errorStyleOfCommandBox, commandBox.getStyleClass());
     }
 
     /**
-     * Runs a command that succeeds, then verifies that text is cleared
-     * and that command box does not have any ERROR_STYLE_CLASS, with style classes the same as default.
+     * Runs a command that succeeds, then verifies that
+     * - the return value of runCommand(...) is true,
+     * - the text is cleared,
+     * - the command box does not have any ERROR_STYLE_CLASS, with style classes the same as default.
      */
     private void assertBehaviorForSuccessfulCommand() {
-        commandBox.runCommand(COMMAND_THAT_SUCCEEDS);
-
+        assertTrue(commandBox.runCommand(COMMAND_THAT_SUCCEEDS));
         assertEquals("", commandBox.getCommandInput());
         assertEquals(defaultStyleOfCommandBox, commandBox.getStyleClass());
     }

--- a/src/test/java/guitests/StatusBarFooterTest.java
+++ b/src/test/java/guitests/StatusBarFooterTest.java
@@ -1,0 +1,64 @@
+package guitests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import static seedu.address.ui.StatusBarFooter.SYNC_STATUS_INITIAL;
+import static seedu.address.ui.StatusBarFooter.SYNC_STATUS_UPDATED;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Date;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import seedu.address.logic.commands.ListCommand;
+import seedu.address.ui.StatusBarFooter;
+
+public class StatusBarFooterTest extends AddressBookGuiTest {
+
+    private Clock originalClock;
+    private Clock injectedClock;
+
+    @Before
+    public void injectFixedClock() {
+        originalClock = StatusBarFooter.getClock();
+        injectedClock = Clock.fixed(Instant.now(), ZoneId.systemDefault());
+        StatusBarFooter.setClock(injectedClock);
+    }
+
+    @After
+    public void restoreOriginalClock() {
+        StatusBarFooter.setClock(originalClock);
+    }
+
+    @Test
+    public void syncStatus_initialValue() {
+        assertEquals(SYNC_STATUS_INITIAL, statusBarFooter.getSyncStatus());
+    }
+
+    @Test
+    public void syncStatus_mutatingCommandSucceeds_syncStatusUpdated() {
+        String timestamp = new Date(injectedClock.millis()).toString();
+        String expected = String.format(SYNC_STATUS_UPDATED, timestamp);
+        assertTrue(commandBox.runCommand(td.hoon.getAddCommand())); // mutating command succeeds
+        assertEquals(expected, statusBarFooter.getSyncStatus());
+    }
+
+    @Test
+    public void syncStatus_nonMutatingCommandSucceeds_syncStatusRemainsUnchanged() {
+        assertTrue(commandBox.runCommand(ListCommand.COMMAND_WORD)); // non-mutating command succeeds
+        assertEquals(SYNC_STATUS_INITIAL, statusBarFooter.getSyncStatus());
+    }
+
+    @Test
+    public void syncStatus_commandFails_syncStatusRemainsUnchanged() {
+        assertFalse(commandBox.runCommand("invalid command")); // invalid command fails
+        assertEquals(SYNC_STATUS_INITIAL, statusBarFooter.getSyncStatus());
+    }
+
+}

--- a/src/test/java/guitests/guihandles/CommandBoxHandle.java
+++ b/src/test/java/guitests/guihandles/CommandBoxHandle.java
@@ -4,6 +4,8 @@ import guitests.GuiRobot;
 import javafx.collections.ObservableList;
 import javafx.stage.Stage;
 
+import seedu.address.ui.CommandBox;
+
 /**
  * A handle to the Command Box in the GUI.
  */
@@ -32,11 +34,13 @@ public class CommandBoxHandle extends GuiHandle {
 
     /**
      * Enters the given command in the Command Box and presses enter.
+     * @return true if the command succeeded, false otherwise.
      */
-    public void runCommand(String command) {
+    public boolean runCommand(String command) {
         enterCommand(command);
         pressEnter();
         guiRobot.sleep(200); //Give time for the command to take effect
+        return !getStyleClass().contains(CommandBox.ERROR_STYLE_CLASS);
     }
 
     public HelpWindowHandle runHelpCommand() {

--- a/src/test/java/guitests/guihandles/MainGuiHandle.java
+++ b/src/test/java/guitests/guihandles/MainGuiHandle.java
@@ -25,6 +25,10 @@ public class MainGuiHandle extends GuiHandle {
         return new CommandBoxHandle(guiRobot, primaryStage, TestApp.APP_TITLE);
     }
 
+    public StatusBarFooterHandle getStatusBarFooter() {
+        return new StatusBarFooterHandle(guiRobot, primaryStage);
+    }
+
     public MainMenuHandle getMainMenu() {
         return new MainMenuHandle(guiRobot, primaryStage);
     }

--- a/src/test/java/guitests/guihandles/StatusBarFooterHandle.java
+++ b/src/test/java/guitests/guihandles/StatusBarFooterHandle.java
@@ -1,0 +1,28 @@
+package guitests.guihandles;
+
+import org.controlsfx.control.StatusBar;
+
+import guitests.GuiRobot;
+import javafx.stage.Stage;
+import seedu.address.TestApp;
+
+/**
+ * A handle for the status bar at the footer of the application.
+ */
+public class StatusBarFooterHandle extends GuiHandle {
+
+    public static final String SYNC_STATUS_ID = "#syncStatus";
+    public static final String SAVE_LOCATION_STATUS_ID = "#saveLocationStatus";
+
+    public StatusBarFooterHandle(GuiRobot guiRobot, Stage primaryStage) {
+        super(guiRobot, primaryStage, TestApp.APP_TITLE);
+    }
+
+    public String getSyncStatus() {
+        return ((StatusBar) getNode(SYNC_STATUS_ID)).getText();
+    }
+
+    public String getSaveLocation() {
+        return ((StatusBar) getNode(SAVE_LOCATION_STATUS_ID)).getText();
+    }
+}


### PR DESCRIPTION
Fixes #114 

Current StatusBarFooterTest includes
- after a successful command, the sync status text has been updated
- after an invalid command, the sync status text is not updated

Some issues:
- only tested AddCommand.

Testing for save location in the status bar can be added later in [another PR](https://github.com/se-edu/addressbook-level4/pull/212) using SaveAsCommand, but some methods (e.g `getSaveLocation`) have already been included in this PR.

Ready for review.

Proposed merge commit message:

> Let's add GUI tests to verify the 'last updated' feature of the status
bar footer.
