### PR TITLE
Create unit tests for ParserUtil#splitPreamble() #401 

### DIFF
--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -34,7 +34,7 @@ public class EditCommandParser {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
-        List<Optional<String>> preambleFields = ParserUtil.splitPreamble(argMultimap.getPreamble(), 2);
+        List<Optional<String>> preambleFields = ParserUtil.split(argMultimap.getPreamble(), 2);
 
         if (!preambleFields.get(0).isPresent()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -40,7 +40,7 @@ public class ParserUtil {
     }
 
     /**
-    * Splits a preamble string into ordered fields.
+    * Splits a {@code preamble} string into ordered fields of size {@code numFields}, using whitespace as a delimiter.
     * @return A list of size {@code numFields} where the ith element is the ith field value if specified in
     *         the input, {@code Optional.empty()} otherwise.
     */

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -40,12 +40,20 @@ public class ParserUtil {
     }
 
     /**
-    * Splits a {@code preamble} string into ordered fields of size {@code numFields}, using whitespace as a delimiter.
-    * @return A list of size {@code numFields} where the ith element is the ith field value if specified in
-    *         the input, {@code Optional.empty()} otherwise.
+    * Splits the {@code string} into {@code numOfParts} parts, using whitespace as a delimiter.
+    * {@code Optional.empty()} objects are appended as 'fillers' if the total number of parts after
+    * splitting {@code string} is fewer than {@code numOfParts}.<br>
+    * Examples:
+    * <pre>
+    *     split("Hello World!", 2) -> "Hello" and "World!"
+    *     split("Hello    World!", 3) -> "Hello" and "World!" and Optional.empty()
+    *     split("Foo bar baz", 2) -> "Foo" and "bar baz" // only 2 parts
+    * </pre>
+    * @return A list of size {@code numOfParts} containing the resultant parts in the order they
+    *         appeared in the input followed by {@code Optional.empty()} objects (if any).
     */
-    public static List<Optional<String>> splitPreamble(String preamble, int numFields) {
-        return Arrays.stream(Arrays.copyOf(preamble.split("\\s+", numFields), numFields))
+    public static List<Optional<String>> split(String string, int numOfParts) {
+        return Arrays.stream(Arrays.copyOf(string.split("\\s+", numOfParts), numOfParts))
                 .map(Optional::ofNullable)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -41,19 +41,19 @@ public class ParserUtil {
 
     /**
     * Splits the {@code string} into {@code numOfParts} parts, using whitespace as a delimiter.
-    * {@code Optional.empty()} objects are appended as 'fillers' if the total number of parts after
-    * splitting {@code string} is fewer than {@code numOfParts}.<br>
+    * Leading and trailing whitespaces will be trimmed. {@code Optional.empty()} objects are appended
+    * as 'fillers' if the total number of parts after splitting {@code string} is fewer than {@code numOfParts}.<br>
     * Examples:
     * <pre>
-    *     split("Hello World!", 2) -> "Hello" and "World!"
-    *     split("Hello    World!", 3) -> "Hello" and "World!" and Optional.empty()
+    *     split("  Hello World! ", 2) -> "Hello" and "World!"
+    *     split(" Hello    World!", 3) -> "Hello" and "World!" and Optional.empty()
     *     split("Foo bar baz", 2) -> "Foo" and "bar baz" // only 2 parts
     * </pre>
     * @return A list of size {@code numOfParts} containing the resultant parts in the order they
     *         appeared in the input followed by {@code Optional.empty()} objects (if any).
     */
     public static List<Optional<String>> split(String string, int numOfParts) {
-        return Arrays.stream(Arrays.copyOf(string.split("\\s+", numOfParts), numOfParts))
+        return Arrays.stream(Arrays.copyOf(string.trim().split("\\s+", numOfParts), numOfParts))
                 .map(Optional::ofNullable)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -25,6 +25,7 @@ import seedu.address.model.tag.Tag;
 public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
+    public static final String MESSAGE_INSUFFICIENT_PARTS = "Number of parts must be more than 1.";
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
@@ -51,8 +52,12 @@ public class ParserUtil {
     * </pre>
     * @return A list of size {@code numOfParts} containing the resultant parts in the order they
     *         appeared in the input followed by {@code Optional.empty()} objects (if any).
+    * @throws IllegalArgumentException if {@code numOfParts} < 2
     */
-    public static List<Optional<String>> split(String string, int numOfParts) {
+    public static List<Optional<String>> split(String string, int numOfParts) throws IllegalArgumentException {
+        if (numOfParts < 2) {
+            throw new IllegalArgumentException(MESSAGE_INSUFFICIENT_PARTS);
+        }
         return Arrays.stream(Arrays.copyOf(string.trim().split("\\s+", numOfParts), numOfParts))
                 .map(Optional::ofNullable)
                 .collect(Collectors.toList());

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -3,6 +3,8 @@ package seedu.address.logic.parser;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.address.testutil.TypicalPersons.INDEX_FIRST_PERSON;
 
@@ -67,26 +69,18 @@ public class ParserUtilTest {
     @Test
     public void split_nullPreamble_throwsNullPointerException() {
         thrown.expect(NullPointerException.class);
-        ParserUtil.split(null, 0);
+        ParserUtil.split(null, 2);
     }
 
     @Test
-    public void split_negativeNumFields_throwsNegativeArraySizeException() {
-        thrown.expect(NegativeArraySizeException.class);
-        ParserUtil.split("abc", -1);
+    public void split_invalidNumOfParts_throwsIllegalArgumentException() {
+        assertSplitFailure("abc", -1);
+        assertSplitFailure("abc", 0);
+        assertSplitFailure("abc", 1);
     }
 
     @Test
     public void split_validInput_success() {
-        // Zero numOfParts
-        assertSplitSuccess("abc", 0, asOptionalList());
-
-        // Empty string
-        assertSplitSuccess("", 1, asOptionalList(""));
-
-        // No whitespaces
-        assertSplitSuccess("abc", 1, asOptionalList("abc"));
-
         // Single whitespace between parts
         assertSplitSuccess("abc 123", 2, asOptionalList("abc", "123"));
 
@@ -101,7 +95,20 @@ public class ParserUtilTest {
     }
 
     /**
-     * Splits {@code string} into ordered parts of size {@code numOfParts}
+     * Asserts that {@code split(string, numOfParts)} is unsuccessful and a matching
+     * {@code IllegalArgumentException} is thrown.
+     */
+    private void assertSplitFailure(String string, int numOfParts) {
+        try {
+            ParserUtil.split(string, numOfParts);
+            fail("The expected IllegalArgumentException was not thrown");
+        } catch (IllegalArgumentException iae) {
+            assertEquals(ParserUtil.MESSAGE_INSUFFICIENT_PARTS, iae.getMessage());
+        }
+    }
+
+    /**
+     * Asserts that {@code string} is successfully split into ordered parts of size {@code numOfParts}
      * and checks if the result is the same as {@code expectedValues}
      */
     private void assertSplitSuccess(String string, int numOfParts, List<Optional<String>> expectedValues) {

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -65,47 +65,47 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void splitPreamble_nullPreamble_throwsNullPointerException() {
+    public void split_nullPreamble_throwsNullPointerException() {
         thrown.expect(NullPointerException.class);
-        ParserUtil.splitPreamble(null, 0);
+        ParserUtil.split(null, 0);
     }
 
     @Test
-    public void splitPreamble_negativeNumFields_throwsNegativeArraySizeException() {
+    public void split_negativeNumFields_throwsNegativeArraySizeException() {
         thrown.expect(NegativeArraySizeException.class);
-        ParserUtil.splitPreamble("abc", -1);
+        ParserUtil.split("abc", -1);
     }
 
     @Test
-    public void splitPreamble_validInput_success() {
-        // Zero numFields
-        assertPreambleListCorrect("abc", 0, asOptionalList());
+    public void split_validInput_success() {
+        // Zero numOfParts
+        assertSplitSuccess("abc", 0, asOptionalList());
 
         // Empty string
-        assertPreambleListCorrect("", 1, asOptionalList(""));
+        assertSplitSuccess("", 1, asOptionalList(""));
 
         // No whitespaces
-        assertPreambleListCorrect("abc", 1, asOptionalList("abc"));
+        assertSplitSuccess("abc", 1, asOptionalList("abc"));
 
-        // Single whitespace between fields
-        assertPreambleListCorrect("abc 123", 2, asOptionalList("abc", "123"));
+        // Single whitespace between parts
+        assertSplitSuccess("abc 123", 2, asOptionalList("abc", "123"));
 
-        // Multiple whitespaces between fields
-        assertPreambleListCorrect("abc  \n qwe \t  123", 3, asOptionalList("abc", "qwe", "123"));
+        // Multiple whitespaces between parts
+        assertSplitSuccess("abc  \n qwe \t  123", 3, asOptionalList("abc", "qwe", "123"));
 
-        // More whitespaces than numFields
-        assertPreambleListCorrect("abc 123 qwe 456", 2,  asOptionalList("abc", "123 qwe 456"));
+        // More whitespaces than numOfParts
+        assertSplitSuccess("abc 123 qwe 456", 2,  asOptionalList("abc", "123 qwe 456"));
 
-        // More numFields than whitespaces
-        assertPreambleListCorrect("abc", 2,  asOptionalList("abc", null));
+        // More numOfParts than whitespaces
+        assertSplitSuccess("abc", 2,  asOptionalList("abc", null));
     }
 
     /**
-     * Splits {@code string} into ordered fields of size {@code numOfParts}
+     * Splits {@code string} into ordered parts of size {@code numOfParts}
      * and checks if the result is the same as {@code expectedValues}
      */
-    private void assertPreambleListCorrect(String string, int numOfParts, List<Optional<String>> expectedValues) {
-        List<Optional<String>> list = ParserUtil.splitPreamble(string, numOfParts);
+    private void assertSplitSuccess(String string, int numOfParts, List<Optional<String>> expectedValues) {
+        List<Optional<String>> list = ParserUtil.split(string, numOfParts);
 
         assertTrue(list.equals(expectedValues));
     }

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -90,8 +90,8 @@ public class ParserUtilTest {
         // Single whitespace between parts
         assertSplitSuccess("abc 123", 2, asOptionalList("abc", "123"));
 
-        // Multiple whitespaces between parts
-        assertSplitSuccess("abc  \n qwe \t  123", 3, asOptionalList("abc", "qwe", "123"));
+        // Leading and trailing whitespaces, multiple whitespaces between parts
+        assertSplitSuccess(" \t abc  \n qwe \t  123\t\n", 3, asOptionalList("abc", "qwe", "123"));
 
         // More whitespaces than numOfParts
         assertSplitSuccess("abc 123 qwe 456", 2,  asOptionalList("abc", "123 qwe 456"));

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -9,8 +9,10 @@ import static seedu.address.testutil.TypicalPersons.INDEX_FIRST_PERSON;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -60,6 +62,60 @@ public class ParserUtilTest {
 
         // Leading and trailing whitespaces
         assertEquals(INDEX_FIRST_PERSON, ParserUtil.parseIndex("  1  "));
+    }
+
+    @Test
+    public void splitPreamble_nullPreamble_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
+        ParserUtil.splitPreamble(null, 0);
+    }
+
+    @Test
+    public void splitPreamble_negativeNumFields_throwsNegativeArraySizeException() {
+        thrown.expect(NegativeArraySizeException.class);
+        ParserUtil.splitPreamble("abc", -1);
+    }
+
+    @Test
+    public void splitPreamble_validInput_success() {
+        // Zero numFields
+        assertPreambleListCorrect("abc", 0, asOptionalList());
+
+        // Empty string
+        assertPreambleListCorrect("", 1, asOptionalList(""));
+
+        // No whitespaces
+        assertPreambleListCorrect("abc", 1, asOptionalList("abc"));
+
+        // Single whitespace between fields
+        assertPreambleListCorrect("abc 123", 2, asOptionalList("abc", "123"));
+
+        // Multiple whitespaces between fields
+        assertPreambleListCorrect("abc  \n qwe \t  123", 3, asOptionalList("abc", "qwe", "123"));
+
+        // More whitespaces than numFields
+        assertPreambleListCorrect("abc 123 qwe 456", 2,  asOptionalList("abc", "123 qwe 456"));
+
+        // More numFields than whitespaces
+        assertPreambleListCorrect("abc", 2,  asOptionalList("abc", null));
+    }
+
+    /**
+     * Splits {@code string} into ordered fields of size {@code numOfParts}
+     * and checks if the result is the same as {@code expectedValues}
+     */
+    private void assertPreambleListCorrect(String string, int numOfParts, List<Optional<String>> expectedValues) {
+        List<Optional<String>> list = ParserUtil.splitPreamble(string, numOfParts);
+
+        assertTrue(list.equals(expectedValues));
+    }
+
+    /**
+     * Returns {@code strings} as {@code List<Optional<String>>}. Null values will be converted to
+     * {@code Optional.empty()}.
+     */
+    private List<Optional<String>> asOptionalList(String... strings) {
+        return Arrays.stream(strings).map(Optional::ofNullable).collect(Collectors.toList());
     }
 
     @Test


### PR DESCRIPTION
Part of #401 

Proposed merge commit message:
```
ParserUtil#split() has no unit test.

It exhibits undesirable behaviours such as not properly splitting the
string when there are leading and trailing white spaces. For example, 
the string " abc def" will be split into: an empty string and "abc def",
instead of two strings "abc" and "def". It also allows the method to be
called when there are fewer than 2 parts.

Let's fix those issues and create unit tests for the method.
```