### PR TITLE
Make Travis CI output less verbose #204

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
 
 script: >-
     ./config/travis/run-checks.sh &&
-    travis_retry ./gradlew clean checkstyleMain checkstyleTest headless allTests coverage coveralls -i
+    travis_retry ./gradlew clean checkstyleMain checkstyleTest headless allTests coverage coveralls
 
 before_install:
           - "export DISPLAY=:99.0"

--- a/build.gradle
+++ b/build.gradle
@@ -124,6 +124,17 @@ class AddressBookTest extends Test {
     public AddressBookTest() {
     	  forkEvery = 1
         systemProperty 'testfx.setup.timeout', '60000'
+
+        /*
+         * Prints the currently running test's name in the CI's build log,
+         * so that we can check if tests are being silently skipped or
+         * stalling the build.
+         */
+        if (System.env.'CI') {
+            beforeTest { descriptor ->
+                logger.lifecycle('Running test: ' + descriptor)
+            }
+        }
     }
 
     public void setHeadless() {


### PR DESCRIPTION
Fixes #204.

Commit message 94c738b:
> Gradle utilises different levels for logging (see
> https://docs.gradle.org/current/userguide/logging.html).
> 
> .travis.yml was set to execute gradle with '-i'. This meant that log
> messages with 'INFO' level and above are generated to stdout. Such
> 'INFO' messages are generally unhelpful, as they do not provide any
> additional meaningful information not already given by test failure
> messages, and they pollute the log due to their large quantity.
> 
> As such, '-i' is removed so that only messages on 'LIFECYCLE' level,
> 'WARNING' level and above are generated (i.e. the 'INFO' level is
> omitted) - this is the default behaviour of Gradle.