### PR TITLE
ReadOnlyPerson: make getTags() read-only #291

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -81,7 +81,7 @@ public class EditCommand extends Command {
         Phone updatedPhone = editPersonDescriptor.getPhone().orElseGet(personToEdit::getPhone);
         Email updatedEmail = editPersonDescriptor.getEmail().orElseGet(personToEdit::getEmail);
         Address updatedAddress = editPersonDescriptor.getAddress().orElseGet(personToEdit::getAddress);
-        UniqueTagList updatedTags = editPersonDescriptor.getTags().orElseGet(personToEdit::getTags);
+        UniqueTagList updatedTags = editPersonDescriptor.getTags().orElse(new UniqueTagList(personToEdit.getTags()));
 
         return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags);
     }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -3,6 +3,7 @@ package seedu.address.model.person;
 import java.util.Objects;
 
 import seedu.address.commons.util.CollectionUtil;
+import seedu.address.model.tag.ReadOnlyUniqueTagList;
 import seedu.address.model.tag.UniqueTagList;
 
 /**
@@ -21,7 +22,7 @@ public class Person implements ReadOnlyPerson {
     /**
      * Every field must be present and not null.
      */
-    public Person(Name name, Phone phone, Email email, Address address, UniqueTagList tags) {
+    public Person(Name name, Phone phone, Email email, Address address, ReadOnlyUniqueTagList tags) {
         assert !CollectionUtil.isAnyNull(name, phone, email, address, tags);
         this.name = name;
         this.phone = phone;
@@ -85,7 +86,7 @@ public class Person implements ReadOnlyPerson {
     /**
      * Replaces this person's tags with the tags in the argument tag list.
      */
-    public void setTags(UniqueTagList replacement) {
+    public void setTags(ReadOnlyUniqueTagList replacement) {
         tags.setTags(replacement);
     }
 

--- a/src/main/java/seedu/address/model/person/ReadOnlyPerson.java
+++ b/src/main/java/seedu/address/model/person/ReadOnlyPerson.java
@@ -1,6 +1,6 @@
 package seedu.address.model.person;
 
-import seedu.address.model.tag.UniqueTagList;
+import seedu.address.model.tag.ReadOnlyUniqueTagList;
 
 /**
  * A read-only immutable interface for a Person in the addressbook.
@@ -17,7 +17,7 @@ public interface ReadOnlyPerson {
      * The returned TagList is a deep copy of the internal TagList,
      * changes on the returned list will not affect the person's internal tags.
      */
-    UniqueTagList getTags();
+    ReadOnlyUniqueTagList getTags();
 
     /**
      * Returns true if both have the same state. (interfaces cannot override .equals)

--- a/src/main/java/seedu/address/model/tag/ReadOnlyUniqueTagList.java
+++ b/src/main/java/seedu/address/model/tag/ReadOnlyUniqueTagList.java
@@ -1,0 +1,29 @@
+package seedu.address.model.tag;
+
+import java.util.Set;
+
+import seedu.address.commons.core.UnmodifiableObservableList;
+
+
+/**
+ * A read-only immutable interface for a list of unique tags.
+ * Implementations should guarantee: details are present and not null, field values are validated.
+ */
+public interface ReadOnlyUniqueTagList extends Iterable<Tag> {
+
+    /**
+     * Returns all tags in this list as a Set.
+     * This set is mutable and change-insulated against the internal list.
+     */
+    Set<Tag> toSet();
+
+    /**
+     * Returns true if the list contains an equivalent Tag as the given argument.
+     */
+    boolean contains(Tag toCheck);
+
+    UnmodifiableObservableList<Tag> asObservableList();
+
+    boolean equalsOrderInsensitive(ReadOnlyUniqueTagList other);
+
+}

--- a/src/main/java/seedu/address/model/tag/UniqueTagList.java
+++ b/src/main/java/seedu/address/model/tag/UniqueTagList.java
@@ -23,7 +23,7 @@ import seedu.address.commons.util.CollectionUtil;
  * @see Tag#equals(Object)
  * @see CollectionUtil#elementsAreUnique(Collection)
  */
-public class UniqueTagList implements Iterable<Tag> {
+public class UniqueTagList implements ReadOnlyUniqueTagList {
 
     private final ObservableList<Tag> internalList = FXCollections.observableArrayList();
 
@@ -76,11 +76,11 @@ public class UniqueTagList implements Iterable<Tag> {
     }
 
     /**
-     * Creates a copy of the given list.
+     * Creates a copy of the given read-only list.
      * Insulates from changes in source.
      */
-    public UniqueTagList(UniqueTagList source) {
-        internalList.addAll(source.internalList); // insulate internal list from changes in argument
+    public UniqueTagList(ReadOnlyUniqueTagList source) {
+        internalList.addAll(source.toSet());
     }
 
     /**
@@ -94,8 +94,8 @@ public class UniqueTagList implements Iterable<Tag> {
     /**
      * Replaces the Tags in this list with those in the argument tag list.
      */
-    public void setTags(UniqueTagList replacement) {
-        this.internalList.setAll(replacement.internalList);
+    public void setTags(ReadOnlyUniqueTagList replacement) {
+        this.internalList.setAll(replacement.toSet());
     }
 
     public void setTags(Collection<Tag> tags) throws DuplicateTagException {
@@ -109,9 +109,9 @@ public class UniqueTagList implements Iterable<Tag> {
     /**
      * Ensures every tag in the argument list exists in this object.
      */
-    public void mergeFrom(UniqueTagList from) {
+    public void mergeFrom(ReadOnlyUniqueTagList from) {
         final Set<Tag> alreadyInside = this.toSet();
-        from.internalList.stream()
+        from.toSet().stream()
                 .filter(tag -> !alreadyInside.contains(tag))
                 .forEach(internalList::add);
     }
@@ -154,8 +154,8 @@ public class UniqueTagList implements Iterable<Tag> {
                 ((UniqueTagList) other).internalList));
     }
 
-    public boolean equalsOrderInsensitive(UniqueTagList other) {
-        return this == other || new HashSet<>(this.internalList).equals(new HashSet<>(other.internalList));
+    public boolean equalsOrderInsensitive(ReadOnlyUniqueTagList other) {
+        return this == other || new HashSet<>(this.internalList).equals(new HashSet<>(other.toSet()));
     }
 
     @Override

--- a/src/test/java/guitests/guihandles/PersonCardHandle.java
+++ b/src/test/java/guitests/guihandles/PersonCardHandle.java
@@ -9,7 +9,7 @@ import javafx.scene.control.Labeled;
 import javafx.scene.layout.Region;
 import javafx.stage.Stage;
 import seedu.address.model.person.ReadOnlyPerson;
-import seedu.address.model.tag.UniqueTagList;
+import seedu.address.model.tag.ReadOnlyUniqueTagList;
 
 /**
  * Provides a handle to a person card in the person list panel.
@@ -60,7 +60,7 @@ public class PersonCardHandle extends GuiHandle {
                 .collect(Collectors.toList());
     }
 
-    private List<String> getTags(UniqueTagList tags) {
+    private List<String> getTags(ReadOnlyUniqueTagList tags) {
         return tags
                 .asObservableList()
                 .stream()


### PR DESCRIPTION
ReadOnlyPerson#getTags() returns a UniqueTagList which is mutable.

This means that ReadOnlyPerson is not actually read-only as the
underlying UniqueTagList is exposed.

Let's make ReadOnlyPerson fully read-only by making
ReadOnlyPerson#getTags() return an immutable ReadOnlyUniqueTagList.