### PR TITLE
Create a new Index class #438

### DIFF
--- a/src/main/java/seedu/address/commons/core/index/Index.java
+++ b/src/main/java/seedu/address/commons/core/index/Index.java
@@ -1,0 +1,54 @@
+package seedu.address.commons.core.index;
+
+/**
+ * Represents a zero-based or one-based index.
+ *
+ * {@code Index} should be used right from the start (when parsing in a new user input), so that if the current
+ * component wants to communicate with another component, it can send an {@code Index} to avoid having to know what
+ * base the other component is using for its index. However, after receiving the {@code Index}, that component can
+ * convert it back to an int if the index will not be passed to a different component again.
+ */
+public class Index {
+    private int zeroBasedIndex;
+
+    /**
+     * Index can only be created by calling {@link Index#fromZeroBased(int)} or
+     * {@link Index#fromOneBased(int)}.
+     */
+    private Index(int zeroBasedIndex) {
+        if (zeroBasedIndex < 0) {
+            throw new IndexOutOfBoundsException();
+        }
+
+        this.zeroBasedIndex = zeroBasedIndex;
+    }
+
+    public int getZeroBased() {
+        return zeroBasedIndex;
+    }
+
+    public int getOneBased() {
+        return zeroBasedIndex + 1;
+    }
+
+    /**
+     * Creates a new {@code Index} using a zero-based index.
+     */
+    public static Index fromZeroBased(int zeroBasedIndex) {
+        return new Index(zeroBasedIndex);
+    }
+
+    /**
+     * Creates a new {@code Index} using a one-based index.
+     */
+    public static Index fromOneBased(int oneBasedIndex) {
+        return new Index(oneBasedIndex - 1);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof Index // instanceof handles nulls
+                && this.zeroBasedIndex == ((Index) other).zeroBasedIndex); // state check
+    }
+}

--- a/src/main/java/seedu/address/commons/events/ui/JumpToListRequestEvent.java
+++ b/src/main/java/seedu/address/commons/events/ui/JumpToListRequestEvent.java
@@ -1,5 +1,6 @@
 package seedu.address.commons.events.ui;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.commons.events.BaseEvent;
 
 /**
@@ -9,8 +10,8 @@ public class JumpToListRequestEvent extends BaseEvent {
 
     public final int targetIndex;
 
-    public JumpToListRequestEvent(int targetIndex) {
-        this.targetIndex = targetIndex;
+    public JumpToListRequestEvent(Index targetIndex) {
+        this.targetIndex = targetIndex.getZeroBased();
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -2,7 +2,7 @@ package seedu.address.logic.commands;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.UnmodifiableObservableList;
-import seedu.address.commons.util.IndexUtil;
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.person.ReadOnlyPerson;
 import seedu.address.model.person.UniquePersonList.PersonNotFoundException;
@@ -21,9 +21,9 @@ public class DeleteCommand extends Command {
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
 
-    public final int targetIndex;
+    public final Index targetIndex;
 
-    public DeleteCommand(int targetIndex) {
+    public DeleteCommand(Index targetIndex) {
         this.targetIndex = targetIndex;
     }
 
@@ -33,11 +33,11 @@ public class DeleteCommand extends Command {
 
         UnmodifiableObservableList<ReadOnlyPerson> lastShownList = model.getFilteredPersonList();
 
-        if (lastShownList.size() < targetIndex) {
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
 
-        ReadOnlyPerson personToDelete = lastShownList.get(IndexUtil.oneToZeroIndex(targetIndex));
+        ReadOnlyPerson personToDelete = lastShownList.get(targetIndex.getZeroBased());
 
         try {
             model.deletePerson(personToDelete);

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.commons.util.AppUtil.checkArgument;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
@@ -12,8 +11,8 @@ import java.util.Optional;
 import java.util.Set;
 
 import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.CollectionUtil;
-import seedu.address.commons.util.IndexUtil;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
@@ -47,18 +46,18 @@ public class EditCommand extends Command {
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book.";
 
-    private final int filteredPersonListIndex;
+    private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;
 
     /**
-     * @param filteredPersonListIndex the index of the person in the filtered person list to edit
+     * @param index of the person in the filtered person list to edit
      * @param editPersonDescriptor details to edit the person with
      */
-    public EditCommand(int filteredPersonListIndex, EditPersonDescriptor editPersonDescriptor) {
-        checkArgument(filteredPersonListIndex > 0);
+    public EditCommand(Index index, EditPersonDescriptor editPersonDescriptor) {
+        requireNonNull(index);
         requireNonNull(editPersonDescriptor);
 
-        this.filteredPersonListIndex = IndexUtil.oneToZeroIndex(filteredPersonListIndex);
+        this.index = index;
         this.editPersonDescriptor = new EditPersonDescriptor(editPersonDescriptor);
     }
 
@@ -66,15 +65,15 @@ public class EditCommand extends Command {
     public CommandResult execute() throws CommandException {
         List<ReadOnlyPerson> lastShownList = model.getFilteredPersonList();
 
-        if (filteredPersonListIndex >= lastShownList.size()) {
+        if (index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
 
-        ReadOnlyPerson personToEdit = lastShownList.get(filteredPersonListIndex);
+        ReadOnlyPerson personToEdit = lastShownList.get(index.getZeroBased());
         Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
 
         try {
-            model.updatePerson(filteredPersonListIndex, editedPerson);
+            model.updatePerson(index, editedPerson);
         } catch (UniquePersonList.DuplicatePersonException dpe) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
@@ -113,7 +112,7 @@ public class EditCommand extends Command {
 
         // state check
         EditCommand e = (EditCommand) other;
-        return filteredPersonListIndex == e.filteredPersonListIndex
+        return index.equals(e.index)
                 && editPersonDescriptor.equals(e.editPersonDescriptor);
     }
 

--- a/src/main/java/seedu/address/logic/commands/SelectCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SelectCommand.java
@@ -3,8 +3,8 @@ package seedu.address.logic.commands;
 import seedu.address.commons.core.EventsCenter;
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.UnmodifiableObservableList;
+import seedu.address.commons.core.index.Index;
 import seedu.address.commons.events.ui.JumpToListRequestEvent;
-import seedu.address.commons.util.IndexUtil;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.person.ReadOnlyPerson;
 
@@ -22,9 +22,9 @@ public class SelectCommand extends Command {
 
     public static final String MESSAGE_SELECT_PERSON_SUCCESS = "Selected Person: %1$s";
 
-    public final int targetIndex;
+    public final Index targetIndex;
 
-    public SelectCommand(int targetIndex) {
+    public SelectCommand(Index targetIndex) {
         this.targetIndex = targetIndex;
     }
 
@@ -33,12 +33,12 @@ public class SelectCommand extends Command {
 
         UnmodifiableObservableList<ReadOnlyPerson> lastShownList = model.getFilteredPersonList();
 
-        if (lastShownList.size() < targetIndex) {
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
 
-        EventsCenter.getInstance().post(new JumpToListRequestEvent(IndexUtil.oneToZeroIndex(targetIndex)));
-        return new CommandResult(String.format(MESSAGE_SELECT_PERSON_SUCCESS, targetIndex));
+        EventsCenter.getInstance().post(new JumpToListRequestEvent(targetIndex));
+        return new CommandResult(String.format(MESSAGE_SELECT_PERSON_SUCCESS, targetIndex.getOneBased()));
 
     }
 

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -18,7 +19,7 @@ public class DeleteCommandParser {
      */
     public DeleteCommand parse(String args) throws ParseException {
         try {
-            int index = ParserUtil.parseIndex(args);
+            Index index = ParserUtil.parseIndex(args);
             return new DeleteCommand(index);
         } catch (IllegalValueException ive) {
             throw new ParseException(

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
@@ -39,7 +40,7 @@ public class EditCommandParser {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
         }
 
-        int index;
+        Index index;
 
         try {
             index = ParserUtil.parseIndex(preambleFields.get(0).get());

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.model.person.Address;
@@ -26,16 +27,16 @@ public class ParserUtil {
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
 
     /**
-     * Parses {@code index} into an integer and returns it. Leading and trailing whitespaces will be trimmed.
+     * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
+     * trimmed.
      * @throws IllegalValueException if the specified index is invalid (not non-zero unsigned integer).
      */
-    public static int parseIndex(String index) throws IllegalValueException {
-        String trimmedIndex = index.trim();
+    public static Index parseIndex(String oneBasedIndex) throws IllegalValueException {
+        String trimmedIndex = oneBasedIndex.trim();
         if (!StringUtil.isNonZeroUnsignedInteger(trimmedIndex)) {
             throw new IllegalValueException(MESSAGE_INVALID_INDEX);
         }
-        return Integer.parseInt(trimmedIndex);
-
+        return Index.fromOneBased(Integer.parseInt(trimmedIndex));
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/SelectCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SelectCommandParser.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -18,7 +19,7 @@ public class SelectCommandParser {
      */
     public SelectCommand parse(String args) throws ParseException {
         try {
-            int index = ParserUtil.parseIndex(args);
+            Index index = ParserUtil.parseIndex(args);
             return new SelectCommand(index);
         } catch (IllegalValueException ive) {
             throw new ParseException(

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -3,6 +3,7 @@ package seedu.address.model;
 import java.util.Set;
 
 import seedu.address.commons.core.UnmodifiableObservableList;
+import seedu.address.commons.core.index.Index;
 import seedu.address.model.person.ReadOnlyPerson;
 import seedu.address.model.person.UniquePersonList;
 import seedu.address.model.person.UniquePersonList.DuplicatePersonException;
@@ -24,14 +25,13 @@ public interface Model {
     void addPerson(ReadOnlyPerson person) throws UniquePersonList.DuplicatePersonException;
 
     /**
-     * Updates the person located at {@code filteredPersonListIndex} with {@code editedPerson}.
+     * Updates the person located at {@code index} with {@code editedPerson}.
      *
      * @throws DuplicatePersonException if updating the person's details causes the person to be equivalent to
      *      another existing person in the list.
-     * @throws IndexOutOfBoundsException if {@code filteredPersonListIndex} < 0 or >= the size of the filtered list.
+     * @throws IndexOutOfBoundsException if {@code index} is out of range of the filtered list.
      */
-    void updatePerson(int filteredPersonListIndex, ReadOnlyPerson editedPerson)
-            throws UniquePersonList.DuplicatePersonException;
+    void updatePerson(Index index, ReadOnlyPerson editedPerson) throws UniquePersonList.DuplicatePersonException;
 
     /** Returns the filtered person list as an {@code UnmodifiableObservableList<ReadOnlyPerson>} */
     UnmodifiableObservableList<ReadOnlyPerson> getFilteredPersonList();

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -10,6 +10,7 @@ import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.ComponentManager;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.core.UnmodifiableObservableList;
+import seedu.address.commons.core.index.Index;
 import seedu.address.commons.events.model.AddressBookChangedEvent;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.model.person.ReadOnlyPerson;
@@ -73,11 +74,11 @@ public class ModelManager extends ComponentManager implements Model {
     }
 
     @Override
-    public void updatePerson(int filteredPersonListIndex, ReadOnlyPerson editedPerson)
+    public void updatePerson(Index index, ReadOnlyPerson editedPerson)
             throws UniquePersonList.DuplicatePersonException {
         requireNonNull(editedPerson);
 
-        int addressBookIndex = filteredPersons.getSourceIndex(filteredPersonListIndex);
+        int addressBookIndex = filteredPersons.getSourceIndex(index.getZeroBased());
         addressBook.updatePerson(addressBookIndex, editedPerson);
         indicateAddressBookChanged();
     }

--- a/src/test/java/seedu/address/commons/core/index/IndexTest.java
+++ b/src/test/java/seedu/address/commons/core/index/IndexTest.java
@@ -1,0 +1,93 @@
+package seedu.address.commons.core.index;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+public class IndexTest {
+
+    @Test
+    public void createOneBasedIndex() {
+        // invalid index
+        assertCreateOneBasedFailure(0);
+
+        // check equality using the same base
+        assertEquals(1, Index.fromOneBased(1).getOneBased());
+        assertEquals(5, Index.fromOneBased(5).getOneBased());
+
+        // convert from one-based index to zero-based index
+        assertEquals(0, Index.fromOneBased(1).getZeroBased());
+        assertEquals(4, Index.fromOneBased(5).getZeroBased());
+    }
+
+    @Test
+    public void createZeroBasedIndex() {
+        // invalid index
+        assertCreateZeroBasedFailure(-1);
+
+        // check equality using the same base
+        assertEquals(0, Index.fromZeroBased(0).getZeroBased());
+        assertEquals(5, Index.fromZeroBased(5).getZeroBased());
+
+        // convert from zero-based index to one-based index
+        assertEquals(1, Index.fromZeroBased(0).getOneBased());
+        assertEquals(6, Index.fromZeroBased(5).getOneBased());
+    }
+
+    /**
+     * Executes {@code Index#fromZeroBased(int)} with {@code invalidZeroBasedIndex}, confirms that an
+     * {@code IndexOutOfBoundsException} is thrown.
+     */
+    private void assertCreateZeroBasedFailure(int invalidZeroBasedIndex) {
+        assertCreateFailure(invalidZeroBasedIndex, true);
+    }
+
+    /**
+     * Executes {@code Index#fromOneBased(int)} with {@code invalidOneBasedIndex}, confirms that an
+     * {@code IndexOutOfBoundsException} is thrown.
+     */
+    private void assertCreateOneBasedFailure(int invalidOneBasedIndex) {
+        assertCreateFailure(invalidOneBasedIndex, false);
+    }
+
+    /**
+     * Executes either {@code Index#fromZeroBased(int)} (if it is zero based), or {@code Index#fromOneBased(int)}
+     * (if it is one based), and confirms that an {@code IndexOutOfBoundsException} is thrown.
+     */
+    private void assertCreateFailure(int invalidIndex, boolean isZeroBased) {
+        try {
+            if (isZeroBased) {
+                Index.fromZeroBased(invalidIndex);
+            } else {
+                Index.fromOneBased(invalidIndex);
+            }
+            fail("The expected IndexOutOfBoundsException was not thrown.");
+        } catch (IndexOutOfBoundsException ie) {
+            // expected behaviour
+        }
+    }
+
+    @Test
+    public void equals() {
+        final Index fifthPersonIndex = Index.fromOneBased(5);
+
+        // same values -> returns true
+        assertTrue(fifthPersonIndex.equals(Index.fromOneBased(5)));
+        assertTrue(fifthPersonIndex.equals(Index.fromZeroBased(4)));
+
+        // same object -> returns true
+        assertTrue(fifthPersonIndex.equals(fifthPersonIndex));
+
+        // null -> returns false
+        assertFalse(fifthPersonIndex.equals(null));
+
+        // different types -> returns false
+        assertFalse(fifthPersonIndex.equals(5.0f));
+
+        // different index -> returns false
+        assertFalse(fifthPersonIndex.equals(Index.fromOneBased(1)));
+    }
+}

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -10,6 +10,8 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.model.util.SampleDataUtil.getTagSet;
+import static seedu.address.testutil.TypicalPersons.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalPersons.INDEX_THIRD_PERSON;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -27,6 +29,7 @@ import org.junit.rules.TemporaryFolder;
 import com.google.common.eventbus.Subscribe;
 
 import seedu.address.commons.core.EventsCenter;
+import seedu.address.commons.core.index.Index;
 import seedu.address.commons.events.model.AddressBookChangedEvent;
 import seedu.address.commons.events.ui.JumpToListRequestEvent;
 import seedu.address.commons.events.ui.ShowHelpRequestEvent;
@@ -73,7 +76,7 @@ public class LogicManagerTest {
     //These are for checking the correctness of the events raised
     private ReadOnlyAddressBook latestSavedAddressBook;
     private boolean helpShown;
-    private int targetedJumpIndex;
+    private Index targetedJumpIndex;
 
     @Subscribe
     private void handleLocalModelChangedEvent(AddressBookChangedEvent abce) {
@@ -87,7 +90,7 @@ public class LogicManagerTest {
 
     @Subscribe
     private void handleJumpToListRequestEvent(JumpToListRequestEvent je) {
-        targetedJumpIndex = je.targetIndex;
+        targetedJumpIndex = Index.fromZeroBased(je.targetIndex);
     }
 
     @Before
@@ -103,7 +106,7 @@ public class LogicManagerTest {
 
         latestSavedAddressBook = new AddressBook(model.getAddressBook()); // last saved assumed to be up to date
         helpShown = false;
-        targetedJumpIndex = -1; // non yet
+        targetedJumpIndex = null;
     }
 
     @After
@@ -317,7 +320,7 @@ public class LogicManagerTest {
             model.addPerson(p);
         }
 
-        assertCommandException(commandWord + " 3", expectedMessage);
+        assertCommandException(commandWord + " " + INDEX_THIRD_PERSON.getOneBased(), expectedMessage);
     }
 
     @Test
@@ -341,7 +344,7 @@ public class LogicManagerTest {
 
         assertCommandSuccess(SelectCommand.COMMAND_WORD + " 2",
                 String.format(SelectCommand.MESSAGE_SELECT_PERSON_SUCCESS, 2), expectedModel);
-        assertEquals(1, targetedJumpIndex);
+        assertEquals(INDEX_SECOND_PERSON, targetedJumpIndex);
         assertEquals(model.getFilteredPersonList().get(1), threePersons.get(1));
     }
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import seedu.address.commons.core.UnmodifiableObservableList;
+import seedu.address.commons.core.index.Index;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -90,7 +91,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public void updatePerson(int filteredPersonListIndex, ReadOnlyPerson editedPerson)
+        public void updatePerson(Index filteredPersonListIndex, ReadOnlyPerson editedPerson)
                 throws DuplicatePersonException {
             fail("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -7,6 +7,8 @@ import static org.junit.Assert.fail;
 import static seedu.address.testutil.EditCommandTestUtil.DESC_AMY;
 import static seedu.address.testutil.EditCommandTestUtil.DESC_BOB;
 import static seedu.address.testutil.EditCommandTestUtil.VALID_NAME_BOB;
+import static seedu.address.testutil.TypicalPersons.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalPersons.INDEX_SECOND_PERSON;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,6 +18,7 @@ import org.junit.Test;
 
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -35,23 +38,18 @@ import seedu.address.testutil.TypicalPersons;
  */
 public class EditCommandTest {
 
-    // zero-based index is used for interacting with Model, one-based index is used for interacting with EditCommand
-    private static final int ZERO_BASED_INDEX_FIRST_PERSON = 0;
-    private static final int ONE_BASED_INDEX_FIRST_PERSON = 1;
-    private static final int ONE_BASED_INDEX_SECOND_PERSON =  ONE_BASED_INDEX_FIRST_PERSON + 1;
-
     private Model model = new ModelManager(new TypicalPersons().getTypicalAddressBook(), new UserPrefs());
 
     @Test
     public void execute_validCommand_succeeds() throws Exception {
         Person editedPerson = new PersonBuilder().build();
         EditPersonDescriptor descriptor = createEditPersonDescriptor(editedPerson);
-        EditCommand editCommand = prepareCommand(ONE_BASED_INDEX_FIRST_PERSON, descriptor);
+        EditCommand editCommand = prepareCommand(INDEX_FIRST_PERSON, descriptor);
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
 
         AddressBook expectedAddressBook = new AddressBook(model.getAddressBook());
-        expectedAddressBook.updatePerson(ZERO_BASED_INDEX_FIRST_PERSON, editedPerson);
+        expectedAddressBook.updatePerson(INDEX_FIRST_PERSON.getZeroBased(), editedPerson);
         FilteredList<ReadOnlyPerson> expectedFilteredList = new FilteredList<>(expectedAddressBook.getPersonList());
 
         assertCommandSuccess(editCommand, expectedMessage, expectedAddressBook, expectedFilteredList);
@@ -59,27 +57,27 @@ public class EditCommandTest {
 
     @Test
     public void execute_duplicatePerson_throwsCommandException() throws Exception {
-        Person firstPerson = new Person(model.getFilteredPersonList().get(ZERO_BASED_INDEX_FIRST_PERSON));
+        Person firstPerson = new Person(model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased()));
         EditPersonDescriptor descriptor = createEditPersonDescriptor(firstPerson);
-        EditCommand editCommand = prepareCommand(ONE_BASED_INDEX_SECOND_PERSON, descriptor);
+        EditCommand editCommand = prepareCommand(INDEX_SECOND_PERSON, descriptor);
         assertCommandFailure(editCommand, EditCommand.MESSAGE_DUPLICATE_PERSON);
     }
 
     @Test
     public void execute_invalidPersonIndex_throwsCommandException() throws Exception {
-        int oneBasedOutOfBoundIndex = model.getFilteredPersonList().size() + 1;
+        Index outOfBoundIndex = Index.fromZeroBased(model.getFilteredPersonList().size());
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build();
-        EditCommand editCommand = prepareCommand(oneBasedOutOfBoundIndex, descriptor);
+        EditCommand editCommand = prepareCommand(outOfBoundIndex, descriptor);
         assertCommandFailure(editCommand, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 
     @Test
     public void equals() {
-        final EditCommand standardCommand = new EditCommand(1, DESC_AMY);
+        final EditCommand standardCommand = new EditCommand(INDEX_FIRST_PERSON, DESC_AMY);
 
         // same values -> returns true
         EditPersonDescriptor copyDescriptor = new EditPersonDescriptor(DESC_AMY);
-        EditCommand commandWithSameValues = new EditCommand(1, copyDescriptor);
+        EditCommand commandWithSameValues = new EditCommand(INDEX_FIRST_PERSON, copyDescriptor);
         assertTrue(standardCommand.equals(commandWithSameValues));
 
         // same object -> returns true
@@ -92,17 +90,17 @@ public class EditCommandTest {
         assertFalse(standardCommand.equals(new ClearCommand()));
 
         // different index -> returns false
-        assertFalse(standardCommand.equals(new EditCommand(2, DESC_AMY)));
+        assertFalse(standardCommand.equals(new EditCommand(INDEX_SECOND_PERSON, DESC_AMY)));
 
         // different descriptor -> returns false
-        assertFalse(standardCommand.equals(new EditCommand(1, DESC_BOB)));
+        assertFalse(standardCommand.equals(new EditCommand(INDEX_FIRST_PERSON, DESC_BOB)));
     }
 
     /**
-     * Returns an {@code EditCommand} with parameters {@code oneBasedIndex} and {@code descriptor}
+     * Returns an {@code EditCommand} with parameters {@code index} and {@code descriptor}
      */
-    private EditCommand prepareCommand(int oneBasedIndex, EditPersonDescriptor descriptor) {
-        EditCommand editCommand = new EditCommand(oneBasedIndex, descriptor);
+    private EditCommand prepareCommand(Index index, EditPersonDescriptor descriptor) {
+        EditCommand editCommand = new EditCommand(index, descriptor);
         editCommand.setData(model);
         return editCommand;
     }

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -16,9 +16,13 @@ import static seedu.address.testutil.EditCommandTestUtil.VALID_PHONE_AMY;
 import static seedu.address.testutil.EditCommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.testutil.EditCommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.address.testutil.EditCommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.testutil.TypicalPersons.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalPersons.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalPersons.INDEX_THIRD_PERSON;
 
 import org.junit.Test;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
@@ -124,9 +128,9 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_allFieldsSpecified_success() throws Exception {
-        int targetIndex = 2;
-        String userInput = targetIndex + NAME_DESC_AMY + PHONE_DESC_BOB + TAG_DESC_HUSBAND + EMAIL_DESC_AMY
-                + ADDRESS_DESC_AMY + TAG_DESC_FRIEND;
+        Index targetIndex = INDEX_SECOND_PERSON;
+        String userInput = targetIndex.getOneBased() + NAME_DESC_AMY + PHONE_DESC_BOB + TAG_DESC_HUSBAND
+                + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + TAG_DESC_FRIEND;
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY)
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)
@@ -138,8 +142,8 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_someFieldsSpecified_success() throws Exception {
-        int targetIndex = 1;
-        String userInput = targetIndex + PHONE_DESC_BOB + EMAIL_DESC_AMY;
+        Index targetIndex = INDEX_FIRST_PERSON;
+        String userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + EMAIL_DESC_AMY;
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withPhone(VALID_PHONE_BOB)
                 .withEmail(VALID_EMAIL_AMY).build();
@@ -151,32 +155,32 @@ public class EditCommandParserTest {
     @Test
     public void parse_oneFieldSpecified_success() throws Exception {
         // name
-        int targetIndex = 3;
-        String userInput = targetIndex + NAME_DESC_AMY;
+        Index targetIndex = INDEX_THIRD_PERSON;
+        String userInput = targetIndex.getOneBased() + NAME_DESC_AMY;
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(userInput, expectedCommand);
 
         // phone
-        userInput = targetIndex + PHONE_DESC_AMY;
+        userInput = targetIndex.getOneBased() + PHONE_DESC_AMY;
         descriptor = new EditPersonDescriptorBuilder().withPhone(VALID_PHONE_AMY).build();
         expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(userInput, expectedCommand);
 
         // email
-        userInput = targetIndex + EMAIL_DESC_AMY;
+        userInput = targetIndex.getOneBased() + EMAIL_DESC_AMY;
         descriptor = new EditPersonDescriptorBuilder().withEmail(VALID_EMAIL_AMY).build();
         expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(userInput, expectedCommand);
 
         // address
-        userInput = targetIndex + ADDRESS_DESC_AMY;
+        userInput = targetIndex.getOneBased() + ADDRESS_DESC_AMY;
         descriptor = new EditPersonDescriptorBuilder().withAddress(VALID_ADDRESS_AMY).build();
         expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(userInput, expectedCommand);
 
         // tags
-        userInput = targetIndex + TAG_DESC_FRIEND;
+        userInput = targetIndex.getOneBased() + TAG_DESC_FRIEND;
         descriptor = new EditPersonDescriptorBuilder().withTags(VALID_TAG_FRIEND).build();
         expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(userInput, expectedCommand);
@@ -184,10 +188,10 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_multipleRepeatedFields_acceptsLast() throws Exception {
-        int targetIndex = 1;
-        String userInput = targetIndex + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY + TAG_DESC_FRIEND
-                + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY + TAG_DESC_FRIEND + PHONE_DESC_BOB
-                + ADDRESS_DESC_BOB + EMAIL_DESC_BOB + TAG_DESC_HUSBAND;
+        Index targetIndex = INDEX_FIRST_PERSON;
+        String userInput = targetIndex.getOneBased()  + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY
+                + TAG_DESC_FRIEND + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY + TAG_DESC_FRIEND
+                + PHONE_DESC_BOB + ADDRESS_DESC_BOB + EMAIL_DESC_BOB + TAG_DESC_HUSBAND;
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withPhone(VALID_PHONE_BOB)
                 .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND)
@@ -200,14 +204,15 @@ public class EditCommandParserTest {
     @Test
     public void parse_invalidValueFollowedByValidValue_success() throws Exception {
         // no other valid values specified
-        int targetIndex = 1;
-        String userInput = targetIndex + INVALID_PHONE_DESC + PHONE_DESC_BOB;
+        Index targetIndex = INDEX_FIRST_PERSON;
+        String userInput = targetIndex.getOneBased() + INVALID_PHONE_DESC + PHONE_DESC_BOB;
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withPhone(VALID_PHONE_BOB).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(userInput, expectedCommand);
 
         // other valid values specified
-        userInput = targetIndex + EMAIL_DESC_BOB + INVALID_PHONE_DESC + ADDRESS_DESC_BOB + PHONE_DESC_BOB;
+        userInput = targetIndex.getOneBased() + EMAIL_DESC_BOB + INVALID_PHONE_DESC + ADDRESS_DESC_BOB
+                + PHONE_DESC_BOB;
         descriptor = new EditPersonDescriptorBuilder().withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
                 .withAddress(VALID_ADDRESS_BOB).build();
         expectedCommand = new EditCommand(targetIndex, descriptor);
@@ -216,8 +221,8 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_resetTags_success() throws Exception {
-        int targetIndex = 3;
-        String userInput = targetIndex + TAG_EMPTY;
+        Index targetIndex = INDEX_THIRD_PERSON;
+        String userInput = targetIndex.getOneBased() + TAG_EMPTY;
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withTags().build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
+import static seedu.address.testutil.TypicalPersons.INDEX_FIRST_PERSON;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -55,10 +56,10 @@ public class ParserUtilTest {
     @Test
     public void parseIndex_validInput_success() throws Exception {
         // No whitespaces
-        assertEquals(1, ParserUtil.parseIndex("1"));
+        assertEquals(INDEX_FIRST_PERSON, ParserUtil.parseIndex("1"));
 
         // Leading and trailing whitespaces
-        assertEquals(1, ParserUtil.parseIndex("  1  "));
+        assertEquals(INDEX_FIRST_PERSON, ParserUtil.parseIndex("  1  "));
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -1,5 +1,6 @@
 package seedu.address.testutil;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.person.Person;
@@ -9,6 +10,10 @@ import seedu.address.model.person.UniquePersonList;
  *
  */
 public class TypicalPersons {
+
+    public static final Index INDEX_FIRST_PERSON = Index.fromOneBased(1);
+    public static final Index INDEX_SECOND_PERSON = Index.fromOneBased(2);
+    public static final Index INDEX_THIRD_PERSON = Index.fromOneBased(3);
 
     public final Person alice, benson, carl, daniel, elle, fiona, george, hoon, ida;
 


### PR DESCRIPTION
Fixes #438

Proposed merge commit message:
```
The usages of zero-based indices and one-based indices are mixed
throughout the codebase. Both uses int, and are only differentiated by
different suffixes for the variable names (e.g int zeroBasedIndex,
int oneBasedIndex).

The index base can be easily confused and is prone to error. The
conversion also takes place at different areas of the codebase and is
not consistent.

Let's create an Index class that understands how to convert to a
both zero-based and one-based index, and update the codebase to use
Index instead of int when handling user inputs.

Index from the point when a new user input is being parsed, so that if
the current component wants to communicate with another component, it
can send an Index to avoid having to know what base the other component
is using for its index. However, after receiving the Index, that
component can convert it back to an int if the index will not be passed
to a different component again.
```