### PR TITLE
Cannot add a label called `location` in person card #336

### DIFF
--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -11,6 +11,14 @@ public class PersonCard extends UiPart<Region> {
 
     private static final String FXML = "PersonListCard.fxml";
 
+    /**
+     * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.
+     * As a consequence, UI elements' variable names cannot be set to such keywords
+     * or an exception will be thrown by JavaFX during runtime.
+     *
+     * @see <a href="https://github.com/se-edu/addressbook-level4/issues/336">The issue on AddressBook level 4</a>
+     */
+
     @FXML
     private HBox cardPane;
     @FXML


### PR DESCRIPTION
Closes #336 

This PR does not resolve the issue. It merely documents the fact that there exists such reserved keywords in JavaFX that cannot be used for UI elements' identification.