### PR TITLE
Remove repeated usage of string literals #376

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -1,5 +1,10 @@
 package seedu.address.logic.commands;
 
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.ReadOnlyPerson;
@@ -13,9 +18,17 @@ public class AddCommand extends Command {
     public static final String COMMAND_WORD = "add";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the address book. "
-            + "Parameters: NAME p/PHONE e/EMAIL a/ADDRESS  [t/TAG]...\n"
-            + "Example: " + COMMAND_WORD
-            + " John Doe p/98765432 e/johnd@example.com a/311, Clementi Ave 2, #02-25 t/friends t/owesMoney";
+            + "Parameters: NAME "
+            + PREFIX_PHONE + "PHONE "
+            + PREFIX_EMAIL + "EMAIL "
+            + PREFIX_ADDRESS + "ADDRESS "
+            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "Example: " + COMMAND_WORD + " John Doe "
+            + PREFIX_PHONE + "98765432 "
+            + PREFIX_EMAIL + "johnd@example.com "
+            + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
+            + PREFIX_TAG + "friends "
+            + PREFIX_TAG + "owesMoney";
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -1,5 +1,10 @@
 package seedu.address.logic.commands;
 
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -27,8 +32,14 @@ public class EditCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the person identified "
             + "by the index number used in the last person listing. "
             + "Existing values will be overwritten by the input values.\n"
-            + "Parameters: INDEX (must be a positive integer) [NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS ] [t/TAG]...\n"
-            + "Example: " + COMMAND_WORD + " 1 p/91234567 e/johndoe@example.com";
+            + "Parameters: INDEX (must be a positive integer) [NAME] "
+            + "[" + PREFIX_PHONE + "PHONE] "
+            + "[" + PREFIX_EMAIL + "EMAIL] "
+            + "[" + PREFIX_ADDRESS + "ADDRESS] "
+            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "Example: " + COMMAND_WORD + " 1 "
+            + PREFIX_PHONE + "91234567 "
+            + PREFIX_EMAIL + "johndoe@example.com";
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";

--- a/src/main/java/seedu/address/logic/parser/Prefix.java
+++ b/src/main/java/seedu/address/logic/parser/Prefix.java
@@ -15,6 +15,10 @@ public class Prefix {
         return prefix;
     }
 
+    public String toString() {
+        return getPrefix();
+    }
+
     @Override
     public int hashCode() {
         return prefix == null ? 0 : prefix.hashCode();

--- a/src/test/java/guitests/AddCommandTest.java
+++ b/src/test/java/guitests/AddCommandTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import guitests.guihandles.PersonCardHandle;
 import seedu.address.commons.core.Messages;
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.ClearCommand;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.PersonUtil;
 import seedu.address.testutil.TestUtil;
@@ -32,7 +33,7 @@ public class AddCommandTest extends AddressBookGuiTest {
         assertTrue(personListPanel.isListMatching(currentList));
 
         //add to empty list
-        commandBox.runCommand("clear");
+        commandBox.runCommand(ClearCommand.COMMAND_WORD);
         assertAddSuccess(td.alice);
 
         //invalid command

--- a/src/test/java/guitests/ClearCommandTest.java
+++ b/src/test/java/guitests/ClearCommandTest.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
+import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.testutil.PersonUtil;
 
 public class ClearCommandTest extends AddressBookGuiTest {
@@ -18,7 +20,7 @@ public class ClearCommandTest extends AddressBookGuiTest {
         //verify other commands can work after a clear command
         commandBox.runCommand(PersonUtil.getAddCommand(td.hoon));
         assertTrue(personListPanel.isListMatching(td.hoon));
-        commandBox.runCommand("delete 1");
+        commandBox.runCommand(DeleteCommand.COMMAND_WORD + " 1");
         assertListSize(0);
 
         //verify clear command works when the list is empty
@@ -26,7 +28,7 @@ public class ClearCommandTest extends AddressBookGuiTest {
     }
 
     private void assertClearCommandSuccess() {
-        commandBox.runCommand("clear");
+        commandBox.runCommand(ClearCommand.COMMAND_WORD);
         assertListSize(0);
         assertResultMessage("Address book has been cleared!");
     }

--- a/src/test/java/guitests/CommandBoxTest.java
+++ b/src/test/java/guitests/CommandBoxTest.java
@@ -9,11 +9,12 @@ import java.util.ArrayList;
 import org.junit.Before;
 import org.junit.Test;
 
+import seedu.address.logic.commands.SelectCommand;
 import seedu.address.ui.CommandBox;
 
 public class CommandBoxTest extends AddressBookGuiTest {
 
-    private static final String COMMAND_THAT_SUCCEEDS = "select 3";
+    private static final String COMMAND_THAT_SUCCEEDS = SelectCommand.COMMAND_WORD + " 3";
     private static final String COMMAND_THAT_FAILS = "invalid command";
 
     private ArrayList<String> defaultStyleOfCommandBox;

--- a/src/test/java/guitests/DeleteCommandTest.java
+++ b/src/test/java/guitests/DeleteCommandTest.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.commands.DeleteCommand.MESSAGE_DELETE_PERSON_S
 import org.junit.Test;
 
 import seedu.address.commons.util.IndexUtil;
+import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.TestUtil;
 
@@ -30,7 +31,7 @@ public class DeleteCommandTest extends AddressBookGuiTest {
         assertDeleteSuccess(targetIndex, currentList);
 
         //invalid index
-        commandBox.runCommand("delete " + currentList.length + 1);
+        commandBox.runCommand(DeleteCommand.COMMAND_WORD + " " + currentList.length + 1);
         assertResultMessage("The person index provided is invalid");
 
     }
@@ -44,7 +45,7 @@ public class DeleteCommandTest extends AddressBookGuiTest {
         Person personToDelete = currentList[IndexUtil.oneToZeroIndex(targetIndexOneIndexed)];
         Person[] expectedRemainder = TestUtil.removePersonFromList(currentList, targetIndexOneIndexed);
 
-        commandBox.runCommand("delete " + targetIndexOneIndexed);
+        commandBox.runCommand(DeleteCommand.COMMAND_WORD + " " + targetIndexOneIndexed);
 
         //confirm the list now contains all previous persons except the deleted person
         assertTrue(personListPanel.isListMatching(expectedRemainder));

--- a/src/test/java/guitests/EditCommandTest.java
+++ b/src/test/java/guitests/EditCommandTest.java
@@ -9,6 +9,7 @@ import guitests.guihandles.PersonCardHandle;
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.util.IndexUtil;
 import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.FindCommand;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
@@ -59,7 +60,7 @@ public class EditCommandTest extends AddressBookGuiTest {
 
     @Test
     public void edit_findThenEdit_success() throws Exception {
-        commandBox.runCommand("find Elle");
+        commandBox.runCommand(FindCommand.COMMAND_WORD + " Elle");
 
         String detailsToEdit = "Belle";
         int filteredPersonListIndex = 1;
@@ -73,43 +74,43 @@ public class EditCommandTest extends AddressBookGuiTest {
 
     @Test
     public void edit_missingPersonIndex_failure() {
-        commandBox.runCommand("edit Bobby");
+        commandBox.runCommand(EditCommand.COMMAND_WORD + " Bobby");
         assertResultMessage(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
     }
 
     @Test
     public void edit_invalidPersonIndex_failure() {
-        commandBox.runCommand("edit 8 Bobby");
+        commandBox.runCommand(EditCommand.COMMAND_WORD + " 8 Bobby");
         assertResultMessage(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 
     @Test
     public void edit_noFieldsSpecified_failure() {
-        commandBox.runCommand("edit 1");
+        commandBox.runCommand(EditCommand.COMMAND_WORD + " 1");
         assertResultMessage(EditCommand.MESSAGE_NOT_EDITED);
     }
 
     @Test
     public void edit_invalidValues_failure() {
-        commandBox.runCommand("edit 1 *&");
+        commandBox.runCommand(EditCommand.COMMAND_WORD + " 1 *&");
         assertResultMessage(Name.MESSAGE_NAME_CONSTRAINTS);
 
-        commandBox.runCommand("edit 1 p/abcd");
+        commandBox.runCommand(EditCommand.COMMAND_WORD + " 1 p/abcd");
         assertResultMessage(Phone.MESSAGE_PHONE_CONSTRAINTS);
 
-        commandBox.runCommand("edit 1 e/yahoo!!!");
+        commandBox.runCommand(EditCommand.COMMAND_WORD + " 1 e/yahoo!!!");
         assertResultMessage(Email.MESSAGE_EMAIL_CONSTRAINTS);
 
-        commandBox.runCommand("edit 1 a/");
+        commandBox.runCommand(EditCommand.COMMAND_WORD + " 1 a/");
         assertResultMessage(Address.MESSAGE_ADDRESS_CONSTRAINTS);
 
-        commandBox.runCommand("edit 1 t/*&");
+        commandBox.runCommand(EditCommand.COMMAND_WORD + " 1 t/*&");
         assertResultMessage(Tag.MESSAGE_TAG_CONSTRAINTS);
     }
 
     @Test
     public void edit_duplicatePerson_failure() {
-        commandBox.runCommand("edit 3 Alice Pauline p/85355255 e/alice@example.com "
+        commandBox.runCommand(EditCommand.COMMAND_WORD + " 3 Alice Pauline p/85355255 e/alice@example.com "
                                 + "a/123, Jurong West Ave 6, #08-111 t/friends");
         assertResultMessage(EditCommand.MESSAGE_DUPLICATE_PERSON);
     }
@@ -125,7 +126,7 @@ public class EditCommandTest extends AddressBookGuiTest {
      */
     private void assertEditSuccess(int filteredPersonListIndex, int addressBookIndex,
                                     String detailsToEdit, Person editedPerson) {
-        commandBox.runCommand("edit " + filteredPersonListIndex + " " + detailsToEdit);
+        commandBox.runCommand(EditCommand.COMMAND_WORD + " " + filteredPersonListIndex + " " + detailsToEdit);
 
         // confirm the new card contains the right data
         PersonCardHandle editedCard = personListPanel.navigateToPerson(editedPerson.getName().fullName);

--- a/src/test/java/guitests/EditCommandTest.java
+++ b/src/test/java/guitests/EditCommandTest.java
@@ -2,6 +2,10 @@ package guitests;
 
 import static org.junit.Assert.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import org.junit.Test;
 
@@ -27,7 +31,10 @@ public class EditCommandTest extends AddressBookGuiTest {
 
     @Test
     public void edit_allFieldsSpecified_success() throws Exception {
-        String detailsToEdit = "Bobby p/91234567 e/bobby@example.com a/Block 123, Bobby Street 3 t/husband";
+        String detailsToEdit = "Bobby " + PREFIX_PHONE + "91234567 "
+                + PREFIX_EMAIL + "bobby@example.com "
+                + PREFIX_ADDRESS + "Block 123, Bobby Street 3 "
+                + PREFIX_TAG + "husband";
         int addressBookIndex = 1;
 
         Person editedPerson = new PersonBuilder().withName("Bobby").withPhone("91234567")
@@ -38,7 +45,8 @@ public class EditCommandTest extends AddressBookGuiTest {
 
     @Test
     public void edit_notAllFieldsSpecified_success() throws Exception {
-        String detailsToEdit = "t/sweetie t/bestie";
+        String detailsToEdit = PREFIX_TAG + "sweetie "
+                + PREFIX_TAG + "bestie";
         int addressBookIndex = 2;
 
         Person personToEdit = expectedPersonsList[IndexUtil.oneToZeroIndex(addressBookIndex)];
@@ -49,7 +57,7 @@ public class EditCommandTest extends AddressBookGuiTest {
 
     @Test
     public void edit_clearTags_success() throws Exception {
-        String detailsToEdit = "t/";
+        String detailsToEdit = PREFIX_TAG.getPrefix();
         int addressBookIndex = 2;
 
         Person personToEdit = expectedPersonsList[IndexUtil.oneToZeroIndex(addressBookIndex)];
@@ -95,23 +103,26 @@ public class EditCommandTest extends AddressBookGuiTest {
         commandBox.runCommand(EditCommand.COMMAND_WORD + " 1 *&");
         assertResultMessage(Name.MESSAGE_NAME_CONSTRAINTS);
 
-        commandBox.runCommand(EditCommand.COMMAND_WORD + " 1 p/abcd");
+        commandBox.runCommand(EditCommand.COMMAND_WORD + " 1 " + PREFIX_PHONE + "abcd");
         assertResultMessage(Phone.MESSAGE_PHONE_CONSTRAINTS);
 
-        commandBox.runCommand(EditCommand.COMMAND_WORD + " 1 e/yahoo!!!");
+        commandBox.runCommand(EditCommand.COMMAND_WORD + " 1 " + PREFIX_EMAIL + "yahoo!!!");
         assertResultMessage(Email.MESSAGE_EMAIL_CONSTRAINTS);
 
-        commandBox.runCommand(EditCommand.COMMAND_WORD + " 1 a/");
+        commandBox.runCommand(EditCommand.COMMAND_WORD + " 1 " + PREFIX_ADDRESS.getPrefix());
         assertResultMessage(Address.MESSAGE_ADDRESS_CONSTRAINTS);
 
-        commandBox.runCommand(EditCommand.COMMAND_WORD + " 1 t/*&");
+        commandBox.runCommand(EditCommand.COMMAND_WORD + " 1 " + PREFIX_TAG + "*&");
         assertResultMessage(Tag.MESSAGE_TAG_CONSTRAINTS);
     }
 
     @Test
     public void edit_duplicatePerson_failure() {
-        commandBox.runCommand(EditCommand.COMMAND_WORD + " 3 Alice Pauline p/85355255 e/alice@example.com "
-                                + "a/123, Jurong West Ave 6, #08-111 t/friends");
+        commandBox.runCommand(EditCommand.COMMAND_WORD + " 3 Alice Pauline "
+                + PREFIX_PHONE + "85355255 "
+                + PREFIX_EMAIL + "alice@example.com "
+                + PREFIX_ADDRESS + "123, Jurong West Ave 6, #08-111 "
+                + PREFIX_TAG + "friends");
         assertResultMessage(EditCommand.MESSAGE_DUPLICATE_PERSON);
     }
 

--- a/src/test/java/guitests/FindCommandTest.java
+++ b/src/test/java/guitests/FindCommandTest.java
@@ -5,29 +5,32 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 import seedu.address.commons.core.Messages;
+import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.FindCommand;
 import seedu.address.model.person.Person;
 
 public class FindCommandTest extends AddressBookGuiTest {
 
     @Test
     public void find_nonEmptyList() {
-        assertFindResult("find Mark"); // no results
-        assertFindResult("find Meier", td.benson, td.daniel); // multiple results
+        assertFindResult(FindCommand.COMMAND_WORD + " Mark"); // no results
+        assertFindResult(FindCommand.COMMAND_WORD + " Meier", td.benson, td.daniel); // multiple results
 
         //find after deleting one result
-        commandBox.runCommand("delete 1");
-        assertFindResult("find Meier", td.daniel);
+        commandBox.runCommand(DeleteCommand.COMMAND_WORD + " 1");
+        assertFindResult(FindCommand.COMMAND_WORD + " Meier", td.daniel);
     }
 
     @Test
     public void find_emptyList() {
-        commandBox.runCommand("clear");
-        assertFindResult("find Jean"); // no results
+        commandBox.runCommand(ClearCommand.COMMAND_WORD);
+        assertFindResult(FindCommand.COMMAND_WORD + " Jean"); // no results
     }
 
     @Test
     public void find_invalidCommand_fail() {
-        commandBox.runCommand("findgeorge");
+        commandBox.runCommand(FindCommand.COMMAND_WORD + "george");
         assertResultMessage(Messages.MESSAGE_UNKNOWN_COMMAND);
     }
 

--- a/src/test/java/guitests/SelectCommandTest.java
+++ b/src/test/java/guitests/SelectCommandTest.java
@@ -5,6 +5,8 @@ import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 
 import seedu.address.commons.util.IndexUtil;
+import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.SelectCommand;
 import seedu.address.model.person.ReadOnlyPerson;
 
 public class SelectCommandTest extends AddressBookGuiTest {
@@ -30,18 +32,18 @@ public class SelectCommandTest extends AddressBookGuiTest {
 
     @Test
     public void selectPerson_emptyList() {
-        commandBox.runCommand("clear");
+        commandBox.runCommand(ClearCommand.COMMAND_WORD);
         assertListSize(0);
         assertSelectionInvalid(1); //invalid index
     }
 
     private void assertSelectionInvalid(int index) {
-        commandBox.runCommand("select " + index);
+        commandBox.runCommand(SelectCommand.COMMAND_WORD + " " + index);
         assertResultMessage("The person index provided is invalid");
     }
 
     private void assertSelectionSuccess(int index) {
-        commandBox.runCommand("select " + index);
+        commandBox.runCommand(SelectCommand.COMMAND_WORD + " " + index);
         assertResultMessage("Selected Person: " + index);
         assertPersonSelected(index);
     }

--- a/src/test/java/guitests/guihandles/CommandBoxHandle.java
+++ b/src/test/java/guitests/guihandles/CommandBoxHandle.java
@@ -4,6 +4,7 @@ import guitests.GuiRobot;
 import javafx.collections.ObservableList;
 import javafx.stage.Stage;
 
+import seedu.address.logic.commands.HelpCommand;
 import seedu.address.ui.CommandBox;
 
 /**
@@ -44,7 +45,7 @@ public class CommandBoxHandle extends GuiHandle {
     }
 
     public HelpWindowHandle runHelpCommand() {
-        enterCommand("help");
+        enterCommand(HelpCommand.COMMAND_WORD);
         pressEnter();
         return new HelpWindowHandle(guiRobot, primaryStage);
     }

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -6,6 +6,10 @@ import static org.junit.Assert.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.model.util.SampleDataUtil.getTagSet;
 
 import java.util.ArrayList;
@@ -197,22 +201,41 @@ public class LogicManagerTest {
     public void execute_add_invalidArgsFormat() {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE);
         assertCommandFailure(AddCommand.COMMAND_WORD + " wrong args wrong args", expectedMessage);
-        assertCommandFailure(AddCommand.COMMAND_WORD + " Valid Name 12345 e/valid@email.butNoPhonePrefix a/valid,address", expectedMessage);
-        assertCommandFailure(AddCommand.COMMAND_WORD + " Valid Name p/12345 valid@email.butNoPrefix a/valid, address", expectedMessage);
-        assertCommandFailure(AddCommand.COMMAND_WORD + " Valid Name p/12345 e/valid@email.butNoAddressPrefix valid, address", expectedMessage);
+        assertCommandFailure(AddCommand.COMMAND_WORD + " Valid Name 12345 "
+                + PREFIX_EMAIL + "valid@email.butNoPhonePrefix "
+                + PREFIX_ADDRESS + "valid,address", expectedMessage);
+        assertCommandFailure(AddCommand.COMMAND_WORD + " Valid Name "
+                + PREFIX_PHONE + "12345 valid@email.butNoPrefix "
+                + PREFIX_ADDRESS + "valid, address", expectedMessage);
+        assertCommandFailure(AddCommand.COMMAND_WORD + " Valid Name "
+                + PREFIX_PHONE + "12345 "
+                + PREFIX_EMAIL + "valid@email.butNoAddressPrefix valid, address",
+                expectedMessage);
     }
 
     @Test
     public void execute_add_invalidPersonData() {
-        assertCommandFailure(AddCommand.COMMAND_WORD + " []\\[;] p/12345 e/valid@e.mail a/valid, address",
+        assertCommandFailure(AddCommand.COMMAND_WORD + " []\\[;] "
+                + PREFIX_PHONE + "12345 "
+                + PREFIX_EMAIL + "valid@e.mail "
+                + PREFIX_ADDRESS + "valid, address",
                 Name.MESSAGE_NAME_CONSTRAINTS);
-        assertCommandFailure(AddCommand.COMMAND_WORD + " Valid Name p/not_numbers e/valid@e.mail a/valid, address",
+        assertCommandFailure(AddCommand.COMMAND_WORD + " Valid Name "
+                + PREFIX_PHONE + "not_numbers "
+                + PREFIX_EMAIL + "valid@e.mail "
+                + PREFIX_ADDRESS + "valid, address",
                 Phone.MESSAGE_PHONE_CONSTRAINTS);
-        assertCommandFailure(AddCommand.COMMAND_WORD + " Valid Name p/12345 e/notAnEmail a/valid, address",
+        assertCommandFailure(AddCommand.COMMAND_WORD + " Valid Name "
+                + PREFIX_PHONE + "12345 "
+                + PREFIX_EMAIL + "notAnEmail "
+                + PREFIX_ADDRESS + "valid, address",
                 Email.MESSAGE_EMAIL_CONSTRAINTS);
-        assertCommandFailure(AddCommand.COMMAND_WORD + " Valid Name p/12345 e/valid@e.mail a/valid, address t/invalid_-[.tag",
+        assertCommandFailure(AddCommand.COMMAND_WORD + " Valid Name "
+                + PREFIX_PHONE + "12345 "
+                + PREFIX_EMAIL + "valid@e.mail "
+                + PREFIX_ADDRESS + "valid, address "
+                + PREFIX_TAG + "invalid_-[.tag",
                 Tag.MESSAGE_TAG_CONSTRAINTS);
-
     }
 
     @Test
@@ -458,13 +481,13 @@ public class LogicManagerTest {
             cmd.append(AddCommand.COMMAND_WORD + " ");
 
             cmd.append(p.getName().toString());
-            cmd.append(" e/").append(p.getEmail());
-            cmd.append(" p/").append(p.getPhone());
-            cmd.append(" a/").append(p.getAddress());
+            cmd.append(" " + PREFIX_EMAIL.getPrefix()).append(p.getEmail());
+            cmd.append(" " + PREFIX_PHONE.getPrefix()).append(p.getPhone());
+            cmd.append(" " + PREFIX_ADDRESS.getPrefix()).append(p.getAddress());
 
             Set<Tag> tags = p.getTags();
             for (Tag t: tags) {
-                cmd.append(" t/").append(t.tagName);
+                cmd.append(" " + PREFIX_TAG.getPrefix()).append(t.tagName);
             }
 
             return cmd.toString();

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -170,13 +170,14 @@ public class LogicManagerTest {
 
     @Test
     public void execute_help() {
-        assertCommandSuccess("help", HelpCommand.SHOWING_HELP_MESSAGE, new AddressBook(), Collections.emptyList());
+        assertCommandSuccess(HelpCommand.COMMAND_WORD, HelpCommand.SHOWING_HELP_MESSAGE,
+                new AddressBook(), Collections.emptyList());
         assertTrue(helpShown);
     }
 
     @Test
     public void execute_exit() {
-        assertCommandSuccess("exit", ExitCommand.MESSAGE_EXIT_ACKNOWLEDGEMENT,
+        assertCommandSuccess(ExitCommand.COMMAND_WORD, ExitCommand.MESSAGE_EXIT_ACKNOWLEDGEMENT,
                 new AddressBook(), Collections.emptyList());
     }
 
@@ -187,28 +188,29 @@ public class LogicManagerTest {
         model.addPerson(helper.generatePerson(2));
         model.addPerson(helper.generatePerson(3));
 
-        assertCommandSuccess("clear", ClearCommand.MESSAGE_SUCCESS, new AddressBook(), Collections.emptyList());
+        assertCommandSuccess(ClearCommand.COMMAND_WORD, ClearCommand.MESSAGE_SUCCESS,
+                new AddressBook(), Collections.emptyList());
     }
 
 
     @Test
     public void execute_add_invalidArgsFormat() {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE);
-        assertCommandFailure("add wrong args wrong args", expectedMessage);
-        assertCommandFailure("add Valid Name 12345 e/valid@email.butNoPhonePrefix a/valid,address", expectedMessage);
-        assertCommandFailure("add Valid Name p/12345 valid@email.butNoPrefix a/valid, address", expectedMessage);
-        assertCommandFailure("add Valid Name p/12345 e/valid@email.butNoAddressPrefix valid, address", expectedMessage);
+        assertCommandFailure(AddCommand.COMMAND_WORD + " wrong args wrong args", expectedMessage);
+        assertCommandFailure(AddCommand.COMMAND_WORD + " Valid Name 12345 e/valid@email.butNoPhonePrefix a/valid,address", expectedMessage);
+        assertCommandFailure(AddCommand.COMMAND_WORD + " Valid Name p/12345 valid@email.butNoPrefix a/valid, address", expectedMessage);
+        assertCommandFailure(AddCommand.COMMAND_WORD + " Valid Name p/12345 e/valid@email.butNoAddressPrefix valid, address", expectedMessage);
     }
 
     @Test
     public void execute_add_invalidPersonData() {
-        assertCommandFailure("add []\\[;] p/12345 e/valid@e.mail a/valid, address",
+        assertCommandFailure(AddCommand.COMMAND_WORD + " []\\[;] p/12345 e/valid@e.mail a/valid, address",
                 Name.MESSAGE_NAME_CONSTRAINTS);
-        assertCommandFailure("add Valid Name p/not_numbers e/valid@e.mail a/valid, address",
+        assertCommandFailure(AddCommand.COMMAND_WORD + " Valid Name p/not_numbers e/valid@e.mail a/valid, address",
                 Phone.MESSAGE_PHONE_CONSTRAINTS);
-        assertCommandFailure("add Valid Name p/12345 e/notAnEmail a/valid, address",
+        assertCommandFailure(AddCommand.COMMAND_WORD + " Valid Name p/12345 e/notAnEmail a/valid, address",
                 Email.MESSAGE_EMAIL_CONSTRAINTS);
-        assertCommandFailure("add Valid Name p/12345 e/valid@e.mail a/valid, address t/invalid_-[.tag",
+        assertCommandFailure(AddCommand.COMMAND_WORD + " Valid Name p/12345 e/valid@e.mail a/valid, address t/invalid_-[.tag",
                 Tag.MESSAGE_TAG_CONSTRAINTS);
 
     }
@@ -254,7 +256,7 @@ public class LogicManagerTest {
         // prepare address book state
         helper.addToModel(model, 2);
 
-        assertCommandSuccess("list",
+        assertCommandSuccess(ListCommand.COMMAND_WORD,
                 ListCommand.MESSAGE_SUCCESS,
                 expectedAb,
                 expectedList);
@@ -299,12 +301,12 @@ public class LogicManagerTest {
     @Test
     public void execute_selectInvalidArgsFormat_errorMessageShown() throws Exception {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, SelectCommand.MESSAGE_USAGE);
-        assertIncorrectIndexFormatBehaviorForCommand("select", expectedMessage);
+        assertIncorrectIndexFormatBehaviorForCommand(SelectCommand.COMMAND_WORD, expectedMessage);
     }
 
     @Test
     public void execute_selectIndexNotFound_errorMessageShown() throws Exception {
-        assertIndexNotFoundBehaviorForCommand("select");
+        assertIndexNotFoundBehaviorForCommand(SelectCommand.COMMAND_WORD);
     }
 
     @Test
@@ -315,7 +317,7 @@ public class LogicManagerTest {
         AddressBook expectedAb = helper.generateAddressBook(threePersons);
         helper.addToModel(model, threePersons);
 
-        assertCommandSuccess("select 2",
+        assertCommandSuccess(SelectCommand.COMMAND_WORD + " 2",
                 String.format(SelectCommand.MESSAGE_SELECT_PERSON_SUCCESS, 2),
                 expectedAb,
                 expectedAb.getPersonList());
@@ -327,12 +329,12 @@ public class LogicManagerTest {
     @Test
     public void execute_deleteInvalidArgsFormat_errorMessageShown() throws Exception {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE);
-        assertIncorrectIndexFormatBehaviorForCommand("delete", expectedMessage);
+        assertIncorrectIndexFormatBehaviorForCommand(DeleteCommand.COMMAND_WORD, expectedMessage);
     }
 
     @Test
     public void execute_deleteIndexNotFound_errorMessageShown() throws Exception {
-        assertIndexNotFoundBehaviorForCommand("delete");
+        assertIndexNotFoundBehaviorForCommand(DeleteCommand.COMMAND_WORD);
     }
 
     @Test
@@ -344,7 +346,7 @@ public class LogicManagerTest {
         expectedAb.removePerson(threePersons.get(1));
         helper.addToModel(model, threePersons);
 
-        assertCommandSuccess("delete 2",
+        assertCommandSuccess(DeleteCommand.COMMAND_WORD + " 2",
                 String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, threePersons.get(1)),
                 expectedAb,
                 expectedAb.getPersonList());
@@ -354,7 +356,7 @@ public class LogicManagerTest {
     @Test
     public void execute_find_invalidArgsFormat() {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE);
-        assertCommandFailure("find ", expectedMessage);
+        assertCommandFailure(FindCommand.COMMAND_WORD + " ", expectedMessage);
     }
 
     @Test
@@ -370,7 +372,7 @@ public class LogicManagerTest {
         List<Person> expectedList = helper.generatePersonList(pTarget1, pTarget2);
         helper.addToModel(model, fourPersons);
 
-        assertCommandSuccess("find KEY",
+        assertCommandSuccess(FindCommand.COMMAND_WORD + " KEY",
                 Command.getMessageForPersonListShownSummary(expectedList.size()),
                 expectedAb,
                 expectedList);
@@ -389,7 +391,7 @@ public class LogicManagerTest {
         List<Person> expectedList = fourPersons;
         helper.addToModel(model, fourPersons);
 
-        assertCommandSuccess("find KEY",
+        assertCommandSuccess(FindCommand.COMMAND_WORD + " KEY",
                 Command.getMessageForPersonListShownSummary(expectedList.size()),
                 expectedAb,
                 expectedList);
@@ -408,7 +410,7 @@ public class LogicManagerTest {
         List<Person> expectedList = helper.generatePersonList(pTarget1, pTarget2, pTarget3);
         helper.addToModel(model, fourPersons);
 
-        assertCommandSuccess("find key rAnDoM",
+        assertCommandSuccess(FindCommand.COMMAND_WORD + " key rAnDoM",
                 Command.getMessageForPersonListShownSummary(expectedList.size()),
                 expectedAb,
                 expectedList);
@@ -453,7 +455,7 @@ public class LogicManagerTest {
         String generateAddCommand(Person p) {
             StringBuffer cmd = new StringBuffer();
 
-            cmd.append("add ");
+            cmd.append(AddCommand.COMMAND_WORD + " ");
 
             cmd.append(p.getName().toString());
             cmd.append(" e/").append(p.getEmail());

--- a/src/test/java/seedu/address/logic/commands/EditCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandIntegrationTest.java
@@ -63,7 +63,7 @@ public class EditCommandIntegrationTest {
     @Test
     public void execute_invalidPersonIndex_throwsCommandException() {
         int oneBasedOutOfBoundIndex = model.getFilteredPersonList().size() + 1;
-        String userInput = "edit " + oneBasedOutOfBoundIndex + " Bobby";
+        String userInput = EditCommand.COMMAND_WORD + " " + oneBasedOutOfBoundIndex + " Bobby";
         Command command = prepareCommand(userInput);
         assertCommandFailure(command, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }

--- a/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
+++ b/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
@@ -110,7 +110,7 @@ public class ArgumentTokenizerTest {
         /** Also covers: testing for prefixes not specified as a prefix **/
 
         // Prefixes not previously given to the tokenizer should not return any values
-        argsString = unknownPrefix.getPrefix() + "some value";
+        argsString = unknownPrefix + "some value";
         argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ);
         assertArgumentAbsent(argMultimap, unknownPrefix);
         assertPreamblePresent(argMultimap, argsString); // Unknown prefix is taken as part of preamble

--- a/src/test/java/seedu/address/testutil/PersonUtil.java
+++ b/src/test/java/seedu/address/testutil/PersonUtil.java
@@ -1,5 +1,7 @@
 package seedu.address.testutil;
 
+import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.EditCommand;
 import seedu.address.model.person.Person;
 
 /**
@@ -11,14 +13,14 @@ public class PersonUtil {
      * Returns an add command string for adding the {@code person}.
      */
     public static String getAddCommand(Person person) {
-        return "add " + getPersonDetails(person);
+        return AddCommand.COMMAND_WORD + " " + getPersonDetails(person);
     }
 
     /**
      * Returns an edit command string for editing the person at {@code zeroBasedIndex} to match {@code editedPerson}.
      */
     public static String getEditCommand(int zeroBasedIndex, Person editedPerson) {
-        return "edit " + (zeroBasedIndex + 1) + " " + getPersonDetails(editedPerson);
+        return EditCommand.COMMAND_WORD + " " + (zeroBasedIndex + 1) + " " + getPersonDetails(editedPerson);
     }
 
     /**

--- a/src/test/java/seedu/address/testutil/PersonUtil.java
+++ b/src/test/java/seedu/address/testutil/PersonUtil.java
@@ -1,5 +1,10 @@
 package seedu.address.testutil;
 
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.model.person.Person;
@@ -29,10 +34,12 @@ public class PersonUtil {
     private static String getPersonDetails(Person person) {
         StringBuilder sb = new StringBuilder();
         sb.append(person.getName().fullName + " ");
-        sb.append("a/" + person.getAddress().value + " ");
-        sb.append("p/" + person.getPhone().value + " ");
-        sb.append("e/" + person.getEmail().value + " ");
-        person.getTags().stream().forEach(s -> sb.append("t/" + s.tagName + " "));
+        sb.append(PREFIX_PHONE + person.getPhone().value + " ");
+        sb.append(PREFIX_EMAIL + person.getEmail().value + " ");
+        sb.append(PREFIX_ADDRESS + person.getAddress().value + " ");
+        person.getTags().stream().forEach(
+            s -> sb.append(PREFIX_TAG + s.tagName + " ")
+        );
         return sb.toString();
     }
 }


### PR DESCRIPTION
Fixes #376 

Preposed merge commit message:
>The repeated usage of string literals violates the DRY principle
> (e.g. "add" for the add command word, "p/" for phone prefix).
>
>Let's replace these string literals with the constants defined for
> them (e.g. AddCommand.COMMAND_WORD for "add",
>CliSyntax.PREFIX_PHONE for "p/").