### PR TITLE
Simplify FXML files #231

### DIFF
--- a/src/main/resources/view/BrowserPanel.fxml
+++ b/src/main/resources/view/BrowserPanel.fxml
@@ -4,5 +4,5 @@
 <?import javafx.scene.web.WebView?>
 
 <AnchorPane xmlns:fx="http://javafx.com/fxml/1">
-  <WebView fx:id="browser"/>
+  <WebView fx:id="browser" />
 </AnchorPane>

--- a/src/main/resources/view/BrowserPanel.fxml
+++ b/src/main/resources/view/BrowserPanel.fxml
@@ -4,5 +4,5 @@
 <?import javafx.scene.web.WebView?>
 
 <AnchorPane xmlns:fx="http://javafx.com/fxml/1">
-    <WebView fx:id="browser"/>
+  <WebView fx:id="browser"/>
 </AnchorPane>

--- a/src/main/resources/view/CommandBox.fxml
+++ b/src/main/resources/view/CommandBox.fxml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.control.TextField?>
+<?import javafx.scene.layout.AnchorPane?>
+
 <AnchorPane styleClass="anchor-pane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1"
   stylesheets="@DarkTheme.css">
   <TextField fx:id="commandTextField" onAction="#handleCommandInputChanged" promptText="Enter command here..."/>

--- a/src/main/resources/view/CommandBox.fxml
+++ b/src/main/resources/view/CommandBox.fxml
@@ -3,7 +3,7 @@
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.control.TextField?>
 <AnchorPane styleClass="anchor-pane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1"
-            stylesheets="@DarkTheme.css">
-   <TextField fx:id="commandTextField" onAction="#handleCommandInputChanged" promptText="Enter command here..."/>
+  stylesheets="@DarkTheme.css">
+  <TextField fx:id="commandTextField" onAction="#handleCommandInputChanged" promptText="Enter command here..."/>
 </AnchorPane>
 

--- a/src/main/resources/view/CommandBox.fxml
+++ b/src/main/resources/view/CommandBox.fxml
@@ -3,8 +3,7 @@
 <?import javafx.scene.control.TextField?>
 <?import javafx.scene.layout.AnchorPane?>
 
-<AnchorPane styleClass="anchor-pane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1"
-  stylesheets="@DarkTheme.css">
+<AnchorPane styleClass="anchor-pane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
   <TextField fx:id="commandTextField" onAction="#handleCommandInputChanged" promptText="Enter command here..."/>
 </AnchorPane>
 

--- a/src/main/resources/view/CommandBox.fxml
+++ b/src/main/resources/view/CommandBox.fxml
@@ -4,6 +4,6 @@
 <?import javafx.scene.layout.AnchorPane?>
 
 <AnchorPane styleClass="anchor-pane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
-  <TextField fx:id="commandTextField" onAction="#handleCommandInputChanged" promptText="Enter command here..."/>
+  <TextField fx:id="commandTextField" onAction="#handleCommandInputChanged" promptText="Enter command here..." />
 </AnchorPane>
 

--- a/src/main/resources/view/HelpWindow.fxml
+++ b/src/main/resources/view/HelpWindow.fxml
@@ -3,6 +3,6 @@
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.web.WebView?>
 
-<AnchorPane fx:id="helpWindowRoot" stylesheets="@DarkTheme.css" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+<AnchorPane fx:id="helpWindowRoot" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
   <WebView fx:id="browser"/>
 </AnchorPane>

--- a/src/main/resources/view/HelpWindow.fxml
+++ b/src/main/resources/view/HelpWindow.fxml
@@ -2,6 +2,7 @@
 
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.web.WebView?>
+
 <AnchorPane fx:id="helpWindowRoot" stylesheets="@DarkTheme.css" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
   <WebView fx:id="browser"/>
 </AnchorPane>

--- a/src/main/resources/view/HelpWindow.fxml
+++ b/src/main/resources/view/HelpWindow.fxml
@@ -3,5 +3,5 @@
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.web.WebView?>
 <AnchorPane fx:id="helpWindowRoot" stylesheets="@DarkTheme.css" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
-    <WebView fx:id="browser"/>
+  <WebView fx:id="browser"/>
 </AnchorPane>

--- a/src/main/resources/view/HelpWindow.fxml
+++ b/src/main/resources/view/HelpWindow.fxml
@@ -4,5 +4,5 @@
 <?import javafx.scene.web.WebView?>
 
 <AnchorPane fx:id="helpWindowRoot" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
-  <WebView fx:id="browser"/>
+  <WebView fx:id="browser" />
 </AnchorPane>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -14,6 +14,7 @@
     <URL value="@DarkTheme.css" />
     <URL value="@Extensions.css" />
   </stylesheets>
+
   <MenuBar VBox.vgrow="NEVER">
     <Menu mnemonicParsing="false" text="File">
       <MenuItem mnemonicParsing="false" onAction="#handleExit" text="Exit" />
@@ -22,16 +23,20 @@
       <MenuItem fx:id="helpMenuItem" mnemonicParsing="false" onAction="#handleHelp" text="Help" />
     </Menu>
   </MenuBar>
+
   <AnchorPane VBox.vgrow="NEVER" fx:id="commandBoxPlaceholder" styleClass="anchor-pane-with-border">
     <padding>
       <Insets top="5.0" bottom="5.0" left="10.0" right="10.0"/>
     </padding>
   </AnchorPane>
-  <AnchorPane VBox.vgrow="NEVER" fx:id="resultDisplayPlaceholder" styleClass="anchor-pane-with-border" minHeight="100" prefHeight="100" maxHeight="100">
+
+  <AnchorPane VBox.vgrow="NEVER" fx:id="resultDisplayPlaceholder" styleClass="anchor-pane-with-border"
+      minHeight="100" prefHeight="100" maxHeight="100">
     <padding>
       <Insets top="5.0" bottom="5.0" left="10.0" right="10.0"/>
     </padding>
   </AnchorPane>
+
   <SplitPane id="splitPane" fx:id="splitPane" dividerPositions="0.4" VBox.vgrow="ALWAYS">
     <VBox fx:id="personList" minWidth="340" prefWidth="340">
       <padding>
@@ -39,11 +44,13 @@
       </padding>
       <AnchorPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
     </VBox>
+
     <AnchorPane fx:id="browserPlaceholder" prefWidth="340" >
       <padding>
         <Insets top="10" bottom="10" left="10" right="10"/>
       </padding>
     </AnchorPane>
   </SplitPane>
+
   <AnchorPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER" />
 </VBox>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -5,52 +5,52 @@
 <?import javafx.scene.layout.*?>
 <?import java.net.URL?>
 <VBox xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
-   <stylesheets>
-      <URL value="@DarkTheme.css" />
-      <URL value="@Extensions.css" />
-   </stylesheets>
-   <children>
-      <MenuBar VBox.vgrow="NEVER">
-         <menus>
-            <Menu mnemonicParsing="false" text="File">
-               <items>
-                  <MenuItem mnemonicParsing="false" onAction="#handleExit" text="Exit" />
-               </items>
-            </Menu>
-            <Menu mnemonicParsing="false" text="Help">
-               <items>
-                  <MenuItem fx:id="helpMenuItem" mnemonicParsing="false" onAction="#handleHelp" text="Help" />
-               </items>
-            </Menu>
-         </menus>
-      </MenuBar>
-      <AnchorPane VBox.vgrow="NEVER" fx:id="commandBoxPlaceholder" styleClass="anchor-pane-with-border">
-         <padding>
-            <Insets top="5.0" bottom="5.0" left="10.0" right="10.0"/>
-         </padding>
-      </AnchorPane>
-       <AnchorPane VBox.vgrow="NEVER" fx:id="resultDisplayPlaceholder" styleClass="anchor-pane-with-border" minHeight="100" prefHeight="100" maxHeight="100">
-           <padding>
-               <Insets top="5.0" bottom="5.0" left="10.0" right="10.0"/>
-           </padding>
-       </AnchorPane>
-      <SplitPane id="splitPane" fx:id="splitPane" dividerPositions="0.4" VBox.vgrow="ALWAYS">
-         <items>
-            <VBox fx:id="personList" minWidth="340" prefWidth="340">
-                <padding>
-                    <Insets bottom="10.0" left="10.0" right="10.0" top="10.0"/>
-                </padding>
-               <children>
-                  <AnchorPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
-               </children>
-            </VBox>
-            <AnchorPane fx:id="browserPlaceholder" prefWidth="340" >
-                <padding>
-                    <Insets top="10" bottom="10" left="10" right="10"/>
-                </padding>
-            </AnchorPane>
-         </items>
-      </SplitPane>
-      <AnchorPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER" />
-   </children>
+  <stylesheets>
+    <URL value="@DarkTheme.css" />
+    <URL value="@Extensions.css" />
+  </stylesheets>
+  <children>
+    <MenuBar VBox.vgrow="NEVER">
+      <menus>
+        <Menu mnemonicParsing="false" text="File">
+          <items>
+            <MenuItem mnemonicParsing="false" onAction="#handleExit" text="Exit" />
+          </items>
+        </Menu>
+        <Menu mnemonicParsing="false" text="Help">
+          <items>
+            <MenuItem fx:id="helpMenuItem" mnemonicParsing="false" onAction="#handleHelp" text="Help" />
+          </items>
+        </Menu>
+      </menus>
+    </MenuBar>
+    <AnchorPane VBox.vgrow="NEVER" fx:id="commandBoxPlaceholder" styleClass="anchor-pane-with-border">
+      <padding>
+        <Insets top="5.0" bottom="5.0" left="10.0" right="10.0"/>
+      </padding>
+    </AnchorPane>
+    <AnchorPane VBox.vgrow="NEVER" fx:id="resultDisplayPlaceholder" styleClass="anchor-pane-with-border" minHeight="100" prefHeight="100" maxHeight="100">
+      <padding>
+        <Insets top="5.0" bottom="5.0" left="10.0" right="10.0"/>
+      </padding>
+    </AnchorPane>
+    <SplitPane id="splitPane" fx:id="splitPane" dividerPositions="0.4" VBox.vgrow="ALWAYS">
+      <items>
+        <VBox fx:id="personList" minWidth="340" prefWidth="340">
+          <padding>
+            <Insets bottom="10.0" left="10.0" right="10.0" top="10.0"/>
+          </padding>
+          <children>
+          <AnchorPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+          </children>
+        </VBox>
+        <AnchorPane fx:id="browserPlaceholder" prefWidth="340" >
+          <padding>
+            <Insets top="10" bottom="10" left="10" right="10"/>
+          </padding>
+        </AnchorPane>
+      </items>
+    </SplitPane>
+    <AnchorPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER" />
+  </children>
 </VBox>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -14,48 +14,36 @@
     <URL value="@DarkTheme.css" />
     <URL value="@Extensions.css" />
   </stylesheets>
-  <children>
-    <MenuBar VBox.vgrow="NEVER">
-      <menus>
-        <Menu mnemonicParsing="false" text="File">
-          <items>
-            <MenuItem mnemonicParsing="false" onAction="#handleExit" text="Exit" />
-          </items>
-        </Menu>
-        <Menu mnemonicParsing="false" text="Help">
-          <items>
-            <MenuItem fx:id="helpMenuItem" mnemonicParsing="false" onAction="#handleHelp" text="Help" />
-          </items>
-        </Menu>
-      </menus>
-    </MenuBar>
-    <AnchorPane VBox.vgrow="NEVER" fx:id="commandBoxPlaceholder" styleClass="anchor-pane-with-border">
+  <MenuBar VBox.vgrow="NEVER">
+    <Menu mnemonicParsing="false" text="File">
+      <MenuItem mnemonicParsing="false" onAction="#handleExit" text="Exit" />
+    </Menu>
+    <Menu mnemonicParsing="false" text="Help">
+      <MenuItem fx:id="helpMenuItem" mnemonicParsing="false" onAction="#handleHelp" text="Help" />
+    </Menu>
+  </MenuBar>
+  <AnchorPane VBox.vgrow="NEVER" fx:id="commandBoxPlaceholder" styleClass="anchor-pane-with-border">
+    <padding>
+      <Insets top="5.0" bottom="5.0" left="10.0" right="10.0"/>
+    </padding>
+  </AnchorPane>
+  <AnchorPane VBox.vgrow="NEVER" fx:id="resultDisplayPlaceholder" styleClass="anchor-pane-with-border" minHeight="100" prefHeight="100" maxHeight="100">
+    <padding>
+      <Insets top="5.0" bottom="5.0" left="10.0" right="10.0"/>
+    </padding>
+  </AnchorPane>
+  <SplitPane id="splitPane" fx:id="splitPane" dividerPositions="0.4" VBox.vgrow="ALWAYS">
+    <VBox fx:id="personList" minWidth="340" prefWidth="340">
       <padding>
-        <Insets top="5.0" bottom="5.0" left="10.0" right="10.0"/>
+        <Insets bottom="10.0" left="10.0" right="10.0" top="10.0"/>
+      </padding>
+      <AnchorPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+    </VBox>
+    <AnchorPane fx:id="browserPlaceholder" prefWidth="340" >
+      <padding>
+        <Insets top="10" bottom="10" left="10" right="10"/>
       </padding>
     </AnchorPane>
-    <AnchorPane VBox.vgrow="NEVER" fx:id="resultDisplayPlaceholder" styleClass="anchor-pane-with-border" minHeight="100" prefHeight="100" maxHeight="100">
-      <padding>
-        <Insets top="5.0" bottom="5.0" left="10.0" right="10.0"/>
-      </padding>
-    </AnchorPane>
-    <SplitPane id="splitPane" fx:id="splitPane" dividerPositions="0.4" VBox.vgrow="ALWAYS">
-      <items>
-        <VBox fx:id="personList" minWidth="340" prefWidth="340">
-          <padding>
-            <Insets bottom="10.0" left="10.0" right="10.0" top="10.0"/>
-          </padding>
-          <children>
-          <AnchorPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
-          </children>
-        </VBox>
-        <AnchorPane fx:id="browserPlaceholder" prefWidth="340" >
-          <padding>
-            <Insets top="10" bottom="10" left="10" right="10"/>
-          </padding>
-        </AnchorPane>
-      </items>
-    </SplitPane>
-    <AnchorPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER" />
-  </children>
+  </SplitPane>
+  <AnchorPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER" />
 </VBox>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -42,7 +42,7 @@
       <padding>
         <Insets top="10" right="10" bottom="10" left="10" />
       </padding>
-      <AnchorPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+      <AnchorPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS" />
     </VBox>
 
     <AnchorPane fx:id="browserPlaceholder" prefWidth="340" >

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -26,28 +26,28 @@
 
   <AnchorPane VBox.vgrow="NEVER" fx:id="commandBoxPlaceholder" styleClass="anchor-pane-with-border">
     <padding>
-      <Insets top="5.0" bottom="5.0" left="10.0" right="10.0"/>
+      <Insets top="5" right="10" bottom="5" left="10" />
     </padding>
   </AnchorPane>
 
   <AnchorPane VBox.vgrow="NEVER" fx:id="resultDisplayPlaceholder" styleClass="anchor-pane-with-border"
       minHeight="100" prefHeight="100" maxHeight="100">
     <padding>
-      <Insets top="5.0" bottom="5.0" left="10.0" right="10.0"/>
+      <Insets top="5" right="10" bottom="5" left="10" />
     </padding>
   </AnchorPane>
 
   <SplitPane id="splitPane" fx:id="splitPane" dividerPositions="0.4" VBox.vgrow="ALWAYS">
     <VBox fx:id="personList" minWidth="340" prefWidth="340">
       <padding>
-        <Insets bottom="10.0" left="10.0" right="10.0" top="10.0"/>
+        <Insets top="10" right="10" bottom="10" left="10" />
       </padding>
       <AnchorPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
     </VBox>
 
     <AnchorPane fx:id="browserPlaceholder" prefWidth="340" >
       <padding>
-        <Insets top="10" bottom="10" left="10" right="10"/>
+        <Insets top="10" right="10" bottom="10" left="10" />
       </padding>
     </AnchorPane>
   </SplitPane>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -1,9 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.geometry.Insets?>
-<?import javafx.scene.control.*?>
-<?import javafx.scene.layout.*?>
 <?import java.net.URL?>
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Menu?>
+<?import javafx.scene.control.MenuBar?>
+<?import javafx.scene.control.MenuItem?>
+<?import javafx.scene.control.SplitPane?>
+<?import javafx.scene.layout.AnchorPane?>
+<?import javafx.scene.layout.VBox?>
+
 <VBox xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
   <stylesheets>
     <URL value="@DarkTheme.css" />

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -19,15 +19,13 @@
         <Insets bottom="5" left="15" right="5" top="5" />
       </padding>
       <HBox spacing="5" alignment="CENTER_LEFT">
-        <HBox>
-          <Label fx:id="id" styleClass="cell_big_label">
-            <minWidth>
-              <!-- Ensures that the label text is never truncated -->
-              <Region fx:constant="USE_PREF_SIZE" />
-            </minWidth>
-          </Label>
-          <Label fx:id="name" text="\$first" styleClass="cell_big_label"/>
-        </HBox>
+        <Label fx:id="id" styleClass="cell_big_label">
+          <minWidth>
+            <!-- Ensures that the label text is never truncated -->
+            <Region fx:constant="USE_PREF_SIZE" />
+          </minWidth>
+        </Label>
+        <Label fx:id="name" text="\$first" styleClass="cell_big_label"/>
       </HBox>
       <FlowPane fx:id="tags" />
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -16,7 +16,7 @@
     </columnConstraints>
     <VBox alignment="CENTER_LEFT" minHeight="105.0" GridPane.columnIndex="0">
       <padding>
-        <Insets bottom="5" left="15" right="5" top="5" />
+        <Insets top="5" right="5" bottom="5" left="15" />
       </padding>
       <HBox spacing="5" alignment="CENTER_LEFT">
         <Label fx:id="id" styleClass="cell_big_label">

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -8,7 +8,6 @@
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.Region?>
-<?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
 
 <HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -11,42 +11,33 @@
 <?import javafx.scene.layout.VBox?>
 
 <HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
-  <children>
-    <GridPane HBox.hgrow="ALWAYS">
-      <columnConstraints>
-        <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="150.0" />
-      </columnConstraints>
-      <children>
-        <VBox alignment="CENTER_LEFT" minHeight="105.0" GridPane.columnIndex="0">
-          <stylesheets>
-            <URL value="@DarkTheme.css" />
-            <URL value="@Extensions.css" />
-          </stylesheets>
-          <padding>
-            <Insets bottom="5" left="15" right="5" top="5" />
-          </padding>
-
-          <children>
-            <HBox spacing="5" alignment="CENTER_LEFT">
-              <children>
-                <HBox>
-                  <Label fx:id="id" styleClass="cell_big_label">
-                    <minWidth>
-                      <!-- Ensures that the label text is never truncated -->
-                      <Region fx:constant="USE_PREF_SIZE" />
-                    </minWidth>
-                  </Label>
-                  <Label fx:id="name" text="\$first" styleClass="cell_big_label"/>
-                </HBox>
-              </children>
-            </HBox>
-            <FlowPane fx:id="tags" />
-            <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
-            <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
-            <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
-          </children>
-        </VBox>
-      </children>
-    </GridPane>
-  </children>
+  <GridPane HBox.hgrow="ALWAYS">
+    <columnConstraints>
+      <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="150.0" />
+    </columnConstraints>
+    <VBox alignment="CENTER_LEFT" minHeight="105.0" GridPane.columnIndex="0">
+      <stylesheets>
+        <URL value="@DarkTheme.css" />
+        <URL value="@Extensions.css" />
+      </stylesheets>
+      <padding>
+        <Insets bottom="5" left="15" right="5" top="5" />
+      </padding>
+      <HBox spacing="5" alignment="CENTER_LEFT">
+        <HBox>
+          <Label fx:id="id" styleClass="cell_big_label">
+            <minWidth>
+              <!-- Ensures that the label text is never truncated -->
+              <Region fx:constant="USE_PREF_SIZE" />
+            </minWidth>
+          </Label>
+          <Label fx:id="name" text="\$first" styleClass="cell_big_label"/>
+        </HBox>
+      </HBox>
+      <FlowPane fx:id="tags" />
+      <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
+      <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
+      <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
+    </VBox>
+  </GridPane>
 </HBox>

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -12,9 +12,9 @@
 <HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
   <GridPane HBox.hgrow="ALWAYS">
     <columnConstraints>
-      <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="150.0" />
+      <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
     </columnConstraints>
-    <VBox alignment="CENTER_LEFT" minHeight="105.0" GridPane.columnIndex="0">
+    <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
       <padding>
         <Insets top="5" right="5" bottom="5" left="15" />
       </padding>

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import java.net.URL?>
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.layout.ColumnConstraints?>
@@ -16,10 +15,6 @@
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="150.0" />
     </columnConstraints>
     <VBox alignment="CENTER_LEFT" minHeight="105.0" GridPane.columnIndex="0">
-      <stylesheets>
-        <URL value="@DarkTheme.css" />
-        <URL value="@Extensions.css" />
-      </stylesheets>
       <padding>
         <Insets bottom="5" left="15" right="5" top="5" />
       </padding>

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -12,42 +12,42 @@
 <?import javafx.scene.layout.VBox?>
 
 <HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
-    <children>
-        <GridPane HBox.hgrow="ALWAYS">
-            <columnConstraints>
-                <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="150.0" />
-            </columnConstraints>
-            <children>
-                <VBox alignment="CENTER_LEFT" minHeight="105.0" GridPane.columnIndex="0">
-                    <stylesheets>
-                        <URL value="@DarkTheme.css" />
-                        <URL value="@Extensions.css" />
-                    </stylesheets>
-                    <padding>
-                        <Insets bottom="5" left="15" right="5" top="5" />
-                    </padding>
+  <children>
+    <GridPane HBox.hgrow="ALWAYS">
+      <columnConstraints>
+        <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="150.0" />
+      </columnConstraints>
+      <children>
+        <VBox alignment="CENTER_LEFT" minHeight="105.0" GridPane.columnIndex="0">
+          <stylesheets>
+            <URL value="@DarkTheme.css" />
+            <URL value="@Extensions.css" />
+          </stylesheets>
+          <padding>
+            <Insets bottom="5" left="15" right="5" top="5" />
+          </padding>
 
-                    <children>
-                        <HBox spacing="5" alignment="CENTER_LEFT">
-                            <children>
-                                <HBox>
-                                    <Label fx:id="id" styleClass="cell_big_label">
-                                        <minWidth>
-                                            <!-- Ensures that the label text is never truncated -->
-                                            <Region fx:constant="USE_PREF_SIZE" />
-                                        </minWidth>
-                                    </Label>
-                                    <Label fx:id="name" text="\$first" styleClass="cell_big_label"/>
-                                </HBox>
-                            </children>
-                        </HBox>
-                        <FlowPane fx:id="tags" />
-                        <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
-                        <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
-                        <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
-                    </children>
-                </VBox>
-            </children>
-        </GridPane>
-    </children>
+          <children>
+            <HBox spacing="5" alignment="CENTER_LEFT">
+              <children>
+                <HBox>
+                  <Label fx:id="id" styleClass="cell_big_label">
+                    <minWidth>
+                      <!-- Ensures that the label text is never truncated -->
+                      <Region fx:constant="USE_PREF_SIZE" />
+                    </minWidth>
+                  </Label>
+                  <Label fx:id="name" text="\$first" styleClass="cell_big_label"/>
+                </HBox>
+              </children>
+            </HBox>
+            <FlowPane fx:id="tags" />
+            <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
+            <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
+            <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
+          </children>
+        </VBox>
+      </children>
+    </GridPane>
+  </children>
 </HBox>

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -25,7 +25,7 @@
             <Region fx:constant="USE_PREF_SIZE" />
           </minWidth>
         </Label>
-        <Label fx:id="name" text="\$first" styleClass="cell_big_label"/>
+        <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
       </HBox>
       <FlowPane fx:id="tags" />
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />

--- a/src/main/resources/view/PersonListPanel.fxml
+++ b/src/main/resources/view/PersonListPanel.fxml
@@ -9,7 +9,5 @@
     <URL value="@DarkTheme.css" />
     <URL value="@Extensions.css" />
   </stylesheets>
-  <children>
-    <ListView fx:id="personListView" VBox.vgrow="ALWAYS" />
-  </children>
+  <ListView fx:id="personListView" VBox.vgrow="ALWAYS" />
 </VBox>

--- a/src/main/resources/view/PersonListPanel.fxml
+++ b/src/main/resources/view/PersonListPanel.fxml
@@ -1,13 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import java.net.URL?>
 <?import javafx.scene.control.ListView?>
 <?import javafx.scene.layout.VBox?>
 
 <VBox xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
-  <stylesheets>
-    <URL value="@DarkTheme.css" />
-    <URL value="@Extensions.css" />
-  </stylesheets>
   <ListView fx:id="personListView" VBox.vgrow="ALWAYS" />
 </VBox>

--- a/src/main/resources/view/PersonListPanel.fxml
+++ b/src/main/resources/view/PersonListPanel.fxml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.scene.control.ListView?>
-<?import javafx.scene.layout.*?>
 <?import java.net.URL?>
+<?import javafx.scene.control.ListView?>
+<?import javafx.scene.layout.VBox?>
+
 <VBox xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
   <stylesheets>
     <URL value="@DarkTheme.css" />

--- a/src/main/resources/view/PersonListPanel.fxml
+++ b/src/main/resources/view/PersonListPanel.fxml
@@ -4,11 +4,11 @@
 <?import javafx.scene.layout.*?>
 <?import java.net.URL?>
 <VBox xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
-    <stylesheets>
-        <URL value="@DarkTheme.css" />
-        <URL value="@Extensions.css" />
-    </stylesheets>
-    <children>
-        <ListView fx:id="personListView" VBox.vgrow="ALWAYS" />
-    </children>
+  <stylesheets>
+    <URL value="@DarkTheme.css" />
+    <URL value="@Extensions.css" />
+  </stylesheets>
+  <children>
+    <ListView fx:id="personListView" VBox.vgrow="ALWAYS" />
+  </children>
 </VBox>

--- a/src/main/resources/view/ResultDisplay.fxml
+++ b/src/main/resources/view/ResultDisplay.fxml
@@ -4,12 +4,12 @@
 <?import java.net.URL?>
 <?import javafx.scene.control.TextArea?>
 <AnchorPane fx:id="placeHolder" styleClass="anchor-pane-with-border" xmlns="http://javafx.com/javafx/8"
-            xmlns:fx="http://javafx.com/fxml/1">
-    <stylesheets>
-        <URL value="@DarkTheme.css"/>
-        <URL value="@Extensions.css"/>
-    </stylesheets>
-    <AnchorPane fx:id="mainPane">
-        <TextArea fx:id="resultDisplay" editable="false" styleClass="result-display"/>
-    </AnchorPane>
+    xmlns:fx="http://javafx.com/fxml/1">
+  <stylesheets>
+    <URL value="@DarkTheme.css"/>
+    <URL value="@Extensions.css"/>
+  </stylesheets>
+  <AnchorPane fx:id="mainPane">
+    <TextArea fx:id="resultDisplay" editable="false" styleClass="result-display"/>
+  </AnchorPane>
 </AnchorPane>

--- a/src/main/resources/view/ResultDisplay.fxml
+++ b/src/main/resources/view/ResultDisplay.fxml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.scene.layout.AnchorPane?>
 <?import java.net.URL?>
 <?import javafx.scene.control.TextArea?>
+<?import javafx.scene.layout.AnchorPane?>
+
 <AnchorPane fx:id="placeHolder" styleClass="anchor-pane-with-border" xmlns="http://javafx.com/javafx/8"
     xmlns:fx="http://javafx.com/fxml/1">
   <stylesheets>

--- a/src/main/resources/view/ResultDisplay.fxml
+++ b/src/main/resources/view/ResultDisplay.fxml
@@ -1,15 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import java.net.URL?>
 <?import javafx.scene.control.TextArea?>
 <?import javafx.scene.layout.AnchorPane?>
 
 <AnchorPane fx:id="placeHolder" styleClass="anchor-pane-with-border" xmlns="http://javafx.com/javafx/8"
     xmlns:fx="http://javafx.com/fxml/1">
-  <stylesheets>
-    <URL value="@DarkTheme.css"/>
-    <URL value="@Extensions.css"/>
-  </stylesheets>
   <AnchorPane fx:id="mainPane">
     <TextArea fx:id="resultDisplay" editable="false" styleClass="result-display"/>
   </AnchorPane>

--- a/src/main/resources/view/ResultDisplay.fxml
+++ b/src/main/resources/view/ResultDisplay.fxml
@@ -6,6 +6,6 @@
 <AnchorPane fx:id="placeHolder" styleClass="anchor-pane-with-border" xmlns="http://javafx.com/javafx/8"
     xmlns:fx="http://javafx.com/fxml/1">
   <AnchorPane fx:id="mainPane">
-    <TextArea fx:id="resultDisplay" editable="false" styleClass="result-display"/>
+    <TextArea fx:id="resultDisplay" editable="false" styleClass="result-display" />
   </AnchorPane>
 </AnchorPane>

--- a/src/main/resources/view/StatusBarFooter.fxml
+++ b/src/main/resources/view/StatusBarFooter.fxml
@@ -9,9 +9,7 @@
     <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
     <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
   </columnConstraints>
-  <children>
-    <StatusBar styleClass="anchor-pane" fx:id="syncStatus" minWidth="0.0"/>
-    <StatusBar styleClass="anchor-pane" fx:id="saveLocationStatus" minWidth="0.0" GridPane.columnIndex="1"
-      nodeOrientation="RIGHT_TO_LEFT" />
-  </children>
+  <StatusBar styleClass="anchor-pane" fx:id="syncStatus" minWidth="0.0"/>
+  <StatusBar styleClass="anchor-pane" fx:id="saveLocationStatus" minWidth="0.0" GridPane.columnIndex="1"
+    nodeOrientation="RIGHT_TO_LEFT" />
 </GridPane>

--- a/src/main/resources/view/StatusBarFooter.fxml
+++ b/src/main/resources/view/StatusBarFooter.fxml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.scene.layout.*?>
 <?import org.controlsfx.control.StatusBar?>
+<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.GridPane?>
+
 <GridPane styleClass="grid-pane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1" stylesheets="@DarkTheme.css">
   <columnConstraints>
     <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />

--- a/src/main/resources/view/StatusBarFooter.fxml
+++ b/src/main/resources/view/StatusBarFooter.fxml
@@ -9,7 +9,6 @@
     <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
     <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
   </columnConstraints>
-  <StatusBar styleClass="anchor-pane" fx:id="syncStatus" minWidth="0.0"/>
-  <StatusBar styleClass="anchor-pane" fx:id="saveLocationStatus" minWidth="0.0" GridPane.columnIndex="1"
-    nodeOrientation="RIGHT_TO_LEFT" />
+  <StatusBar styleClass="anchor-pane" fx:id="syncStatus" />
+  <StatusBar styleClass="anchor-pane" fx:id="saveLocationStatus" GridPane.columnIndex="1" nodeOrientation="RIGHT_TO_LEFT" />
 </GridPane>

--- a/src/main/resources/view/StatusBarFooter.fxml
+++ b/src/main/resources/view/StatusBarFooter.fxml
@@ -6,8 +6,8 @@
 
 <GridPane styleClass="grid-pane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
   <columnConstraints>
-    <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-    <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
+    <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="100" />
+    <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="100" />
   </columnConstraints>
   <StatusBar styleClass="anchor-pane" fx:id="syncStatus" />
   <StatusBar styleClass="anchor-pane" fx:id="saveLocationStatus" GridPane.columnIndex="1" nodeOrientation="RIGHT_TO_LEFT" />

--- a/src/main/resources/view/StatusBarFooter.fxml
+++ b/src/main/resources/view/StatusBarFooter.fxml
@@ -4,7 +4,7 @@
 <?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.GridPane?>
 
-<GridPane styleClass="grid-pane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1" stylesheets="@DarkTheme.css">
+<GridPane styleClass="grid-pane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
   <columnConstraints>
     <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
     <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />

--- a/src/main/resources/view/StatusBarFooter.fxml
+++ b/src/main/resources/view/StatusBarFooter.fxml
@@ -3,13 +3,13 @@
 <?import javafx.scene.layout.*?>
 <?import org.controlsfx.control.StatusBar?>
 <GridPane styleClass="grid-pane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1" stylesheets="@DarkTheme.css">
-<columnConstraints>
-  <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-  <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-</columnConstraints>
- <children>
-      <StatusBar styleClass="anchor-pane" fx:id="syncStatus" minWidth="0.0"/>
-      <StatusBar styleClass="anchor-pane" fx:id="saveLocationStatus" minWidth="0.0" GridPane.columnIndex="1"
-          nodeOrientation="RIGHT_TO_LEFT" />
- </children>
+  <columnConstraints>
+    <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
+    <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
+  </columnConstraints>
+  <children>
+    <StatusBar styleClass="anchor-pane" fx:id="syncStatus" minWidth="0.0"/>
+    <StatusBar styleClass="anchor-pane" fx:id="saveLocationStatus" minWidth="0.0" GridPane.columnIndex="1"
+      nodeOrientation="RIGHT_TO_LEFT" />
+  </children>
 </GridPane>


### PR DESCRIPTION
Closes #231 


Propsed merge commit message:

```
The FXML files are deeply nested with unnecessary parent elements.
There are also multiple conflicting coding styles that exists within
the same file.

This makes the files hard to read and navigate. Furthermore, the
differing coding styles in the same file makes the whole file
inconsistent.

Let's modify the FXML files as follows:
    * Change indentations to 2 spaces in all FXML files as these files
      tends to have deep nesting
    * Remove all star imports and reorder the rest in alphabetical
      order in all FXML files
    * Remove unnecessary parent elements to reduce the nesting in
      all FXML files
    * Remove all unnecessary CSS style sheet imports except those
      in MainWindow.fxml
    * Wrap long attributes into multiple lines and add white spaces
      in MainWindow.fxml to improve readability
    * Remove unneeded minwidth attribute in StatusBarFooter.fxml
    * Remove unnecessary HBox element in PersonListCard.fxml
    * Standardize inset attributes order declarations in all FXML files
    * Add a space before closing slash in self-closing tags in all FXML files
    * Standardize height and width declarations in all FXML files to use
      only integer values 

```