### PR TITLE
Make help documentation accessible offline #417

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ preferences.json
 classes/
 /data/
 /bin/
+src/main/resources/docs/

--- a/build.gradle
+++ b/build.gradle
@@ -210,4 +210,17 @@ task copyStylesheets(type: Copy) {
 }
 asciidoctor.dependsOn copyStylesheets
 
+task deployOfflineDocs(type: Copy) {
+    into('src/main/resources/docs')
+
+    from ("${asciidoctor.outputDir}/html5") {
+        include 'stylesheets/*'
+        include 'images/*'
+        include 'UserGuide.html'
+    }
+}
+
+deployOfflineDocs.dependsOn asciidoctor
+processResources.dependsOn deployOfflineDocs
+
 defaultTasks 'clean', 'headless', 'allTests', 'coverage', 'asciidoctor'

--- a/docs/UsingGradle.adoc
+++ b/docs/UsingGradle.adoc
@@ -55,6 +55,8 @@ e.g. `./gradlew clean shadowJar`
 
 * **`asciidoctor`** +
 Converts AsciiDoc files in `docs` to HTML format. Generated HTML files can be found in `build/docs`.
+* **`deployOfflineDocs`** +
+Updates the offline user guide, and its associated files, used by the Help window in the application. Deployed HTML files and images can be found in `src/main/resources/docs`.
 
 == Running the application
 

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -19,8 +19,7 @@ public class HelpWindow extends UiPart<Region> {
     private static final String ICON = "/images/help_icon.png";
     private static final String FXML = "HelpWindow.fxml";
     private static final String TITLE = "Help";
-    private static final String USERGUIDE_URL =
-            "https://se-edu.github.io/addressbook-level4/UserGuide.html";
+    private static final String USERGUIDE_FILE_PATH = "/docs/UserGuide.html";
 
     @FXML
     private WebView browser;
@@ -35,7 +34,8 @@ public class HelpWindow extends UiPart<Region> {
         dialogStage.setMaximized(true); //TODO: set a more appropriate initial size
         FxViewUtil.setStageIcon(dialogStage, ICON);
 
-        browser.getEngine().load(USERGUIDE_URL);
+        String userGuideUrl = getClass().getResource(USERGUIDE_FILE_PATH).toString();
+        browser.getEngine().load(userGuideUrl);
     }
 
     public void show() {


### PR DESCRIPTION
Fixes #417.
Also fixes #419.

Proposed merge commit message:

```
The help window accesses the online version of the documentation.

Users are unable to access it if they are offline. Furthermore, the
application version for the online documentation may not match the
application version that the user is using.

Let's change the help window to use an offline version instead, and
deploy the offline version to the 'src/main/resources/' folder such 
that shadowJar will automatically bundle the documentation with the app.
```