### PR TITLE
Parser and ArgumentTokenizer cleanups #235

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -1,8 +1,5 @@
 package seedu.address.logic.commands;
 
-import java.util.HashSet;
-import java.util.Set;
-
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.person.Address;
@@ -11,7 +8,6 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.UniquePersonList;
-import seedu.address.model.tag.Tag;
 import seedu.address.model.tag.UniqueTagList;
 
 /**
@@ -36,18 +32,14 @@ public class AddCommand extends Command {
      *
      * @throws IllegalValueException if any of the raw values are invalid
      */
-    public AddCommand(String name, String phone, String email, String address, Set<String> tags)
+    public AddCommand(String name, String phone, String email, String address, UniqueTagList tags)
             throws IllegalValueException {
-        final Set<Tag> tagSet = new HashSet<>();
-        for (String tagName : tags) {
-            tagSet.add(new Tag(tagName));
-        }
         this.toAdd = new Person(
                 new Name(name),
                 new Phone(phone),
                 new Email(email),
                 new Address(address),
-                new UniqueTagList(tagSet)
+                new UniqueTagList(tags)
         );
     }
 

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -32,7 +32,7 @@ public class AddCommandParser {
                     argsTokenizer.getValue(PREFIX_PHONE).get(),
                     argsTokenizer.getValue(PREFIX_EMAIL).get(),
                     argsTokenizer.getValue(PREFIX_ADDRESS).get(),
-                    ParserUtil.toSet(argsTokenizer.getAllValues(PREFIX_TAG))
+                    ParserUtil.parseTags(argsTokenizer.getAllValues(PREFIX_TAG))
             );
         } catch (NoSuchElementException nsee) {
             return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -28,7 +28,7 @@ public class AddCommandParser {
         argsTokenizer.tokenize(args);
         try {
             return new AddCommand(
-                    argsTokenizer.getPreamble().get(),
+                    argsTokenizer.getPreamble(),
                     argsTokenizer.getValue(PREFIX_PHONE).get(),
                     argsTokenizer.getValue(PREFIX_EMAIL).get(),
                     argsTokenizer.getValue(PREFIX_ADDRESS).get(),

--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -59,19 +59,11 @@ public class ArgumentTokenizer {
     }
 
     /**
-     * Returns the preamble (text before the first valid prefix), if any. Leading/trailing spaces will be trimmed.
-     *     If the string before the first prefix is empty, Optional.empty() will be returned.
+     * Returns the preamble (text before the first valid prefix). Trims any leading/trailing spaces.
      */
-    public Optional<String> getPreamble() {
-
+    public String getPreamble() {
         Optional<String> storedPreamble = getValue(new Prefix(""));
-
-        /* An empty preamble is considered 'no preamble present' */
-        if (storedPreamble.isPresent() && !storedPreamble.get().isEmpty()) {
-            return storedPreamble;
-        } else {
-            return Optional.empty();
-        }
+        return storedPreamble.orElse("");
     }
 
     private void resetTokenizerState() {

--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -44,18 +45,19 @@ public class ArgumentTokenizer {
      * Returns last value of given prefix.
      */
     public Optional<String> getValue(Prefix prefix) {
-        return getAllValues(prefix).flatMap((values) -> Optional.of(values.get(values.size() - 1)));
+        List<String> values = getAllValues(prefix);
+        return values.isEmpty() ? Optional.empty() : Optional.of(values.get(values.size() - 1));
     }
 
     /**
-     * Returns all values of given prefix.
+     * Returns all values of given prefix, if any.
+     * If the prefix does not exist or has no values, returns an empty list.
      */
-    public Optional<List<String>> getAllValues(Prefix prefix) {
+    public List<String> getAllValues(Prefix prefix) {
         if (!this.tokenizedArguments.containsKey(prefix)) {
-            return Optional.empty();
+            return Collections.emptyList();
         }
-        List<String> values = new ArrayList<>(this.tokenizedArguments.get(prefix));
-        return Optional.of(values);
+        return new ArrayList<>(this.tokenizedArguments.get(prefix));
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -1,7 +1,5 @@
 package seedu.address.logic.parser;
 
-import java.util.regex.Pattern;
-
 import seedu.address.logic.parser.ArgumentTokenizer.Prefix;
 
 /**
@@ -14,9 +12,5 @@ public class CliSyntax {
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
-
-    /* Patterns definitions */
-    public static final Pattern KEYWORDS_ARGS_FORMAT =
-            Pattern.compile("(?<keywords>\\S+(?:\\s+\\S+)*)"); // one or more keywords separated by whitespace
 
 }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -32,7 +32,7 @@ public class EditCommandParser {
         ArgumentTokenizer argsTokenizer =
                 new ArgumentTokenizer(PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
         argsTokenizer.tokenize(args);
-        List<Optional<String>> preambleFields = ParserUtil.splitPreamble(argsTokenizer.getPreamble().orElse(""), 2);
+        List<Optional<String>> preambleFields = ParserUtil.splitPreamble(argsTokenizer.getPreamble(), 2);
 
         Optional<Integer> index = preambleFields.get(0).flatMap(ParserUtil::parseIndex);
         if (!index.isPresent()) {

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -45,7 +45,7 @@ public class EditCommandParser {
             editPersonDescriptor.setPhone(ParserUtil.parsePhone(argsTokenizer.getValue(PREFIX_PHONE)));
             editPersonDescriptor.setEmail(ParserUtil.parseEmail(argsTokenizer.getValue(PREFIX_EMAIL)));
             editPersonDescriptor.setAddress(ParserUtil.parseAddress(argsTokenizer.getValue(PREFIX_ADDRESS)));
-            editPersonDescriptor.setTags(parseTagsForEdit(ParserUtil.toSet(argsTokenizer.getAllValues(PREFIX_TAG))));
+            editPersonDescriptor.setTags(parseTagsForEdit(argsTokenizer.getAllValues(PREFIX_TAG)));
         } catch (IllegalValueException ive) {
             return new IncorrectCommand(ive.getMessage());
         }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -1,12 +1,10 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.KEYWORDS_ARGS_FORMAT;
 
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.regex.Matcher;
 
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.FindCommand;
@@ -22,14 +20,14 @@ public class FindCommandParser {
      * and returns an FindCommand object for execution.
      */
     public Command parse(String args) {
-        final Matcher matcher = KEYWORDS_ARGS_FORMAT.matcher(args.trim());
-        if (!matcher.matches()) {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
             return new IncorrectCommand(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
         // keywords delimited by whitespace
-        final String[] keywords = matcher.group("keywords").split("\\s+");
+        final String[] keywords = trimmedArgs.split("\\s+");
         final Set<String> keywordSet = new HashSet<>(Arrays.asList(keywords));
         return new FindCommand(keywordSet);
     }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -45,15 +45,6 @@ public class ParserUtil {
     }
 
     /**
-     * Returns a new Set populated by all elements in the given list of strings
-     * Returns an empty set if the given {@code Optional} is empty,
-     * or if the list contained in the {@code Optional} is empty
-     */
-    public static Set<String> toSet(List<String> list) {
-        return new HashSet<>(list);
-    }
-
-    /**
     * Splits a preamble string into ordered fields.
     * @return A list of size {@code numFields} where the ith element is the ith field value if specified in
     *         the input, {@code Optional.empty()} otherwise.

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -6,8 +6,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import seedu.address.commons.exceptions.IllegalValueException;
@@ -24,19 +22,12 @@ import seedu.address.model.tag.UniqueTagList;
  */
 public class ParserUtil {
 
-    private static final Pattern INDEX_ARGS_FORMAT = Pattern.compile("(?<targetIndex>.+)");
-
     /**
      * Returns the specified index in the {@code command} if it is a positive unsigned integer
      * Returns an {@code Optional.empty()} otherwise.
      */
     public static Optional<Integer> parseIndex(String command) {
-        final Matcher matcher = INDEX_ARGS_FORMAT.matcher(command.trim());
-        if (!matcher.matches()) {
-            return Optional.empty();
-        }
-
-        String index = matcher.group("targetIndex");
+        String index = command.trim();
         if (!StringUtil.isUnsignedInteger(index)) {
             return Optional.empty();
         }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -2,7 +2,6 @@ package seedu.address.logic.parser;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -50,9 +49,8 @@ public class ParserUtil {
      * Returns an empty set if the given {@code Optional} is empty,
      * or if the list contained in the {@code Optional} is empty
      */
-    public static Set<String> toSet(Optional<List<String>> list) {
-        List<String> elements = list.orElse(Collections.emptyList());
-        return new HashSet<>(elements);
+    public static Set<String> toSet(List<String> list) {
+        return new HashSet<>(list);
     }
 
     /**

--- a/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
+++ b/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
@@ -47,11 +47,11 @@ public class ArgumentTokenizerTest {
         assertEquals(expectedValues[expectedValues.length - 1], argsTokenizer.getValue(prefix).get());
 
         // Verify the number of values returned is as expected
-        assertEquals(expectedValues.length, argsTokenizer.getAllValues(prefix).get().size());
+        assertEquals(expectedValues.length, argsTokenizer.getAllValues(prefix).size());
 
         // Verify all values returned are as expected and in order
         for (int i = 0; i < expectedValues.length; i++) {
-            assertEquals(expectedValues[i], argsTokenizer.getAllValues(prefix).get().get(i));
+            assertEquals(expectedValues[i], argsTokenizer.getAllValues(prefix).get(i));
         }
     }
 

--- a/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
+++ b/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
@@ -18,7 +19,7 @@ public class ArgumentTokenizerTest {
     @Test
     public void accessors_notTokenizedYet() {
         ArgumentTokenizer tokenizer = new ArgumentTokenizer(slashP);
-        assertPreambleAbsent(tokenizer);
+        assertPreambleEmpty(tokenizer);
         assertArgumentAbsent(tokenizer, slashP);
     }
 
@@ -28,16 +29,16 @@ public class ArgumentTokenizerTest {
         String argsString = "  ";
         tokenizer.tokenize(argsString);
 
-        assertPreambleAbsent(tokenizer);
+        assertPreambleEmpty(tokenizer);
         assertArgumentAbsent(tokenizer, slashP);
     }
 
     private void assertPreamblePresent(ArgumentTokenizer argsTokenizer, String expectedPreamble) {
-        assertEquals(expectedPreamble, argsTokenizer.getPreamble().get());
+        assertEquals(expectedPreamble, argsTokenizer.getPreamble());
     }
 
-    private void assertPreambleAbsent(ArgumentTokenizer argsTokenizer) {
-        assertFalse(argsTokenizer.getPreamble().isPresent());
+    private void assertPreambleEmpty(ArgumentTokenizer argsTokenizer) {
+        assertTrue(argsTokenizer.getPreamble().isEmpty());
     }
 
     private void assertArgumentPresent(ArgumentTokenizer argsTokenizer, Prefix prefix, String... expectedValues) {
@@ -80,7 +81,7 @@ public class ArgumentTokenizerTest {
 
         // No preamble
         tokenizer.tokenize(" /p   Argument value ");
-        assertPreambleAbsent(tokenizer);
+        assertPreambleEmpty(tokenizer);
         assertArgumentPresent(tokenizer, slashP, "Argument value");
 
     }
@@ -110,7 +111,7 @@ public class ArgumentTokenizerTest {
         // Reuse tokenizer on an empty string to ensure state is correctly reset
         //   (i.e. no stale values from the previous tokenizing remain in the state)
         tokenizer.tokenize("");
-        assertPreambleAbsent(tokenizer);
+        assertPreambleEmpty(tokenizer);
         assertArgumentAbsent(tokenizer, slashP);
 
         /** Also covers: testing for prefixes not specified as a prefix **/


### PR DESCRIPTION
Fixes #235 
Collecting a list of small cleanups that can be made.
Cleanups have also been applied to 97c34f2b96ec34b3afd93876f3eda12455759c91 that addresses #141.

## `ArgumentTokenizer`

- `getPreamble()`: Rather than returning `Optional.empty()`, an empty string can be returned instead. (With defensive programming, callers will need to check for empty string anyway).

- `getAllValues()`: Rather than returning `Optional.empty()`, an empty list can be returned instead. (With defensive programming, callers will need to check for an empty list anyway). This has the side benefit of removing the `toSet()` helper in `Parser`.

## `Parser`

Use of regular expressions that are less readable than their less fancy counterparts:

- `PERSON_INDEX_ARGS_FORMAT` can be replaced with `String.isEmpty()`. Actually, I think `StringUtils.isUnsignedInteger()` already checks for empty string soo...

- `KEYWORDS_ARGS_FORMAT` can be replaced with `keywords.length <= 0`.
