### PR TITLE
Use StackPanes for holding UiParts #309

### DIFF
--- a/src/main/java/seedu/address/commons/util/FxViewUtil.java
+++ b/src/main/java/seedu/address/commons/util/FxViewUtil.java
@@ -1,20 +1,11 @@
 package seedu.address.commons.util;
 
-import javafx.scene.Node;
-import javafx.scene.layout.AnchorPane;
 import javafx.stage.Stage;
 
 /**
  * Contains utility methods for JavaFX views
  */
 public class FxViewUtil {
-
-    public static void applyAnchorBoundaryParameters(Node node, double left, double right, double top, double bottom) {
-        AnchorPane.setBottomAnchor(node, bottom);
-        AnchorPane.setLeftAnchor(node, left);
-        AnchorPane.setRightAnchor(node, right);
-        AnchorPane.setTopAnchor(node, top);
-    }
 
     /**
      * Sets the given image as the icon for the given stage.

--- a/src/main/java/seedu/address/ui/BrowserPanel.java
+++ b/src/main/java/seedu/address/ui/BrowserPanel.java
@@ -4,11 +4,10 @@ import java.net.URL;
 
 import javafx.event.Event;
 import javafx.fxml.FXML;
-import javafx.scene.layout.AnchorPane;
+import javafx.scene.layout.Pane;
 import javafx.scene.layout.Region;
 import javafx.scene.web.WebView;
 import seedu.address.MainApp;
-import seedu.address.commons.util.FxViewUtil;
 import seedu.address.model.person.ReadOnlyPerson;
 
 /**
@@ -23,15 +22,14 @@ public class BrowserPanel extends UiPart<Region> {
     private WebView browser;
 
     /**
-     * @param placeholder The AnchorPane where the BrowserPanel must be inserted
+     * @param placeholder The Pane where the BrowserPanel must be inserted
      */
-    public BrowserPanel(AnchorPane placeholder) {
+    public BrowserPanel(Pane placeholder) {
         super(FXML);
 
         // To prevent triggering events for typing inside the loaded Web page.
         placeholder.setOnKeyPressed(Event::consume);
 
-        FxViewUtil.applyAnchorBoundaryParameters(browser, 0.0, 0.0, 0.0, 0.0);
         placeholder.getChildren().add(browser);
 
         loadDefaultPage();

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -6,11 +6,10 @@ import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.SplitPane;
 import javafx.scene.control.TextField;
-import javafx.scene.layout.AnchorPane;
+import javafx.scene.layout.Pane;
 import javafx.scene.layout.Region;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.events.ui.NewResultAvailableEvent;
-import seedu.address.commons.util.FxViewUtil;
 import seedu.address.logic.Logic;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -26,17 +25,15 @@ public class CommandBox extends UiPart<Region> {
     @FXML
     private TextField commandTextField;
 
-    public CommandBox(AnchorPane commandBoxPlaceholder, Logic logic) {
+    public CommandBox(Pane commandBoxPlaceholder, Logic logic) {
         super(FXML);
         this.logic = logic;
         addToPlaceholder(commandBoxPlaceholder);
     }
 
-    private void addToPlaceholder(AnchorPane placeHolderPane) {
+    private void addToPlaceholder(Pane placeHolderPane) {
         SplitPane.setResizableWithParent(placeHolderPane, false);
         placeHolderPane.getChildren().add(commandTextField);
-        FxViewUtil.applyAnchorBoundaryParameters(getRoot(), 0.0, 0.0, 0.0, 0.0);
-        FxViewUtil.applyAnchorBoundaryParameters(commandTextField, 0.0, 0.0, 0.0, 0.0);
     }
 
     @FXML

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -36,7 +36,6 @@ public class HelpWindow extends UiPart<Region> {
         FxViewUtil.setStageIcon(dialogStage, ICON);
 
         browser.getEngine().load(USERGUIDE_URL);
-        FxViewUtil.applyAnchorBoundaryParameters(browser, 0.0, 0.0, 0.0, 0.0);
     }
 
     public void show() {

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -43,7 +43,7 @@ public class MainWindow extends UiPart<Region> {
     private StackPane browserPlaceholder;
 
     @FXML
-    private AnchorPane commandBoxPlaceholder;
+    private StackPane commandBoxPlaceholder;
 
     @FXML
     private MenuItem helpMenuItem;
@@ -123,7 +123,7 @@ public class MainWindow extends UiPart<Region> {
         new CommandBox(getCommandBoxPlaceholder(), logic);
     }
 
-    private AnchorPane getCommandBoxPlaceholder() {
+    private StackPane getCommandBoxPlaceholder() {
         return commandBoxPlaceholder;
     }
 

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -9,6 +9,7 @@ import javafx.scene.input.KeyCombination;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.Region;
+import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 import seedu.address.commons.core.Config;
 import seedu.address.commons.core.GuiSettings;
@@ -39,7 +40,7 @@ public class MainWindow extends UiPart<Region> {
     private UserPrefs prefs;
 
     @FXML
-    private AnchorPane browserPlaceholder;
+    private StackPane browserPlaceholder;
 
     @FXML
     private AnchorPane commandBoxPlaceholder;

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -7,7 +7,6 @@ import javafx.scene.control.MenuItem;
 import javafx.scene.control.TextInputControl;
 import javafx.scene.input.KeyCombination;
 import javafx.scene.input.KeyEvent;
-import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
@@ -55,7 +54,7 @@ public class MainWindow extends UiPart<Region> {
     private StackPane resultDisplayPlaceholder;
 
     @FXML
-    private AnchorPane statusbarPlaceholder;
+    private StackPane statusbarPlaceholder;
 
     public MainWindow(Stage primaryStage, Config config, UserPrefs prefs, Logic logic) {
         super(FXML);
@@ -127,7 +126,7 @@ public class MainWindow extends UiPart<Region> {
         return commandBoxPlaceholder;
     }
 
-    private AnchorPane getStatusbarPlaceholder() {
+    private StackPane getStatusbarPlaceholder() {
         return statusbarPlaceholder;
     }
 

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -52,7 +52,7 @@ public class MainWindow extends UiPart<Region> {
     private StackPane personListPanelPlaceholder;
 
     @FXML
-    private AnchorPane resultDisplayPlaceholder;
+    private StackPane resultDisplayPlaceholder;
 
     @FXML
     private AnchorPane statusbarPlaceholder;
@@ -131,7 +131,7 @@ public class MainWindow extends UiPart<Region> {
         return statusbarPlaceholder;
     }
 
-    private AnchorPane getResultDisplayPlaceholder() {
+    private StackPane getResultDisplayPlaceholder() {
         return resultDisplayPlaceholder;
     }
 

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -49,7 +49,7 @@ public class MainWindow extends UiPart<Region> {
     private MenuItem helpMenuItem;
 
     @FXML
-    private AnchorPane personListPanelPlaceholder;
+    private StackPane personListPanelPlaceholder;
 
     @FXML
     private AnchorPane resultDisplayPlaceholder;
@@ -135,7 +135,7 @@ public class MainWindow extends UiPart<Region> {
         return resultDisplayPlaceholder;
     }
 
-    private AnchorPane getPersonListPlaceholder() {
+    private StackPane getPersonListPlaceholder() {
         return personListPanelPlaceholder;
     }
 

--- a/src/main/java/seedu/address/ui/PersonListPanel.java
+++ b/src/main/java/seedu/address/ui/PersonListPanel.java
@@ -8,11 +8,10 @@ import javafx.fxml.FXML;
 import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import javafx.scene.control.SplitPane;
-import javafx.scene.layout.AnchorPane;
+import javafx.scene.layout.Pane;
 import javafx.scene.layout.Region;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.events.ui.PersonPanelSelectionChangedEvent;
-import seedu.address.commons.util.FxViewUtil;
 import seedu.address.model.person.ReadOnlyPerson;
 
 /**
@@ -25,7 +24,7 @@ public class PersonListPanel extends UiPart<Region> {
     @FXML
     private ListView<ReadOnlyPerson> personListView;
 
-    public PersonListPanel(AnchorPane personListPlaceholder, ObservableList<ReadOnlyPerson> personList) {
+    public PersonListPanel(Pane personListPlaceholder, ObservableList<ReadOnlyPerson> personList) {
         super(FXML);
         setConnections(personList);
         addToPlaceholder(personListPlaceholder);
@@ -37,9 +36,8 @@ public class PersonListPanel extends UiPart<Region> {
         setEventHandlerForSelectionChangeEvent();
     }
 
-    private void addToPlaceholder(AnchorPane placeHolderPane) {
+    private void addToPlaceholder(Pane placeHolderPane) {
         SplitPane.setResizableWithParent(placeHolderPane, false);
-        FxViewUtil.applyAnchorBoundaryParameters(getRoot(), 0.0, 0.0, 0.0, 0.0);
         placeHolderPane.getChildren().add(getRoot());
     }
 

--- a/src/main/java/seedu/address/ui/ResultDisplay.java
+++ b/src/main/java/seedu/address/ui/ResultDisplay.java
@@ -8,11 +8,10 @@ import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.fxml.FXML;
 import javafx.scene.control.TextArea;
-import javafx.scene.layout.AnchorPane;
+import javafx.scene.layout.Pane;
 import javafx.scene.layout.Region;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.events.ui.NewResultAvailableEvent;
-import seedu.address.commons.util.FxViewUtil;
 
 /**
  * A ui for the status bar that is displayed at the header of the application.
@@ -25,17 +24,12 @@ public class ResultDisplay extends UiPart<Region> {
     private final StringProperty displayed = new SimpleStringProperty("");
 
     @FXML
-    private AnchorPane mainPane;
-
-    @FXML
     private TextArea resultDisplay;
 
-    public ResultDisplay(AnchorPane placeHolder) {
+    public ResultDisplay(Pane placeHolder) {
         super(FXML);
         resultDisplay.textProperty().bind(displayed);
-        FxViewUtil.applyAnchorBoundaryParameters(resultDisplay, 0.0, 0.0, 0.0, 0.0);
-        FxViewUtil.applyAnchorBoundaryParameters(mainPane, 0.0, 0.0, 0.0, 0.0);
-        placeHolder.getChildren().add(mainPane);
+        placeHolder.getChildren().add(resultDisplay);
         registerAsAnEventHandler(this);
     }
 

--- a/src/main/java/seedu/address/ui/StatusBarFooter.java
+++ b/src/main/java/seedu/address/ui/StatusBarFooter.java
@@ -9,11 +9,10 @@ import org.controlsfx.control.StatusBar;
 import com.google.common.eventbus.Subscribe;
 
 import javafx.fxml.FXML;
-import javafx.scene.layout.AnchorPane;
+import javafx.scene.layout.Pane;
 import javafx.scene.layout.Region;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.events.model.AddressBookChangedEvent;
-import seedu.address.commons.util.FxViewUtil;
 
 /**
  * A ui for the status bar that is displayed at the footer of the application.
@@ -43,7 +42,7 @@ public class StatusBarFooter extends UiPart<Region> {
     private StatusBar saveLocationStatus;
 
 
-    public StatusBarFooter(AnchorPane placeHolder, String saveLocation) {
+    public StatusBarFooter(Pane placeHolder, String saveLocation) {
         super(FXML);
         addToPlaceholder(placeHolder);
         setSyncStatus(SYNC_STATUS_INITIAL);
@@ -65,8 +64,7 @@ public class StatusBarFooter extends UiPart<Region> {
         return clock;
     }
 
-    private void addToPlaceholder(AnchorPane placeHolder) {
-        FxViewUtil.applyAnchorBoundaryParameters(getRoot(), 0.0, 0.0, 0.0, 0.0);
+    private void addToPlaceholder(Pane placeHolder) {
         placeHolder.getChildren().add(getRoot());
     }
 

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -135,13 +135,7 @@
      -fx-background-color: derive(#1d1d1d, 20%);
 }
 
-.anchor-pane-with-border {
-     -fx-background-color: derive(#1d1d1d, 20%);
-     -fx-border-color: derive(#1d1d1d, 10%);
-     -fx-border-top-width: 1px;
-}
-
-.stack-pane-with-border {
+.pane-with-border {
      -fx-background-color: derive(#1d1d1d, 20%);
      -fx-border-color: derive(#1d1d1d, 10%);
      -fx-border-top-width: 1px;

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -141,6 +141,12 @@
      -fx-border-top-width: 1px;
 }
 
+.stack-pane-with-border {
+     -fx-background-color: derive(#1d1d1d, 20%);
+     -fx-border-color: derive(#1d1d1d, 10%);
+     -fx-border-top-width: 1px;
+}
+
 .status-bar {
     -fx-background-color: derive(#1d1d1d, 20%);
     -fx-text-fill: black;

--- a/src/main/resources/view/HelpWindow.fxml
+++ b/src/main/resources/view/HelpWindow.fxml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.scene.layout.AnchorPane?>
+<?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.web.WebView?>
 
-<AnchorPane fx:id="helpWindowRoot" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+<StackPane fx:id="helpWindowRoot" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
   <WebView fx:id="browser" />
-</AnchorPane>
+</StackPane>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -7,6 +7,7 @@
 <?import javafx.scene.control.MenuItem?>
 <?import javafx.scene.control.SplitPane?>
 <?import javafx.scene.layout.AnchorPane?>
+<?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 
 <VBox xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
@@ -45,11 +46,11 @@
       <AnchorPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS" />
     </VBox>
 
-    <AnchorPane fx:id="browserPlaceholder" prefWidth="340" >
+    <StackPane fx:id="browserPlaceholder" prefWidth="340" >
       <padding>
         <Insets top="10" right="10" bottom="10" left="10" />
       </padding>
-    </AnchorPane>
+    </StackPane>
   </SplitPane>
 
   <AnchorPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER" />

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -31,12 +31,12 @@
     </padding>
   </StackPane>
 
-  <AnchorPane VBox.vgrow="NEVER" fx:id="resultDisplayPlaceholder" styleClass="anchor-pane-with-border"
+  <StackPane VBox.vgrow="NEVER" fx:id="resultDisplayPlaceholder" styleClass="stack-pane-with-border"
       minHeight="100" prefHeight="100" maxHeight="100">
     <padding>
       <Insets top="5" right="10" bottom="5" left="10" />
     </padding>
-  </AnchorPane>
+  </StackPane>
 
   <SplitPane id="splitPane" fx:id="splitPane" dividerPositions="0.4" VBox.vgrow="ALWAYS">
     <VBox fx:id="personList" minWidth="340" prefWidth="340">

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -25,11 +25,11 @@
     </Menu>
   </MenuBar>
 
-  <AnchorPane VBox.vgrow="NEVER" fx:id="commandBoxPlaceholder" styleClass="anchor-pane-with-border">
+  <StackPane VBox.vgrow="NEVER" fx:id="commandBoxPlaceholder" styleClass="stack-pane-with-border">
     <padding>
       <Insets top="5" right="10" bottom="5" left="10" />
     </padding>
-  </AnchorPane>
+  </StackPane>
 
   <AnchorPane VBox.vgrow="NEVER" fx:id="resultDisplayPlaceholder" styleClass="anchor-pane-with-border"
       minHeight="100" prefHeight="100" maxHeight="100">

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -43,7 +43,7 @@
       <padding>
         <Insets top="10" right="10" bottom="10" left="10" />
       </padding>
-      <AnchorPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS" />
+      <StackPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS" />
     </VBox>
 
     <StackPane fx:id="browserPlaceholder" prefWidth="340" >

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -24,13 +24,13 @@
     </Menu>
   </MenuBar>
 
-  <StackPane VBox.vgrow="NEVER" fx:id="commandBoxPlaceholder" styleClass="stack-pane-with-border">
+  <StackPane VBox.vgrow="NEVER" fx:id="commandBoxPlaceholder" styleClass="pane-with-border">
     <padding>
       <Insets top="5" right="10" bottom="5" left="10" />
     </padding>
   </StackPane>
 
-  <StackPane VBox.vgrow="NEVER" fx:id="resultDisplayPlaceholder" styleClass="stack-pane-with-border"
+  <StackPane VBox.vgrow="NEVER" fx:id="resultDisplayPlaceholder" styleClass="pane-with-border"
       minHeight="100" prefHeight="100" maxHeight="100">
     <padding>
       <Insets top="5" right="10" bottom="5" left="10" />

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -6,7 +6,6 @@
 <?import javafx.scene.control.MenuBar?>
 <?import javafx.scene.control.MenuItem?>
 <?import javafx.scene.control.SplitPane?>
-<?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 
@@ -53,5 +52,5 @@
     </StackPane>
   </SplitPane>
 
-  <AnchorPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER" />
+  <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER" />
 </VBox>

--- a/src/main/resources/view/ResultDisplay.fxml
+++ b/src/main/resources/view/ResultDisplay.fxml
@@ -3,7 +3,7 @@
 <?import javafx.scene.control.TextArea?>
 <?import javafx.scene.layout.AnchorPane?>
 
-<AnchorPane fx:id="placeHolder" styleClass="anchor-pane-with-border" xmlns="http://javafx.com/javafx/8"
+<AnchorPane fx:id="placeHolder" styleClass="pane-with-border" xmlns="http://javafx.com/javafx/8"
     xmlns:fx="http://javafx.com/fxml/1">
   <TextArea fx:id="resultDisplay" editable="false" styleClass="result-display" />
 </AnchorPane>

--- a/src/main/resources/view/ResultDisplay.fxml
+++ b/src/main/resources/view/ResultDisplay.fxml
@@ -5,7 +5,5 @@
 
 <AnchorPane fx:id="placeHolder" styleClass="anchor-pane-with-border" xmlns="http://javafx.com/javafx/8"
     xmlns:fx="http://javafx.com/fxml/1">
-  <AnchorPane fx:id="mainPane">
-    <TextArea fx:id="resultDisplay" editable="false" styleClass="result-display" />
-  </AnchorPane>
+  <TextArea fx:id="resultDisplay" editable="false" styleClass="result-display" />
 </AnchorPane>


### PR DESCRIPTION
Fixes #309.

Proposed merge commit message:
```
MainWindow uses AnchorPanes as a placeholder for UiParts. AnchorPane's
default behavior does not make its children fill up the entire space,
thus we have to manually call FxViewUtil#applyAnchorBoundaryParameters()
to do so.

StackPane's default behavior fills up the entire placeholder space
automatically.

Let's
  - replace the usage of AnchorPane with StackPane.
  - remove FxViewUtil#applyAnchorBoundaryParameters(), since we no
    longer have to manually fill up the entire space.
```