### PR TITLE
Checkstyle: enforce more rules of the oss java coding standard #319

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -162,6 +162,11 @@
     LENGTH and CODING CHECKS
     -->
 
+    <module name="ArrayTypeStyle">
+      <!-- Checks that array type declarations follow Java Style -->
+      <property name="severity" value="error"/>
+    </module>
+
     <module name ="DeclarationOrder">
       <!-- Checks if the Class and Interface declarations is organized in order -->
       <property name="severity" value="warning"/>

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -209,7 +209,7 @@
       <property name="severity" value="warning"/>
       <property name="tokens" value="LITERAL_FOR, LITERAL_WHILE, LITERAL_DO, LITERAL_IF, LITERAL_ELSE"/>
       <!--
-      if (true) return 1; // Allowed
+      if (true) return 1; // Not allowed for debugging purposes
 
       if (true) { return 1; } // Not allowed
 
@@ -221,7 +221,7 @@
         return 1; // Not allowed
       -->
       <property name="allowEmptyLoopBody" value="true"/>
-      <property name="allowSingleLineStatement" value="true"/>
+      <property name="allowSingleLineStatement" value="false"/>
     </module>
 
     <module name="UpperEll">

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -138,7 +138,7 @@
     <module name="MethodName">
       <!-- Validates identifiers for method names against the supplied expression. -->
       <metadata name="altname" value="MethodName"/>
-      <property name="format" value="^[a-z][a-zA-Z0-9]*(_[a-zA-Z0-9]+)*|_+[A-Z]+(_[A-Z]+)*_+$"/>
+      <property name="format" value="^[a-z][a-zA-Z0-9]*(_[a-z][a-zA-Z0-9]+)*$"/>
       <property name="severity" value="warning"/>
     </module>
 

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -82,6 +82,13 @@
     NAMING CHECKS
     -->
 
+    <module name="AbbreviationAsWordInName">
+      <!-- Validate abbreviations(consecutive capital letters) length in identifier name -->
+      <property name="ignoreFinal" value="false"/>
+      <property name="allowedAbbreviationLength" value="1"/>
+      <property name="severity" value="warning"/>
+    </module>
+
     <module name="PackageName">
       <!-- Validates identifiers for package names against the supplied expression. -->
       <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]{1,})*$"/>

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -162,6 +162,11 @@
     LENGTH and CODING CHECKS
     -->
 
+    <module name ="DeclarationOrder">
+      <!-- Checks if the Class and Interface declarations is organized in order -->
+      <property name="severity" value="warning"/>
+    </module>
+
     <module name="LineLength">
       <!-- Checks if a line is too long. -->
       <property name="max" value="120"/>

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -331,5 +331,12 @@
       <property name="protectedAllowed" value="true"/>
       <property name="allowPublicFinalFields" value="true"/>
     </module>
+
+    <module name="AtclauseOrder">
+      <!-- Checks that the order of at-clauses follows the tagOrder property value order. -->
+      <property name="severity" value="error"/>
+      <property name="tagOrder" value="@param, @return, @throws, @exception, @deprecated"/>
+      <property name="target" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
+    </module>
   </module>
 </module>

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -320,6 +320,11 @@
       <property name="severity" value="warning"/>
     </module>
 
+    <module name="CommentsIndentation">
+      <!-- Checks that comments are indented relative to their position in the code -->
+      <property name="severity" value="error"/>
+    </module>
+
     <module name="VisibilityModifier">
       <!-- Checks that Class variables should never be declared public. -->
       <property name="severity" value="warning"/>

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -320,5 +320,11 @@
       <property name="severity" value="warning"/>
     </module>
 
+    <module name="VisibilityModifier">
+      <!-- Checks that Class variables should never be declared public. -->
+      <property name="severity" value="warning"/>
+      <property name="protectedAllowed" value="true"/>
+      <property name="allowPublicFinalFields" value="true"/>
+    </module>
   </module>
 </module>


### PR DESCRIPTION
Fixing #319 
### Phase 1 :
Rules that are outright English related are not enforceable as checkstyle does not check for English.
Some, also, may not be enforceable as checkstyle currently does not have such checks yet.
(Do let me know if anyone knows alternative to implement those check that I thought to be not possible)

1. Adding enforceable rules stated in Java Coding Convention from oss-generic.
(https://oss-generic.github.io/process/codingStandards/CodingStandard-Java.html)

**Ready for review**
### Phase 2 : 
As Java Coding Convention from oss-generic states that use the Google Java Style Guide for any topics not covered in this document. Since google has its own checkstyle configuration file, we can simply compare and collect those useful but unused in our configuration file.

1. Adding rules, that is not covered in oss java coding convention but beneficial, from google checkstyle.

**Not started**
### Phase 3 : 
Rules that are newly implemented with error severity may cause the build to fail as there are some violations currently exist in the addressbook.
In addition, our checkstyle configuration file is not well arranged both in terms of chronological order and categorized by checkstyle categories.

1. Fix existing violation of new rules in src.
2. Rearrange rules in checkstyle configuration file according to checkstyle catergories and chronological order to enhance readability.

**Not started**
### Current Progress (Java Coding Convention from oss-generic):
https://docs.google.com/document/d/19Ca176H0m7vCc29a_rxq2l8_TOjHkBYzuAHNxcUEAFY/edit?usp=sharing

**Legend :**
Strikeout - checked / implemented / done / unneccessary
Red - unlikely to be possible
Yellow - currently / may not enforceable
Green - to be done
Cyan - done and ready to be merged