### PR TITLE
CollectionUtil: refactor assertNoNullElements -> isAnyNull(Collection)

### DIFF
--- a/src/main/java/seedu/address/commons/util/CollectionUtil.java
+++ b/src/main/java/seedu/address/commons/util/CollectionUtil.java
@@ -12,16 +12,17 @@ import java.util.stream.Stream;
  */
 public class CollectionUtil {
 
-    /**
-     * Returns true if any of the given items are null.
-     */
+    /** @see #isAnyNull(Collection) */
     public static boolean isAnyNull(Object... items) {
-        for (Object item : items) {
-            if (item == null) {
-                return true;
-            }
-        }
-        return false;
+        return Stream.of(items).anyMatch(Objects::isNull);
+    }
+
+    /**
+     * Returns true if any element of {@code items} is null.
+     * @throws NullPointerException if {@code items} itself is null.
+     */
+    public static boolean isAnyNull(Collection<?> items) {
+        return items.stream().anyMatch(Objects::isNull);
     }
 
     /**
@@ -29,14 +30,6 @@ public class CollectionUtil {
      */
     public static boolean isAnyPresent(Optional<?>... items) {
         return Stream.of(items).anyMatch(Optional::isPresent);
-    }
-
-    /**
-     * Throws an assertion error if the collection or any item in it is null.
-     */
-    public static void assertNoNullElements(Collection<?> items) {
-        assert items != null;
-        assert !items.stream().anyMatch(Objects::isNull);
     }
 
     /**

--- a/src/main/java/seedu/address/commons/util/CollectionUtil.java
+++ b/src/main/java/seedu/address/commons/util/CollectionUtil.java
@@ -2,6 +2,7 @@ package seedu.address.commons.util;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -35,7 +36,7 @@ public class CollectionUtil {
      */
     public static void assertNoNullElements(Collection<?> items) {
         assert items != null;
-        assert !isAnyNull(items);
+        assert !items.stream().anyMatch(Objects::isNull);
     }
 
     /**

--- a/src/main/java/seedu/address/model/tag/UniqueTagList.java
+++ b/src/main/java/seedu/address/model/tag/UniqueTagList.java
@@ -71,7 +71,7 @@ public class UniqueTagList implements Iterable<Tag> {
      * Enforces no nulls.
      */
     public UniqueTagList(Set<Tag> tags) {
-        CollectionUtil.assertNoNullElements(tags);
+        assert !CollectionUtil.isAnyNull(tags);
         internalList.addAll(tags);
     }
 
@@ -99,7 +99,7 @@ public class UniqueTagList implements Iterable<Tag> {
     }
 
     public void setTags(Collection<Tag> tags) throws DuplicateTagException {
-        CollectionUtil.assertNoNullElements(tags);
+        assert !CollectionUtil.isAnyNull(tags);
         if (!CollectionUtil.elementsAreUnique(tags)) {
             throw new DuplicateTagException();
         }

--- a/src/test/java/seedu/address/commons/util/CollectionUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/CollectionUtilTest.java
@@ -4,37 +4,82 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class CollectionUtilTest {
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
     @Test
-    public void isAnyNull() {
-        // empty list
+    public void isAnyNullVarargs() {
+        // no arguments
         assertFalse(CollectionUtil.isAnyNull());
 
-        // Any non-empty list
+        // any non-empty argument list
         assertFalse(CollectionUtil.isAnyNull(new Object(), new Object()));
         assertFalse(CollectionUtil.isAnyNull("test"));
         assertFalse(CollectionUtil.isAnyNull(""));
 
-        // non empty list with just one null at the beginning
+        // argument lists with just one null at the beginning
         assertTrue(CollectionUtil.isAnyNull((Object) null));
         assertTrue(CollectionUtil.isAnyNull(null, "", new Object()));
         assertTrue(CollectionUtil.isAnyNull(null, new Object(), new Object()));
 
-        // non empty list with nulls in the middle
+        // argument lists with nulls in the middle
         assertTrue(CollectionUtil.isAnyNull(new Object(), null, null, "test"));
         assertTrue(CollectionUtil.isAnyNull("", null, new Object()));
 
-        // non empty list with one null as the last element
+        // argument lists with one null as the last argument
         assertTrue(CollectionUtil.isAnyNull("", new Object(), null));
         assertTrue(CollectionUtil.isAnyNull(new Object(), new Object(), null));
 
-        // confirms nulls inside the list are not considered
-        List<Object> nullList = Arrays.asList((Object) null);
-        assertFalse(CollectionUtil.isAnyNull(nullList));
+        // confirms nulls inside lists in the argument list are not considered
+        List<Object> containingNull = Arrays.asList((Object) null);
+        assertFalse(CollectionUtil.isAnyNull(containingNull, new Object()));
+    }
+
+    @Test
+    public void isAnyNullVarargs_nullReference_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
+        CollectionUtil.isAnyNull((Object[]) null);
+    }
+
+    @Test
+    public void isAnyNullCollection() {
+        // lists containing nulls in the front
+        assertTrue(CollectionUtil.isAnyNull(Arrays.asList((Object) null)));
+        assertTrue(CollectionUtil.isAnyNull(Arrays.asList(null, new Object(), "")));
+
+        // lists containing nulls in the middle
+        assertTrue(CollectionUtil.isAnyNull(Arrays.asList("spam", null, new Object())));
+        assertTrue(CollectionUtil.isAnyNull(Arrays.asList("spam", null, "eggs", null, new Object())));
+
+        // lists containing nulls at the end
+        assertTrue(CollectionUtil.isAnyNull(Arrays.asList("spam", new Object(), null)));
+        assertTrue(CollectionUtil.isAnyNull(Arrays.asList(new Object(), null)));
+
+        // empty list
+        assertFalse(CollectionUtil.isAnyNull(Collections.emptyList()));
+
+        // list with all non-null elements
+        assertFalse(CollectionUtil.isAnyNull(Arrays.asList(new Object(), "ham", new Integer(1))));
+        assertFalse(CollectionUtil.isAnyNull(Arrays.asList(new Object())));
+
+        // confirms nulls inside nested lists are not considered
+        List<Object> containingNull = Arrays.asList((Object) null);
+        assertFalse(CollectionUtil.isAnyNull(Arrays.asList(containingNull, new Object())));
+    }
+
+    @Test
+    public void isAnyNullCollection_nullReference_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
+        CollectionUtil.isAnyNull((Collection<Object>) null);
     }
 
     @Test


### PR DESCRIPTION
Previously, assertNoNullElements wasn't even working as intended at all. The
original intention of this method was to ensure each element of the given
collection was non-null. However, by simply doing
'assert !isAnyNull(Collection)', the collection was parsed as an Object, instead
of an Object[]. Meaning it only checked if the collection reference was
null rather than its actual elements.

This commit both fixes this issue and refactors it into an overloaded method.
By refactoring the method to return boolean instead of void, we shift the
assertion responsibility outwards to wherever this method is called. Forcing
the explicit usage of the 'assert' keyword thus making it clearer that an
assertion is actually happening.

As [requested](https://github.com/se-edu/addressbook-level4/pull/248#issuecomment-275677459) by @pyokagan 