### PR TITLE
Hack out Undo / Redo commands

### DIFF
--- a/src/main/java/seedu/address/logic/History.java
+++ b/src/main/java/seedu/address/logic/History.java
@@ -1,0 +1,10 @@
+package seedu.address.logic;
+
+import java.util.Optional;
+
+import seedu.address.logic.commands.ReversibleCommand;
+
+public interface History {
+    public Optional<ReversibleCommand> getPreviousCommand();
+    public Optional<ReversibleCommand> getNextCommand();
+}

--- a/src/main/java/seedu/address/logic/HistoryManager.java
+++ b/src/main/java/seedu/address/logic/HistoryManager.java
@@ -1,0 +1,37 @@
+package seedu.address.logic;
+
+import java.util.ArrayList;
+import java.util.Optional;
+
+import seedu.address.logic.commands.ReversibleCommand;
+
+public class HistoryManager implements History {
+    private ArrayList<ReversibleCommand> commandHistory;
+    private int pointer; // points to the command to be undone in commandHistory
+
+    public HistoryManager() {
+        commandHistory = new ArrayList<ReversibleCommand>();
+        pointer = -1;
+    }
+
+    public void push(ReversibleCommand e) {
+        // if after undoing a few commands, you did not redo all of them, and now you are executing
+        // new command
+        if (pointer != commandHistory.size() - 1) {
+            commandHistory.subList(pointer + 1, commandHistory.size()).clear();
+        }
+
+        commandHistory.add(e);
+        pointer = commandHistory.size() - 1;
+    }
+
+    public Optional<ReversibleCommand> getPreviousCommand() {
+        return pointer >= 0 ? Optional.of(commandHistory.get(pointer--)) :
+            Optional.empty();
+    }
+
+    public Optional<ReversibleCommand> getNextCommand() {
+        return pointer < commandHistory.size() - 1 ? Optional.of(commandHistory.get(++pointer)) :
+            Optional.empty();
+    }
+}

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -7,6 +7,7 @@ import seedu.address.commons.core.ComponentManager;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.ReversibleCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.Parser;
 import seedu.address.model.Model;
@@ -21,10 +22,12 @@ public class LogicManager extends ComponentManager implements Logic {
 
     private final Model model;
     private final Parser parser;
+    private final HistoryManager historyManager;
 
     public LogicManager(Model model, Storage storage) {
+        historyManager = new HistoryManager();
         this.model = model;
-        this.parser = new Parser();
+        this.parser = new Parser(historyManager);
     }
 
     @Override
@@ -32,7 +35,15 @@ public class LogicManager extends ComponentManager implements Logic {
         logger.info("----------------[USER COMMAND][" + commandText + "]");
         Command command = parser.parseCommand(commandText);
         command.setData(model);
-        return command.execute();
+        CommandResult result = command.execute();
+
+        // Only store into historyManager the commands that have been successfully executed;
+        // the commands that aren't successfully executed would have thrown exception already.
+        if (command instanceof ReversibleCommand) {
+            historyManager.push((ReversibleCommand) command);
+        }
+
+        return result;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -4,11 +4,12 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.ReadOnlyPerson;
 import seedu.address.model.person.UniquePersonList;
+import seedu.address.model.person.UniquePersonList.PersonNotFoundException;
 
 /**
  * Adds a person to the address book.
  */
-public class AddCommand extends Command {
+public class AddCommand extends ReversibleCommand {
 
     public static final String COMMAND_WORD = "add";
 
@@ -41,4 +42,14 @@ public class AddCommand extends Command {
 
     }
 
+    @Override
+    public void undo() {
+        assert model.getAddressBook().getPersonList().size() != 0;
+
+        try {
+            model.deletePerson(toAdd);
+        } catch (PersonNotFoundException pnfe) {
+            assert false : "The target person cannot be missing";
+        }
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -1,20 +1,29 @@
 package seedu.address.logic.commands;
 
 import seedu.address.model.AddressBook;
+import seedu.address.model.ReadOnlyAddressBook;
 
 /**
  * Clears the address book.
  */
-public class ClearCommand extends Command {
+public class ClearCommand extends ReversibleCommand {
 
     public static final String COMMAND_WORD = "clear";
     public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
 
+    private ReadOnlyAddressBook previousAddressBook;
 
     @Override
     public CommandResult execute() {
         assert model != null;
+        previousAddressBook = new AddressBook(model.getAddressBook());
         model.resetData(new AddressBook());
         return new CommandResult(MESSAGE_SUCCESS);
+    }
+
+    @Override
+    public void undo() {
+        assert previousAddressBook != null;
+        model.resetData(previousAddressBook);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -4,13 +4,15 @@ import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.UnmodifiableObservableList;
 import seedu.address.commons.util.IndexUtil;
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.AddressBook;
+import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.ReadOnlyPerson;
 import seedu.address.model.person.UniquePersonList.PersonNotFoundException;
 
 /**
  * Deletes a person identified using it's last displayed index from the address book.
  */
-public class DeleteCommand extends Command {
+public class DeleteCommand extends ReversibleCommand {
 
     public static final String COMMAND_WORD = "delete";
 
@@ -22,6 +24,7 @@ public class DeleteCommand extends Command {
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
 
     public final int targetIndex;
+    private ReadOnlyAddressBook previousAddressBook;
 
     public DeleteCommand(int targetIndex) {
         this.targetIndex = targetIndex;
@@ -40,6 +43,7 @@ public class DeleteCommand extends Command {
         ReadOnlyPerson personToDelete = lastShownList.get(IndexUtil.oneToZeroIndex(targetIndex));
 
         try {
+            previousAddressBook = new AddressBook(model.getAddressBook());
             model.deletePerson(personToDelete);
         } catch (PersonNotFoundException pnfe) {
             assert false : "The target person cannot be missing";
@@ -48,4 +52,9 @@ public class DeleteCommand extends Command {
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete));
     }
 
+    @Override
+    public void undo() {
+        assert previousAddressBook != null;
+        model.resetData(previousAddressBook);
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -8,6 +8,8 @@ import seedu.address.commons.core.Messages;
 import seedu.address.commons.util.CollectionUtil;
 import seedu.address.commons.util.IndexUtil;
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.AddressBook;
+import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
@@ -20,7 +22,7 @@ import seedu.address.model.tag.Tag;
 /**
  * Edits the details of an existing person in the address book.
  */
-public class EditCommand extends Command {
+public class EditCommand extends ReversibleCommand {
 
     public static final String COMMAND_WORD = "edit";
 
@@ -36,6 +38,7 @@ public class EditCommand extends Command {
 
     private final int filteredPersonListIndex;
     private final EditPersonDescriptor editPersonDescriptor;
+    private ReadOnlyAddressBook previousAddressBook;
 
     /**
      * @param filteredPersonListIndex the index of the person in the filtered person list to edit
@@ -61,12 +64,19 @@ public class EditCommand extends Command {
         Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
 
         try {
+            previousAddressBook = new AddressBook(model.getAddressBook());
             model.updatePerson(filteredPersonListIndex, editedPerson);
         } catch (UniquePersonList.DuplicatePersonException dpe) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
         model.updateFilteredListToShowAll();
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, personToEdit));
+    }
+
+    @Override
+    public void undo() {
+        assert previousAddressBook != null;
+        model.resetData(previousAddressBook);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/RedoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RedoCommand.java
@@ -1,0 +1,33 @@
+package seedu.address.logic.commands;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+
+/**
+ * Clears the address book.
+ */
+public class RedoCommand extends Command {
+
+    public static final String COMMAND_WORD = "redo";
+    public static final String MESSAGE_SUCCESS = "Redo success!";
+    public static final String MESSAGE_FAILURE = "There's no more commands left to be redone!";
+
+    private Command nextCommand;
+
+    public RedoCommand(ReversibleCommand command) {
+        nextCommand = command;
+    }
+
+    @Override
+    public CommandResult execute() {
+        assert model != null;
+        assert nextCommand != null;
+
+        try {
+            nextCommand.execute();
+        } catch (CommandException e) {
+            assert false : "";
+        }
+
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/ReversibleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ReversibleCommand.java
@@ -1,0 +1,5 @@
+package seedu.address.logic.commands;
+
+public abstract class ReversibleCommand extends Command {
+    public abstract void undo();
+}

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -1,0 +1,26 @@
+package seedu.address.logic.commands;
+
+/**
+ * Clears the address book.
+ */
+public class UndoCommand extends Command {
+
+    public static final String COMMAND_WORD = "undo";
+    public static final String MESSAGE_SUCCESS = "Undo success!";
+    public static final String MESSAGE_FAILURE = "There's no more commands left to be undone!";
+
+    private ReversibleCommand previousCommand;
+
+    public UndoCommand(ReversibleCommand command) {
+        previousCommand = command;
+    }
+
+    @Override
+    public CommandResult execute() {
+        assert model != null;
+        assert previousCommand != null;
+
+        previousCommand.undo();
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/Parser.java
+++ b/src/main/java/seedu/address/logic/parser/Parser.java
@@ -6,6 +6,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import seedu.address.logic.History;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
@@ -16,7 +17,9 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.IncorrectCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.SelectCommand;
+import seedu.address.logic.commands.UndoCommand;
 
 /**
  * Parses user input.
@@ -27,6 +30,11 @@ public class Parser {
      * Used for initial separation of command word and args.
      */
     private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+)(?<arguments>.*)");
+    private History history;
+
+    public Parser(History history) {
+        this.history = history;
+    }
 
     /**
      * Parses user input into command for execution.
@@ -70,6 +78,12 @@ public class Parser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case UndoCommand.COMMAND_WORD:
+            return new UndoCommandParser(history).parse();
+
+        case RedoCommand.COMMAND_WORD:
+            return new RedoCommandParser(history).parse();
 
         default:
             return new IncorrectCommand(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/RedoCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/RedoCommandParser.java
@@ -1,0 +1,27 @@
+package seedu.address.logic.parser;
+
+import java.util.Optional;
+
+import seedu.address.logic.History;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.IncorrectCommand;
+import seedu.address.logic.commands.RedoCommand;
+import seedu.address.logic.commands.ReversibleCommand;
+
+public class RedoCommandParser {
+
+    private History history;
+
+    public RedoCommandParser(History history) {
+        this.history = history;
+    }
+
+    public Command parse() {
+        Optional<ReversibleCommand> command = history.getNextCommand();
+        if (command.isPresent()) {
+            return new RedoCommand(command.get());
+        } else {
+            return new IncorrectCommand(RedoCommand.MESSAGE_FAILURE);
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/UndoCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UndoCommandParser.java
@@ -1,0 +1,27 @@
+package seedu.address.logic.parser;
+
+import java.util.Optional;
+
+import seedu.address.logic.History;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.IncorrectCommand;
+import seedu.address.logic.commands.ReversibleCommand;
+import seedu.address.logic.commands.UndoCommand;
+
+public class UndoCommandParser {
+
+    private History history;
+
+    public UndoCommandParser(History history) {
+        this.history = history;
+    }
+
+    public Command parse() {
+        Optional<ReversibleCommand> command = history.getPreviousCommand();
+        if (command.isPresent()) {
+            return new UndoCommand(command.get());
+        } else {
+            return new IncorrectCommand(UndoCommand.MESSAGE_FAILURE);
+        }
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/EditCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandIntegrationTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 import org.junit.Test;
 
 import seedu.address.commons.core.Messages;
+import seedu.address.logic.HistoryManager;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.Parser;
 import seedu.address.model.AddressBook;
@@ -31,7 +32,7 @@ public class EditCommandIntegrationTest {
     private static final int ZERO_BASED_INDEX_SECOND_PERSON =  ZERO_BASED_INDEX_FIRST_PERSON + 1;
 
     private Model model = new ModelManager(new TypicalPersons().getTypicalAddressBook(), new UserPrefs());
-    private Parser parser = new Parser();
+    private Parser parser = new Parser(new HistoryManager());
 
     @Test
     public void execute_validCommand_succeeds() throws Exception {


### PR DESCRIPTION
This is done in a hackish manner, and the rough architecture is laid out here.

The undoing of Delete, Clear and Edit commands are the same (I just stored the previous AddressBook state) because properly implementing it requires much more editing of Model / ModelManager / AddressBook which will get quite messy, and is unnecessary now since we are just looking through the architecture.

The main highlights are:

1. Each `ReversibleCommand` stores the values that it requires to undo itself. For example, when properly implemented, the `DeleteCommand` will store `deletedPerson` and `indexOfDeletedPerson`.

2. Parser now has a `History` object (referencing the `HistoryManager` in `LogicManager`), and Parser passes this `History` object to `UndoCommandParser` and `RedoCommandParser`. This may seem kinda weird, but my opinion is that this is the best way to do it. Other possible ways include:

- Remove entirely `UndoCommandParser` and `RedoCommandParser` since they don't really do much. We can put the logic of these parsers into the commands' constructor.

- Let `LogicManager` do the logic of `UndoCommandParser` and `RedoCommandParser`; after the line `Command command = parser.parse..` in `LogicManager`, then `LogicManager` checks if the command is `undo / redo`. If true, `LogicManager` will then execute undo / redo respectively. This means more logic inside `LogicManager`, and it seems like `LogicManager` will handle a lot of low-level things which seems wrong. The plus point however is that Parser has no need to store a reference to the `History` object.