### PR TITLE
Update URL of help window #217

### DIFF
--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -20,7 +20,7 @@ public class HelpWindow extends UiPart<Region> {
     private static final String FXML = "HelpWindow.fxml";
     private static final String TITLE = "Help";
     private static final String USERGUIDE_URL =
-            "https://github.com/se-edu/addressbook-level4/blob/master/docs/UserGuide.md";
+            "https://se-edu.github.io/addressbook-level4/docs/UserGuide.html";
 
     @FXML
     private WebView browser;


### PR DESCRIPTION
Closes #217 

This points the URL of the help window to a more aesthetically pleasing document rather than the current one pointing directly to the markdown in github