### PR TITLE
Move all parsing from AddCommand to AddCommandParser #306

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -1,16 +1,9 @@
 package seedu.address.logic.commands;
 
-import java.util.Set;
-
-import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.model.person.Address;
-import seedu.address.model.person.Email;
-import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
-import seedu.address.model.person.Phone;
+import seedu.address.model.person.ReadOnlyPerson;
 import seedu.address.model.person.UniquePersonList;
-import seedu.address.model.tag.Tag;
 
 /**
  * Adds a person to the address book.
@@ -30,19 +23,10 @@ public class AddCommand extends Command {
     private final Person toAdd;
 
     /**
-     * Creates an AddCommand using raw values.
-     *
-     * @throws IllegalValueException if any of the raw values are invalid
+     * Creates an AddCommand to add the specified {@code ReadOnlyPerson}
      */
-    public AddCommand(String name, String phone, String email, String address, Set<Tag> tags)
-            throws IllegalValueException {
-        this.toAdd = new Person(
-                new Name(name),
-                new Phone(phone),
-                new Email(email),
-                new Address(address),
-                tags
-        );
+    public AddCommand(ReadOnlyPerson person) {
+        toAdd = new Person(person);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -6,12 +6,20 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.util.Set;
 import java.util.stream.Stream;
 
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.IncorrectCommand;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
+import seedu.address.model.person.ReadOnlyPerson;
+import seedu.address.model.tag.Tag;
 
 /**
  * Parses input arguments and creates a new AddCommand object
@@ -31,13 +39,15 @@ public class AddCommandParser {
         }
 
         try {
-            return new AddCommand(
-                    argMultimap.getPreamble(),
-                    argMultimap.getValue(PREFIX_PHONE).get(),
-                    argMultimap.getValue(PREFIX_EMAIL).get(),
-                    argMultimap.getValue(PREFIX_ADDRESS).get(),
-                    ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG))
-            );
+            Name name = new Name(argMultimap.getPreamble());
+            Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE)).get();
+            Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL)).get();
+            Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS)).get();
+            Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+
+            ReadOnlyPerson person = new Person(name, phone, email, address, tagList);
+
+            return new AddCommand(person);
         } catch (IllegalValueException ive) {
             return new IncorrectCommand(ive.getMessage());
         }

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -6,7 +6,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
-import java.util.NoSuchElementException;
+import java.util.stream.Stream;
 
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.logic.commands.AddCommand;
@@ -25,6 +25,11 @@ public class AddCommandParser {
     public Command parse(String args) {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_ADDRESS, PREFIX_PHONE, PREFIX_EMAIL)) {
+            return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+        }
+
         try {
             return new AddCommand(
                     argMultimap.getPreamble(),
@@ -33,11 +38,17 @@ public class AddCommandParser {
                     argMultimap.getValue(PREFIX_ADDRESS).get(),
                     ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG))
             );
-        } catch (NoSuchElementException nsee) {
-            return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         } catch (IllegalValueException ive) {
             return new IncorrectCommand(ive.getMessage());
         }
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 
 }


### PR DESCRIPTION
Closes #306

Proposed merge commit message:

```
Parsing the add command string into a Person object
is split between the AddCommandParser and the AddCommand.

It is more cohesive if the said parsing is done entirely
by the AddCommandParser itself.

Let's modify the construction of add command as follows:
    * Add an explicit check for empty prefixes and remove the use of
      NoSuchElementException to detect missing prefixes.
    * Make AddCommandParser do the parsing and create a
      fully parsed Person object.
    * Make AddCommand's constructor accept a fully parsed
      ReadOnlyPerson.
```