### PR TITLE
Reduce unnecessary asserts #239

### DIFF
--- a/src/main/java/seedu/address/commons/core/UnmodifiableObservableList.java
+++ b/src/main/java/seedu/address/commons/core/UnmodifiableObservableList.java
@@ -1,5 +1,7 @@
 package seedu.address.commons.core;
 
+import static java.util.Objects.requireNonNull;
+
 import java.text.Collator;
 import java.util.Collection;
 import java.util.Collections;
@@ -28,8 +30,7 @@ public class UnmodifiableObservableList<E> implements ObservableList<E> {
     private final ObservableList<? extends E> backingList;
 
     public UnmodifiableObservableList(ObservableList<? extends E> backingList) {
-        assert backingList != null;
-        this.backingList = backingList;
+        this.backingList = requireNonNull(backingList);
     }
 
     @Override

--- a/src/main/java/seedu/address/commons/util/AppUtil.java
+++ b/src/main/java/seedu/address/commons/util/AppUtil.java
@@ -1,5 +1,7 @@
 package seedu.address.commons.util;
 
+import static java.util.Objects.requireNonNull;
+
 import javafx.scene.image.Image;
 import seedu.address.MainApp;
 
@@ -9,8 +11,29 @@ import seedu.address.MainApp;
 public class AppUtil {
 
     public static Image getImage(String imagePath) {
-        assert imagePath != null;
+        requireNonNull(imagePath);
         return new Image(MainApp.class.getResourceAsStream(imagePath));
     }
 
+    /**
+     * Checks that {@code condition} is true. Used for validating arguments to methods.
+     *
+     * @throws IllegalArgumentException if {@code condition} is false.
+     */
+    public static void checkArgument(Boolean condition) {
+        if (!condition) {
+            throw new IllegalArgumentException();
+        }
+    }
+
+    /**
+     * Checks that {@code condition} is true. Used for validating arguments to methods.
+     *
+     * @throws IllegalArgumentException with {@code errorMessage} if {@code condition} is false.
+     */
+    public static void checkArgument(Boolean condition, String errorMessage) {
+        if (!condition) {
+            throw new IllegalArgumentException(errorMessage);
+        }
+    }
 }

--- a/src/main/java/seedu/address/commons/util/CollectionUtil.java
+++ b/src/main/java/seedu/address/commons/util/CollectionUtil.java
@@ -12,17 +12,18 @@ import java.util.stream.Stream;
  */
 public class CollectionUtil {
 
-    /** @see #isAnyNull(Collection) */
-    public static boolean isAnyNull(Object... items) {
-        return Stream.of(items).anyMatch(Objects::isNull);
+    /** @see #requireAllNonNull(Collection) */
+    public static void requireAllNonNull(Object... items) {
+        Objects.requireNonNull(items);
+        Stream.of(items).forEach(Objects::requireNonNull);
     }
 
     /**
-     * Returns true if any element of {@code items} is null.
-     * @throws NullPointerException if {@code items} itself is null.
+     * Throws NullPointerException if {@code items} or any element of {@code items} is null.
      */
-    public static boolean isAnyNull(Collection<?> items) {
-        return items.stream().anyMatch(Objects::isNull);
+    public static void requireAllNonNull(Collection<?> items) {
+        Objects.requireNonNull(items);
+        items.forEach(Objects::requireNonNull);
     }
 
     /**

--- a/src/main/java/seedu/address/commons/util/FileUtil.java
+++ b/src/main/java/seedu/address/commons/util/FileUtil.java
@@ -1,5 +1,7 @@
 package seedu.address.commons.util;
 
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -80,8 +82,7 @@ public class FileUtil {
      * @return {@code pathWithForwardSlash} but '/' replaced with {@code File.separator}
      */
     public static String getPath(String pathWithForwardSlash) {
-        assert pathWithForwardSlash != null;
-        assert pathWithForwardSlash.contains("/");
+        checkArgument(pathWithForwardSlash.contains("/"));
         return pathWithForwardSlash.replace("/", File.separator);
     }
 

--- a/src/main/java/seedu/address/commons/util/JsonUtil.java
+++ b/src/main/java/seedu/address/commons/util/JsonUtil.java
@@ -1,5 +1,7 @@
 package seedu.address.commons.util;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.Optional;
@@ -54,9 +56,7 @@ public class JsonUtil {
      */
     public static <T> Optional<T> readJsonFile(
             String filePath, Class<T> classOfObjectToDeserialize) throws DataConversionException {
-
-        assert filePath != null;
-
+        requireNonNull(filePath);
         File file = new File(filePath);
 
         if (!file.exists()) {
@@ -84,8 +84,8 @@ public class JsonUtil {
      * @throws IOException if there was an error during writing to the file
      */
     public static <T> void saveJsonFile(T jsonFile, String filePath) throws IOException {
-        assert jsonFile != null;
-        assert filePath != null;
+        requireNonNull(filePath);
+        requireNonNull(jsonFile);
 
         serializeObjectToJsonFile(new File(filePath), jsonFile);
     }

--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -1,5 +1,8 @@
 package seedu.address.commons.util;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
 import java.io.PrintWriter;
 import java.io.StringWriter;
 
@@ -20,12 +23,12 @@ public class StringUtil {
      * @param word cannot be null, cannot be empty, must be a single word
      */
     public static boolean containsWordIgnoreCase(String sentence, String word) {
-        assert word != null : "Word parameter cannot be null";
-        assert sentence != null : "Sentence parameter cannot be null";
+        requireNonNull(sentence);
+        requireNonNull(word);
 
         String preppedWord = word.trim();
-        assert !preppedWord.isEmpty() : "Word parameter cannot be empty";
-        assert preppedWord.split("\\s+").length == 1 : "Word parameter should be a single word";
+        checkArgument(!preppedWord.isEmpty(), "Word parameter cannot be empty");
+        checkArgument(preppedWord.split("\\s+").length == 1, "Word parameter should be a single word");
 
         String preppedSentence = sentence;
         String[] wordsInPreppedSentence = preppedSentence.split("\\s+");
@@ -42,7 +45,7 @@ public class StringUtil {
      * Returns a detailed message of the t, including the stack trace.
      */
     public static String getDetails(Throwable t) {
-        assert t != null;
+        requireNonNull(t);
         StringWriter sw = new StringWriter();
         t.printStackTrace(new PrintWriter(sw));
         return t.getMessage() + "\n" + sw.toString();

--- a/src/main/java/seedu/address/commons/util/XmlUtil.java
+++ b/src/main/java/seedu/address/commons/util/XmlUtil.java
@@ -1,5 +1,7 @@
 package seedu.address.commons.util;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 
@@ -27,8 +29,8 @@ public class XmlUtil {
     public static <T> T getDataFromFile(File file, Class<T> classToConvert)
             throws FileNotFoundException, JAXBException {
 
-        assert file != null;
-        assert classToConvert != null;
+        requireNonNull(file);
+        requireNonNull(classToConvert);
 
         if (!FileUtil.isFileExists(file)) {
             throw new FileNotFoundException("File not found : " + file.getAbsolutePath());
@@ -51,8 +53,8 @@ public class XmlUtil {
      */
     public static <T> void saveDataToFile(File file, T data) throws FileNotFoundException, JAXBException {
 
-        assert file != null;
-        assert data != null;
+        requireNonNull(file);
+        requireNonNull(data);
 
         if (!file.exists()) {
             throw new FileNotFoundException("File not found : " + file.getAbsolutePath());

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
@@ -44,7 +45,7 @@ public class AddCommand extends Command {
 
     @Override
     public CommandResult execute() throws CommandException {
-        assert model != null;
+        requireNonNull(model);
         try {
             model.addPerson(toAdd);
             return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -1,5 +1,7 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+
 import seedu.address.model.AddressBook;
 
 /**
@@ -13,7 +15,7 @@ public class ClearCommand extends Command {
 
     @Override
     public CommandResult execute() {
-        assert model != null;
+        requireNonNull(model);
         model.resetData(new AddressBook());
         return new CommandResult(MESSAGE_SUCCESS);
     }

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -1,5 +1,7 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * Represents the result of a command execution.
  */
@@ -8,8 +10,7 @@ public class CommandResult {
     public final String feedbackToUser;
 
     public CommandResult(String feedbackToUser) {
-        assert feedbackToUser != null;
-        this.feedbackToUser = feedbackToUser;
+        this.feedbackToUser = requireNonNull(feedbackToUser);
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -1,5 +1,7 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
@@ -53,8 +55,8 @@ public class EditCommand extends Command {
      * @param editPersonDescriptor details to edit the person with
      */
     public EditCommand(int filteredPersonListIndex, EditPersonDescriptor editPersonDescriptor) {
-        assert filteredPersonListIndex > 0;
-        assert editPersonDescriptor != null;
+        checkArgument(filteredPersonListIndex > 0);
+        requireNonNull(editPersonDescriptor);
 
         this.filteredPersonListIndex = IndexUtil.oneToZeroIndex(filteredPersonListIndex);
         this.editPersonDescriptor = new EditPersonDescriptor(editPersonDescriptor);
@@ -144,8 +146,7 @@ public class EditCommand extends Command {
         }
 
         public void setName(Optional<Name> name) {
-            assert name != null;
-            this.name = name;
+            this.name = requireNonNull(name);
         }
 
         public Optional<Name> getName() {
@@ -153,8 +154,7 @@ public class EditCommand extends Command {
         }
 
         public void setPhone(Optional<Phone> phone) {
-            assert phone != null;
-            this.phone = phone;
+            this.phone = requireNonNull(phone);
         }
 
         public Optional<Phone> getPhone() {
@@ -162,8 +162,7 @@ public class EditCommand extends Command {
         }
 
         public void setEmail(Optional<Email> email) {
-            assert email != null;
-            this.email = email;
+            this.email = requireNonNull(email);
         }
 
         public Optional<Email> getEmail() {
@@ -171,8 +170,7 @@ public class EditCommand extends Command {
         }
 
         public void setAddress(Optional<Address> address) {
-            assert address != null;
-            this.address = address;
+            this.address = requireNonNull(address);
         }
 
         public Optional<Address> getAddress() {
@@ -180,8 +178,7 @@ public class EditCommand extends Command {
         }
 
         public void setTags(Optional<Set<Tag>> tags) {
-            assert tags != null;
-            this.tags = tags;
+            this.tags = requireNonNull(tags);
         }
 
         public Optional<Set<Tag>> getTags() {

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
@@ -29,7 +30,7 @@ public class EditCommandParser {
      * @throws ParseException if the user input does not conform the expected format
      */
     public EditCommand parse(String args) throws ParseException {
-        assert args != null;
+        requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
         List<Optional<String>> preambleFields = ParserUtil.splitPreamble(argMultimap.getPreamble(), 2);

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -1,5 +1,7 @@
 package seedu.address.logic.parser;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
@@ -49,7 +51,7 @@ public class ParserUtil {
      * Parses a {@code Optional<String> name} into an {@code Optional<Name>} if {@code name} is present.
      */
     public static Optional<Name> parseName(Optional<String> name) throws IllegalValueException {
-        assert name != null;
+        requireNonNull(name);
         return name.isPresent() ? Optional.of(new Name(name.get())) : Optional.empty();
     }
 
@@ -57,7 +59,7 @@ public class ParserUtil {
      * Parses a {@code Optional<String> phone} into an {@code Optional<Phone>} if {@code phone} is present.
      */
     public static Optional<Phone> parsePhone(Optional<String> phone) throws IllegalValueException {
-        assert phone != null;
+        requireNonNull(phone);
         return phone.isPresent() ? Optional.of(new Phone(phone.get())) : Optional.empty();
     }
 
@@ -65,7 +67,7 @@ public class ParserUtil {
      * Parses a {@code Optional<String> address} into an {@code Optional<Address>} if {@code address} is present.
      */
     public static Optional<Address> parseAddress(Optional<String> address) throws IllegalValueException {
-        assert address != null;
+        requireNonNull(address);
         return address.isPresent() ? Optional.of(new Address(address.get())) : Optional.empty();
     }
 
@@ -73,7 +75,7 @@ public class ParserUtil {
      * Parses a {@code Optional<String> email} into an {@code Optional<Email>} if {@code email} is present.
      */
     public static Optional<Email> parseEmail(Optional<String> email) throws IllegalValueException {
-        assert email != null;
+        requireNonNull(email);
         return email.isPresent() ? Optional.of(new Email(email.get())) : Optional.empty();
     }
 
@@ -81,7 +83,7 @@ public class ParserUtil {
      * Parses {@code Collection<String> tags} into a {@code Set<Tag>}.
      */
     public static Set<Tag> parseTags(Collection<String> tags) throws IllegalValueException {
-        assert tags != null;
+        requireNonNull(tags);
         final Set<Tag> tagSet = new HashSet<>();
         for (String tagName : tags) {
             tagSet.add(new Tag(tagName));

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -1,5 +1,7 @@
 package seedu.address.model;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -60,7 +62,7 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     public void resetData(ReadOnlyAddressBook newData) {
-        assert newData != null;
+        requireNonNull(newData);
         try {
             setPersons(newData.getPersonList());
         } catch (UniquePersonList.DuplicatePersonException e) {
@@ -101,7 +103,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void updatePerson(int index, ReadOnlyPerson editedReadOnlyPerson)
             throws UniquePersonList.DuplicatePersonException {
-        assert editedReadOnlyPerson != null;
+        requireNonNull(editedReadOnlyPerson);
 
         Person editedPerson = new Person(editedReadOnlyPerson);
         syncMasterTagListWith(editedPerson);

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -1,5 +1,8 @@
 package seedu.address.model;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
 import java.util.Set;
 import java.util.logging.Logger;
 
@@ -29,7 +32,7 @@ public class ModelManager extends ComponentManager implements Model {
      */
     public ModelManager(ReadOnlyAddressBook addressBook, UserPrefs userPrefs) {
         super();
-        assert !CollectionUtil.isAnyNull(addressBook, userPrefs);
+        checkArgument(!CollectionUtil.isAnyNull(addressBook, userPrefs));
 
         logger.fine("Initializing with address book: " + addressBook + " and user prefs " + userPrefs);
 
@@ -73,7 +76,7 @@ public class ModelManager extends ComponentManager implements Model {
     @Override
     public void updatePerson(int filteredPersonListIndex, ReadOnlyPerson editedPerson)
             throws UniquePersonList.DuplicatePersonException {
-        assert editedPerson != null;
+        requireNonNull(editedPerson);
 
         int addressBookIndex = filteredPersons.getSourceIndex(filteredPersonListIndex);
         addressBook.updatePerson(addressBookIndex, editedPerson);

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -1,7 +1,7 @@
 package seedu.address.model;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.commons.util.AppUtil.checkArgument;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Set;
 import java.util.logging.Logger;
@@ -11,7 +11,6 @@ import seedu.address.commons.core.ComponentManager;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.core.UnmodifiableObservableList;
 import seedu.address.commons.events.model.AddressBookChangedEvent;
-import seedu.address.commons.util.CollectionUtil;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.model.person.ReadOnlyPerson;
 import seedu.address.model.person.UniquePersonList;
@@ -32,7 +31,7 @@ public class ModelManager extends ComponentManager implements Model {
      */
     public ModelManager(ReadOnlyAddressBook addressBook, UserPrefs userPrefs) {
         super();
-        checkArgument(!CollectionUtil.isAnyNull(addressBook, userPrefs));
+        requireAllNonNull(addressBook, userPrefs);
 
         logger.fine("Initializing with address book: " + addressBook + " and user prefs " + userPrefs);
 

--- a/src/main/java/seedu/address/model/person/Address.java
+++ b/src/main/java/seedu/address/model/person/Address.java
@@ -1,6 +1,8 @@
 package seedu.address.model.person;
 
 
+import static java.util.Objects.requireNonNull;
+
 import seedu.address.commons.exceptions.IllegalValueException;
 
 /**
@@ -26,7 +28,7 @@ public class Address {
      * @throws IllegalValueException if given address string is invalid.
      */
     public Address(String address) throws IllegalValueException {
-        assert address != null;
+        requireNonNull(address);
         if (!isValidAddress(address)) {
             throw new IllegalValueException(MESSAGE_ADDRESS_CONSTRAINTS);
         }

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -1,5 +1,6 @@
 package seedu.address.model.person;
 
+import static java.util.Objects.requireNonNull;
 
 import seedu.address.commons.exceptions.IllegalValueException;
 
@@ -21,7 +22,7 @@ public class Email {
      * @throws IllegalValueException if given email address string is invalid.
      */
     public Email(String email) throws IllegalValueException {
-        assert email != null;
+        requireNonNull(email);
         String trimmedEmail = email.trim();
         if (!isValidEmail(trimmedEmail)) {
             throw new IllegalValueException(MESSAGE_EMAIL_CONSTRAINTS);

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -1,5 +1,7 @@
 package seedu.address.model.person;
 
+import static java.util.Objects.requireNonNull;
+
 import seedu.address.commons.exceptions.IllegalValueException;
 
 /**
@@ -25,7 +27,7 @@ public class Name {
      * @throws IllegalValueException if given name string is invalid.
      */
     public Name(String name) throws IllegalValueException {
-        assert name != null;
+        requireNonNull(name);
         String trimmedName = name.trim();
         if (!isValidName(trimmedName)) {
             throw new IllegalValueException(MESSAGE_NAME_CONSTRAINTS);

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -1,13 +1,12 @@
 package seedu.address.model.person;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.commons.util.AppUtil.checkArgument;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
 
-import seedu.address.commons.util.CollectionUtil;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.tag.UniqueTagList;
 
@@ -28,7 +27,7 @@ public class Person implements ReadOnlyPerson {
      * Every field must be present and not null.
      */
     public Person(Name name, Phone phone, Email email, Address address, Set<Tag> tags) {
-        checkArgument(!CollectionUtil.isAnyNull(name, phone, email, address, tags));
+        requireAllNonNull(name, phone, email, address, tags);
         this.name = name;
         this.phone = phone;
         this.email = email;

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -1,5 +1,8 @@
 package seedu.address.model.person;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
 import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
@@ -25,7 +28,7 @@ public class Person implements ReadOnlyPerson {
      * Every field must be present and not null.
      */
     public Person(Name name, Phone phone, Email email, Address address, Set<Tag> tags) {
-        assert !CollectionUtil.isAnyNull(name, phone, email, address, tags);
+        checkArgument(!CollectionUtil.isAnyNull(name, phone, email, address, tags));
         this.name = name;
         this.phone = phone;
         this.email = email;
@@ -42,8 +45,7 @@ public class Person implements ReadOnlyPerson {
     }
 
     public void setName(Name name) {
-        assert name != null;
-        this.name = name;
+        this.name = requireNonNull(name);
     }
 
     @Override
@@ -52,8 +54,7 @@ public class Person implements ReadOnlyPerson {
     }
 
     public void setPhone(Phone phone) {
-        assert phone != null;
-        this.phone = phone;
+        this.phone = requireNonNull(phone);
     }
 
     @Override
@@ -62,8 +63,7 @@ public class Person implements ReadOnlyPerson {
     }
 
     public void setEmail(Email email) {
-        assert email != null;
-        this.email = email;
+        this.email = requireNonNull(email);
     }
 
     @Override
@@ -72,8 +72,7 @@ public class Person implements ReadOnlyPerson {
     }
 
     public void setAddress(Address address) {
-        assert address != null;
-        this.address = address;
+        this.address = requireNonNull(address);
     }
 
     @Override
@@ -101,7 +100,7 @@ public class Person implements ReadOnlyPerson {
      * Updates this person with the details of {@code replacement}.
      */
     public void resetData(ReadOnlyPerson replacement) {
-        assert replacement != null;
+        requireNonNull(replacement);
 
         this.setName(replacement.getName());
         this.setPhone(replacement.getPhone());

--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -1,5 +1,7 @@
 package seedu.address.model.person;
 
+import static java.util.Objects.requireNonNull;
+
 import seedu.address.commons.exceptions.IllegalValueException;
 
 /**
@@ -20,7 +22,7 @@ public class Phone {
      * @throws IllegalValueException if given phone string is invalid.
      */
     public Phone(String phone) throws IllegalValueException {
-        assert phone != null;
+        requireNonNull(phone);
         String trimmedPhone = phone.trim();
         if (!isValidPhone(trimmedPhone)) {
             throw new IllegalValueException(MESSAGE_PHONE_CONSTRAINTS);

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -1,5 +1,7 @@
 package seedu.address.model.person;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.Iterator;
 import java.util.List;
 
@@ -25,7 +27,7 @@ public class UniquePersonList implements Iterable<Person> {
      * Returns true if the list contains an equivalent person as the given argument.
      */
     public boolean contains(ReadOnlyPerson toCheck) {
-        assert toCheck != null;
+        requireNonNull(toCheck);
         return internalList.contains(toCheck);
     }
 
@@ -35,7 +37,7 @@ public class UniquePersonList implements Iterable<Person> {
      * @throws DuplicatePersonException if the person to add is a duplicate of an existing person in the list.
      */
     public void add(ReadOnlyPerson toAdd) throws DuplicatePersonException {
-        assert toAdd != null;
+        requireNonNull(toAdd);
         if (contains(toAdd)) {
             throw new DuplicatePersonException();
         }
@@ -50,7 +52,7 @@ public class UniquePersonList implements Iterable<Person> {
      * @throws IndexOutOfBoundsException if {@code index} < 0 or >= the size of the list.
      */
     public void updatePerson(int index, ReadOnlyPerson editedPerson) throws DuplicatePersonException {
-        assert editedPerson != null;
+        requireNonNull(editedPerson);
 
         Person personToUpdate = internalList.get(index);
         if (!personToUpdate.equals(editedPerson) && internalList.contains(editedPerson)) {
@@ -70,7 +72,7 @@ public class UniquePersonList implements Iterable<Person> {
      * @throws PersonNotFoundException if no such person could be found in the list.
      */
     public boolean remove(ReadOnlyPerson toRemove) throws PersonNotFoundException {
-        assert toRemove != null;
+        requireNonNull(toRemove);
         final boolean personFoundAndDeleted = internalList.remove(toRemove);
         if (!personFoundAndDeleted) {
             throw new PersonNotFoundException();

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -1,5 +1,6 @@
 package seedu.address.model.tag;
 
+import static java.util.Objects.requireNonNull;
 
 import seedu.address.commons.exceptions.IllegalValueException;
 
@@ -20,7 +21,7 @@ public class Tag {
      * @throws IllegalValueException if the given tag name string is invalid.
      */
     public Tag(String name) throws IllegalValueException {
-        assert name != null;
+        requireNonNull(name);
         String trimmedName = name.trim();
         if (!isValidTagName(trimmedName)) {
             throw new IllegalValueException(MESSAGE_TAG_CONSTRAINTS);

--- a/src/main/java/seedu/address/model/tag/UniqueTagList.java
+++ b/src/main/java/seedu/address/model/tag/UniqueTagList.java
@@ -1,7 +1,7 @@
 package seedu.address.model.tag;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.commons.util.AppUtil.checkArgument;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -54,7 +54,7 @@ public class UniqueTagList implements Iterable<Tag> {
      * Enforces no nulls or duplicates.
      */
     public UniqueTagList(Tag... tags) throws DuplicateTagException {
-        checkArgument(!CollectionUtil.isAnyNull((Object[]) tags));
+        requireAllNonNull((Object[]) tags);
         final List<Tag> initialTags = Arrays.asList(tags);
         if (!CollectionUtil.elementsAreUnique(initialTags)) {
             throw new DuplicateTagException();
@@ -80,7 +80,7 @@ public class UniqueTagList implements Iterable<Tag> {
      * Enforces no nulls.
      */
     public UniqueTagList(Set<Tag> tags) {
-        checkArgument(!CollectionUtil.isAnyNull(tags));
+        requireAllNonNull(tags);
         internalList.addAll(tags);
 
         assert CollectionUtil.elementsAreUnique(internalList);
@@ -114,7 +114,7 @@ public class UniqueTagList implements Iterable<Tag> {
     }
 
     public void setTags(Collection<Tag> tags) throws DuplicateTagException {
-        checkArgument(!CollectionUtil.isAnyNull(tags));
+        requireAllNonNull(tags);
         if (!CollectionUtil.elementsAreUnique(tags)) {
             throw new DuplicateTagException();
         }

--- a/src/main/java/seedu/address/model/tag/UniqueTagList.java
+++ b/src/main/java/seedu/address/model/tag/UniqueTagList.java
@@ -1,5 +1,8 @@
 package seedu.address.model.tag;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -51,7 +54,7 @@ public class UniqueTagList implements Iterable<Tag> {
      * Enforces no nulls or duplicates.
      */
     public UniqueTagList(Tag... tags) throws DuplicateTagException {
-        assert !CollectionUtil.isAnyNull((Object[]) tags);
+        checkArgument(!CollectionUtil.isAnyNull((Object[]) tags));
         final List<Tag> initialTags = Arrays.asList(tags);
         if (!CollectionUtil.elementsAreUnique(initialTags)) {
             throw new DuplicateTagException();
@@ -77,7 +80,7 @@ public class UniqueTagList implements Iterable<Tag> {
      * Enforces no nulls.
      */
     public UniqueTagList(Set<Tag> tags) {
-        assert !CollectionUtil.isAnyNull(tags);
+        checkArgument(!CollectionUtil.isAnyNull(tags));
         internalList.addAll(tags);
 
         assert CollectionUtil.elementsAreUnique(internalList);
@@ -111,7 +114,7 @@ public class UniqueTagList implements Iterable<Tag> {
     }
 
     public void setTags(Collection<Tag> tags) throws DuplicateTagException {
-        assert !CollectionUtil.isAnyNull(tags);
+        checkArgument(!CollectionUtil.isAnyNull(tags));
         if (!CollectionUtil.elementsAreUnique(tags)) {
             throw new DuplicateTagException();
         }
@@ -136,7 +139,7 @@ public class UniqueTagList implements Iterable<Tag> {
      * Returns true if the list contains an equivalent Tag as the given argument.
      */
     public boolean contains(Tag toCheck) {
-        assert toCheck != null;
+        requireNonNull(toCheck);
         return internalList.contains(toCheck);
     }
 
@@ -146,7 +149,7 @@ public class UniqueTagList implements Iterable<Tag> {
      * @throws DuplicateTagException if the Tag to add is a duplicate of an existing Tag in the list.
      */
     public void add(Tag toAdd) throws DuplicateTagException {
-        assert toAdd != null;
+        requireNonNull(toAdd);
         if (contains(toAdd)) {
             throw new DuplicateTagException();
         }

--- a/src/main/java/seedu/address/storage/XmlAddressBookStorage.java
+++ b/src/main/java/seedu/address/storage/XmlAddressBookStorage.java
@@ -1,5 +1,7 @@
 package seedu.address.storage;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -40,7 +42,7 @@ public class XmlAddressBookStorage implements AddressBookStorage {
      */
     public Optional<ReadOnlyAddressBook> readAddressBook(String filePath) throws DataConversionException,
                                                                                  FileNotFoundException {
-        assert filePath != null;
+        requireNonNull(filePath);
 
         File addressBookFile = new File(filePath);
 
@@ -64,8 +66,8 @@ public class XmlAddressBookStorage implements AddressBookStorage {
      * @param filePath location of the data. Cannot be null
      */
     public void saveAddressBook(ReadOnlyAddressBook addressBook, String filePath) throws IOException {
-        assert addressBook != null;
-        assert filePath != null;
+        requireNonNull(addressBook);
+        requireNonNull(filePath);
 
         File file = new File(filePath);
         FileUtil.createIfMissing(file);

--- a/src/main/java/seedu/address/ui/UiPart.java
+++ b/src/main/java/seedu/address/ui/UiPart.java
@@ -1,5 +1,7 @@
 package seedu.address.ui;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.IOException;
 import java.net.URL;
 
@@ -27,7 +29,7 @@ public abstract class UiPart<T> {
      * The FXML file must not specify the {@code fx:controller} attribute.
      */
     public UiPart(URL fxmlFileUrl) {
-        assert fxmlFileUrl != null;
+        requireNonNull(fxmlFileUrl);
         fxmlLoader = new FXMLLoader(fxmlFileUrl);
         fxmlLoader.setController(this);
         try {

--- a/src/test/java/guitests/guihandles/AlertDialogHandle.java
+++ b/src/test/java/guitests/guihandles/AlertDialogHandle.java
@@ -1,5 +1,7 @@
 package guitests.guihandles;
 
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
 import guitests.GuiRobot;
 import javafx.scene.control.DialogPane;
 import javafx.stage.Stage;
@@ -16,7 +18,7 @@ public class AlertDialogHandle extends GuiHandle {
     }
 
     public boolean isMatching(String headerMessage, String contentMessage) {
-        assert intermediateStage.isPresent() : "Alert dialog is not present";
+        checkArgument(intermediateStage.isPresent(), "Alert dialog is not present");
         DialogPane dialogPane = getNode("#" + UiManager.ALERT_DIALOG_PANE_FIELD_ID);
         boolean isMatching = dialogPane.getHeaderText().equals(headerMessage)
                 && dialogPane.getContentText().equals(contentMessage);

--- a/src/test/java/seedu/address/commons/util/AppUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/AppUtilTest.java
@@ -20,10 +20,28 @@ public class AppUtilTest {
 
 
     @Test
-    public void getImage_nullGiven_assertionError() {
-        thrown.expect(AssertionError.class);
+    public void getImage_nullGiven_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
         AppUtil.getImage(null);
     }
 
+    @Test
+    public void checkArgument_true_nothingHappens() {
+        AppUtil.checkArgument(true);
+        AppUtil.checkArgument(true, "");
+    }
 
+    @Test
+    public void checkArgument_falseWithoutErrorMessage_throwsIllegalArgumentException() {
+        thrown.expect(IllegalArgumentException.class);
+        AppUtil.checkArgument(false);
+    }
+
+    @Test
+    public void checkArgument_falseWithErrorMessage_throwsIllegalArgumentException() {
+        String errorMessage = "error message";
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage(errorMessage);
+        AppUtil.checkArgument(false,  errorMessage);
+    }
 }

--- a/src/test/java/seedu/address/commons/util/CollectionUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/CollectionUtilTest.java
@@ -2,84 +2,75 @@ package seedu.address.commons.util;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class CollectionUtilTest {
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
     @Test
-    public void isAnyNullVarargs() {
+    public void requireAllNonNullVarargs() {
         // no arguments
-        assertFalse(CollectionUtil.isAnyNull());
+        assertNullPointerExceptionNotThrown();
 
         // any non-empty argument list
-        assertFalse(CollectionUtil.isAnyNull(new Object(), new Object()));
-        assertFalse(CollectionUtil.isAnyNull("test"));
-        assertFalse(CollectionUtil.isAnyNull(""));
+        assertNullPointerExceptionNotThrown(new Object(), new Object());
+        assertNullPointerExceptionNotThrown("test");
+        assertNullPointerExceptionNotThrown("");
 
         // argument lists with just one null at the beginning
-        assertTrue(CollectionUtil.isAnyNull((Object) null));
-        assertTrue(CollectionUtil.isAnyNull(null, "", new Object()));
-        assertTrue(CollectionUtil.isAnyNull(null, new Object(), new Object()));
+        assertNullPointerExceptionThrown((Object) null);
+        assertNullPointerExceptionThrown(null, "", new Object());
+        assertNullPointerExceptionThrown(null, new Object(), new Object());
 
         // argument lists with nulls in the middle
-        assertTrue(CollectionUtil.isAnyNull(new Object(), null, null, "test"));
-        assertTrue(CollectionUtil.isAnyNull("", null, new Object()));
+        assertNullPointerExceptionThrown(new Object(), null, null, "test");
+        assertNullPointerExceptionThrown("", null, new Object());
 
         // argument lists with one null as the last argument
-        assertTrue(CollectionUtil.isAnyNull("", new Object(), null));
-        assertTrue(CollectionUtil.isAnyNull(new Object(), new Object(), null));
+        assertNullPointerExceptionThrown("", new Object(), null);
+        assertNullPointerExceptionThrown(new Object(), new Object(), null);
+
+        // null reference
+        assertNullPointerExceptionThrown((Object[]) null);
 
         // confirms nulls inside lists in the argument list are not considered
         List<Object> containingNull = Arrays.asList((Object) null);
-        assertFalse(CollectionUtil.isAnyNull(containingNull, new Object()));
+        assertNullPointerExceptionNotThrown(containingNull, new Object());
     }
 
     @Test
-    public void isAnyNullVarargs_nullReference_throwsNullPointerException() {
-        thrown.expect(NullPointerException.class);
-        CollectionUtil.isAnyNull((Object[]) null);
-    }
-
-    @Test
-    public void isAnyNullCollection() {
+    public void requireAllNonNullCollection() {
         // lists containing nulls in the front
-        assertTrue(CollectionUtil.isAnyNull(Arrays.asList((Object) null)));
-        assertTrue(CollectionUtil.isAnyNull(Arrays.asList(null, new Object(), "")));
+        assertNullPointerExceptionThrown(Arrays.asList((Object) null));
+        assertNullPointerExceptionThrown(Arrays.asList(null, new Object(), ""));
 
         // lists containing nulls in the middle
-        assertTrue(CollectionUtil.isAnyNull(Arrays.asList("spam", null, new Object())));
-        assertTrue(CollectionUtil.isAnyNull(Arrays.asList("spam", null, "eggs", null, new Object())));
+        assertNullPointerExceptionThrown(Arrays.asList("spam", null, new Object()));
+        assertNullPointerExceptionThrown(Arrays.asList("spam", null, "eggs", null, new Object()));
 
         // lists containing nulls at the end
-        assertTrue(CollectionUtil.isAnyNull(Arrays.asList("spam", new Object(), null)));
-        assertTrue(CollectionUtil.isAnyNull(Arrays.asList(new Object(), null)));
+        assertNullPointerExceptionThrown(Arrays.asList("spam", new Object(), null));
+        assertNullPointerExceptionThrown(Arrays.asList(new Object(), null));
+
+        // null reference
+        assertNullPointerExceptionThrown((Collection<Object>) null);
 
         // empty list
-        assertFalse(CollectionUtil.isAnyNull(Collections.emptyList()));
+        assertNullPointerExceptionNotThrown(Collections.emptyList());
 
         // list with all non-null elements
-        assertFalse(CollectionUtil.isAnyNull(Arrays.asList(new Object(), "ham", new Integer(1))));
-        assertFalse(CollectionUtil.isAnyNull(Arrays.asList(new Object())));
+        assertNullPointerExceptionNotThrown(Arrays.asList(new Object(), "ham", new Integer(1)));
+        assertNullPointerExceptionNotThrown(Arrays.asList(new Object()));
 
         // confirms nulls inside nested lists are not considered
         List<Object> containingNull = Arrays.asList((Object) null);
-        assertFalse(CollectionUtil.isAnyNull(Arrays.asList(containingNull, new Object())));
-    }
-
-    @Test
-    public void isAnyNullCollection_nullReference_throwsNullPointerException() {
-        thrown.expect(NullPointerException.class);
-        CollectionUtil.isAnyNull((Collection<Object>) null);
+        assertNullPointerExceptionNotThrown(Arrays.asList(containingNull, new Object()));
     }
 
     @Test
@@ -105,6 +96,32 @@ public class CollectionUtilTest {
         assertNotUnique(null, 1, new Integer(1));
         assertNotUnique(null, null);
         assertNotUnique(null, "a", "b", null);
+    }
+
+    private void assertNullPointerExceptionThrown(Object... objects) {
+        try {
+            requireAllNonNull(objects);
+            fail("The expected NullPointerException was not thrown");
+        } catch (NullPointerException npe) {
+            // expected behavior
+        }
+    }
+
+    private void assertNullPointerExceptionThrown(Collection<?> collection) {
+        try {
+            requireAllNonNull(collection);
+            fail("The expected NullPointerException was not thrown");
+        } catch (NullPointerException npe) {
+            // expected behavior
+        }
+    }
+
+    private void assertNullPointerExceptionNotThrown(Object... objects) {
+        requireAllNonNull(objects);
+    }
+
+    private void assertNullPointerExceptionNotThrown(Collection<?> collection) {
+        requireAllNonNull(collection);
     }
 
     private void assertAreUnique(Object... objects) {

--- a/src/test/java/seedu/address/commons/util/ConfigUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/ConfigUtilTest.java
@@ -27,8 +27,8 @@ public class ConfigUtilTest {
     public TemporaryFolder testFolder = new TemporaryFolder();
 
     @Test
-    public void read_null_assertionFailure() throws DataConversionException {
-        thrown.expect(AssertionError.class);
+    public void read_null_throwsNullPointerException() throws DataConversionException {
+        thrown.expect(NullPointerException.class);
         read(null);
     }
 
@@ -85,14 +85,14 @@ public class ConfigUtilTest {
     }
 
     @Test
-    public void save_nullConfig_assertionFailure() throws IOException {
-        thrown.expect(AssertionError.class);
+    public void save_nullConfig_throwsNullPointerException() throws IOException {
+        thrown.expect(NullPointerException.class);
         save(null, "SomeFile.json");
     }
 
     @Test
-    public void save_nullFile_assertionFailure() throws IOException {
-        thrown.expect(AssertionError.class);
+    public void save_nullFile_throwsNullPointerException() throws IOException {
+        thrown.expect(NullPointerException.class);
         save(new Config(), null);
     }
 

--- a/src/test/java/seedu/address/commons/util/FileUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/FileUtilTest.java
@@ -20,8 +20,8 @@ public class FileUtilTest {
         // valid case
         assertEquals("folder" + File.separator + "sub-folder", FileUtil.getPath("folder/sub-folder"));
 
-        // null parameter -> assertion failure
-        thrown.expect(AssertionError.class);
+        // null parameter -> throws NullPointerException
+        thrown.expect(NullPointerException.class);
         FileUtil.getPath(null);
 
         // no forwards slash -> assertion failure

--- a/src/test/java/seedu/address/commons/util/StringUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/StringUtilTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.FileNotFoundException;
+import java.util.Optional;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -58,29 +59,32 @@ public class StringUtilTest {
      */
 
     @Test
-    public void containsWordIgnoreCase_nullWord_exceptionThrown() {
-        assertExceptionThrown("typical sentence", null, "Word parameter cannot be null");
+    public void containsWordIgnoreCase_nullWord_throwsNullPointerException() {
+        assertExceptionThrown(NullPointerException.class, "typical sentence", null, Optional.empty());
     }
 
-    private void assertExceptionThrown(String sentence, String word, String errorMessage) {
-        thrown.expect(AssertionError.class);
-        thrown.expectMessage(errorMessage);
+    private void assertExceptionThrown(Class<? extends Throwable> exceptionClass, String sentence, String word,
+            Optional<String> errorMessage) {
+        thrown.expect(exceptionClass);
+        errorMessage.ifPresent(message -> thrown.expectMessage(message));
         StringUtil.containsWordIgnoreCase(sentence, word);
     }
 
     @Test
-    public void containsWordIgnoreCase_emptyWord_exceptionThrown() {
-        assertExceptionThrown("typical sentence", "  ", "Word parameter cannot be empty");
+    public void containsWordIgnoreCase_emptyWord_throwsIllegalArgumentException() {
+        assertExceptionThrown(IllegalArgumentException.class, "typical sentence", "  ",
+                Optional.of("Word parameter cannot be empty"));
     }
 
     @Test
-    public void containsWordIgnoreCase_multipleWords_exceptionThrown() {
-        assertExceptionThrown("typical sentence", "aaa BBB", "Word parameter should be a single word");
+    public void containsWordIgnoreCase_multipleWords_throwsIllegalArgumentException() {
+        assertExceptionThrown(IllegalArgumentException.class, "typical sentence", "aaa BBB",
+                Optional.of("Word parameter should be a single word"));
     }
 
     @Test
-    public void containsWordIgnoreCase_nullSentence_exceptionThrown() {
-        assertExceptionThrown(null, "abc", "Sentence parameter cannot be null");
+    public void containsWordIgnoreCase_nullSentence_throwsNullPointerException() {
+        assertExceptionThrown(NullPointerException.class, null, "abc", Optional.empty());
     }
 
     /*
@@ -143,8 +147,8 @@ public class StringUtilTest {
     }
 
     @Test
-    public void getDetails_nullGiven_assertionError() {
-        thrown.expect(AssertionError.class);
+    public void getDetails_nullGiven_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
         StringUtil.getDetails(null);
     }
 

--- a/src/test/java/seedu/address/commons/util/XmlUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/XmlUtilTest.java
@@ -28,14 +28,14 @@ public class XmlUtilTest {
     public ExpectedException thrown = ExpectedException.none();
 
     @Test
-    public void getDataFromFile_nullFile_assertionError() throws Exception {
-        thrown.expect(AssertionError.class);
+    public void getDataFromFile_nullFile_throwsNullPointerException() throws Exception {
+        thrown.expect(NullPointerException.class);
         XmlUtil.getDataFromFile(null, AddressBook.class);
     }
 
     @Test
-    public void getDataFromFile_nullClass_assertionError() throws Exception {
-        thrown.expect(AssertionError.class);
+    public void getDataFromFile_nullClass_throwsNullPointerException() throws Exception {
+        thrown.expect(NullPointerException.class);
         XmlUtil.getDataFromFile(VALID_FILE, null);
     }
 
@@ -59,14 +59,14 @@ public class XmlUtilTest {
     }
 
     @Test
-    public void saveDataToFile_nullFile_assertionError() throws Exception {
-        thrown.expect(AssertionError.class);
+    public void saveDataToFile_nullFile_throwsNullPointerException() throws Exception {
+        thrown.expect(NullPointerException.class);
         XmlUtil.saveDataToFile(null, new AddressBook());
     }
 
     @Test
-    public void saveDataToFile_nullClass_assertionError() throws Exception {
-        thrown.expect(AssertionError.class);
+    public void saveDataToFile_nullClass_throwsNullPointerException() throws Exception {
+        thrown.expect(NullPointerException.class);
         XmlUtil.saveDataToFile(VALID_FILE, null);
     }
 

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -60,8 +60,8 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void parseName_null_throwsAssertionError() throws Exception {
-        thrown.expect(AssertionError.class);
+    public void parseName_null_throwsNullPointerException() throws Exception {
+        thrown.expect(NullPointerException.class);
         ParserUtil.parseName(null);
     }
 
@@ -85,8 +85,8 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void parsePhone_null_throwsAssertionError() throws Exception {
-        thrown.expect(AssertionError.class);
+    public void parsePhone_null_throwsNullPointerException() throws Exception {
+        thrown.expect(NullPointerException.class);
         ParserUtil.parsePhone(null);
     }
 
@@ -110,8 +110,8 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void parseAddress_null_throwsAssertionError() throws Exception {
-        thrown.expect(AssertionError.class);
+    public void parseAddress_null_throwsNullPointerException() throws Exception {
+        thrown.expect(NullPointerException.class);
         ParserUtil.parseAddress(null);
     }
 
@@ -135,8 +135,8 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void parseEmail_null_throwsAssertionError() throws Exception {
-        thrown.expect(AssertionError.class);
+    public void parseEmail_null_throwsNullPointerException() throws Exception {
+        thrown.expect(NullPointerException.class);
         ParserUtil.parseEmail(null);
     }
 
@@ -160,8 +160,8 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void parseTags_null_throwsAssertionError() throws Exception {
-        thrown.expect(AssertionError.class);
+    public void parseTags_null_throwsNullPointerException() throws Exception {
+        thrown.expect(NullPointerException.class);
         ParserUtil.parseTags(null);
     }
 

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -33,8 +33,8 @@ public class AddressBookTest {
     }
 
     @Test
-    public void resetData_null_throwsAssertionError() {
-        thrown.expect(AssertionError.class);
+    public void resetData_null_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
         addressBook.resetData(null);
     }
 

--- a/src/test/java/seedu/address/storage/JsonUserPrefsStorageTest.java
+++ b/src/test/java/seedu/address/storage/JsonUserPrefsStorageTest.java
@@ -28,8 +28,8 @@ public class JsonUserPrefsStorageTest {
     public TemporaryFolder testFolder = new TemporaryFolder();
 
     @Test
-    public void readUserPrefs_nullFilePath_assertionFailure() throws DataConversionException {
-        thrown.expect(AssertionError.class);
+    public void readUserPrefs_nullFilePath_throwsNullPointerException() throws DataConversionException {
+        thrown.expect(NullPointerException.class);
         readUserPrefs(null);
     }
 
@@ -89,14 +89,14 @@ public class JsonUserPrefsStorageTest {
     }
 
     @Test
-    public void savePrefs_nullPrefs_assertionFailure() throws IOException {
-        thrown.expect(AssertionError.class);
+    public void savePrefs_nullPrefs_throwsNullPointerException() throws IOException {
+        thrown.expect(NullPointerException.class);
         saveUserPrefs(null, "SomeFile.json");
     }
 
     @Test
-    public void saveUserPrefs_nullFilePath_assertionFailure() throws IOException {
-        thrown.expect(AssertionError.class);
+    public void saveUserPrefs_nullFilePath_throwsNullPointerException() throws IOException {
+        thrown.expect(NullPointerException.class);
         saveUserPrefs(new UserPrefs(), null);
     }
 

--- a/src/test/java/seedu/address/storage/XmlAddressBookStorageTest.java
+++ b/src/test/java/seedu/address/storage/XmlAddressBookStorageTest.java
@@ -28,8 +28,8 @@ public class XmlAddressBookStorageTest {
     public TemporaryFolder testFolder = new TemporaryFolder();
 
     @Test
-    public void readAddressBook_nullFilePath_assertionFailure() throws Exception {
-        thrown.expect(AssertionError.class);
+    public void readAddressBook_nullFilePath_throwsNullPointerException() throws Exception {
+        thrown.expect(NullPointerException.class);
         readAddressBook(null);
     }
 
@@ -87,8 +87,8 @@ public class XmlAddressBookStorageTest {
     }
 
     @Test
-    public void saveAddressBook_nullAddressBook_assertionFailure() throws IOException {
-        thrown.expect(AssertionError.class);
+    public void saveAddressBook_nullAddressBook_throwsNullPointerException() throws IOException {
+        thrown.expect(NullPointerException.class);
         saveAddressBook(null, "SomeFile.xml");
     }
 
@@ -97,8 +97,8 @@ public class XmlAddressBookStorageTest {
     }
 
     @Test
-    public void saveAddressBook_nullFilePath_assertionFailure() throws IOException {
-        thrown.expect(AssertionError.class);
+    public void saveAddressBook_nullFilePath_throwsNullPointerException() throws IOException {
+        thrown.expect(NullPointerException.class);
         saveAddressBook(new AddressBook(), null);
     }
 

--- a/src/test/java/seedu/address/ui/UiPartTest.java
+++ b/src/test/java/seedu/address/ui/UiPartTest.java
@@ -27,8 +27,8 @@ public class UiPartTest {
     public TemporaryFolder testFolder = new TemporaryFolder();
 
     @Test
-    public void constructor_nullFileUrl_throwsAssertionError() {
-        thrown.expect(AssertionError.class);
+    public void constructor_nullFileUrl_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
         new TestUiPart<Object>((URL) null);
     }
 
@@ -53,14 +53,14 @@ public class UiPartTest {
     }
 
     @Test
-    public void constructor_nullFileName_throwsAssertionError() {
-        thrown.expect(AssertionError.class);
+    public void constructor_nullFileName_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
         new TestUiPart<Object>((String) null);
     }
 
     @Test
-    public void constructor_missingFileName_throwsAssertionError() {
-        thrown.expect(AssertionError.class);
+    public void constructor_missingFileName_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
         new TestUiPart<Object>(MISSING_FILE_PATH);
     }
 


### PR DESCRIPTION
Fixes #239 

Proposed merge commit message:
```
Parameter validation is done by using asserts, and throws AssertionError
when validation fails.

Asserts may not always be enabled. Furthermore, specific exceptions
such as NullPointerException should be thrown to make the error more
explicit.

Let's
    - Replace the asserts for public APIs with checkNotNull() and
      checkArgument(), which throws an appropriate exception when 
      validation fails.
    - Enhance CollectionUtil#isAnyNull(…) to do the same operation as
      Objects#requireNonNull(T), and also able to take in multiple 
      parameters.
```