### PR TITLE
Update tests to compare at Model level #456

### DIFF
--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -104,6 +104,24 @@ public class ModelManager extends ComponentManager implements Model {
         filteredPersons.setPredicate(expression::satisfies);
     }
 
+    @Override
+    public boolean equals(Object obj) {
+        // short circuit if same object
+        if (obj == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(obj instanceof ModelManager)) {
+            return false;
+        }
+
+        // state check
+        ModelManager other = (ModelManager) obj;
+        return addressBook.equals(other.addressBook)
+                && filteredPersons.equals(other.filteredPersons);
+    }
+
     //========== Inner classes/interfaces used for filtering =================================================
 
     interface Expression {

--- a/src/test/java/seedu/address/logic/commands/EditCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandIntegrationTest.java
@@ -3,23 +3,16 @@ package seedu.address.logic.commands;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.junit.Test;
 
-import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
-import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.Person;
-import seedu.address.model.person.ReadOnlyPerson;
 import seedu.address.testutil.PersonBuilder;
 import seedu.address.testutil.PersonUtil;
 import seedu.address.testutil.TypicalPersons;
@@ -46,11 +39,10 @@ public class EditCommandIntegrationTest {
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
 
-        AddressBook expectedAddressBook = new AddressBook(model.getAddressBook());
-        expectedAddressBook.updatePerson(ZERO_BASED_INDEX_FIRST_PERSON, editedPerson);
-        FilteredList<ReadOnlyPerson> expectedFilteredList = new FilteredList<>(expectedAddressBook.getPersonList());
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.updatePerson(ZERO_BASED_INDEX_FIRST_PERSON, editedPerson);
 
-        assertCommandSuccess(command, expectedMessage, expectedAddressBook, expectedFilteredList);
+        assertCommandSuccess(command, expectedMessage, expectedModel);
     }
 
     @Test
@@ -82,12 +74,10 @@ public class EditCommandIntegrationTest {
      * - the filtered person list in the model matches {@code expectedFilteredList} <br>
      */
     private void assertCommandSuccess(Command command, String expectedMessage,
-            ReadOnlyAddressBook expectedAddressBook,
-            List<? extends ReadOnlyPerson> expectedFilteredList) throws CommandException {
+            Model expectedModel) throws CommandException {
         CommandResult result = command.execute();
         assertEquals(expectedMessage, result.feedbackToUser);
-        assertEquals(expectedAddressBook, model.getAddressBook());
-        assertEquals(expectedFilteredList, model.getFilteredPersonList());
+        assertEquals(expectedModel, model);
     }
 
     /**
@@ -98,15 +88,13 @@ public class EditCommandIntegrationTest {
      * - the filtered person list in the model remains unchanged <br>
      */
     private void assertCommandFailure(Command command, String expectedMessage) {
-        AddressBook expectedAddressBook = new AddressBook(model.getAddressBook());
-        List<ReadOnlyPerson> expectedFilteredList = new ArrayList<>(model.getFilteredPersonList());
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         try {
             command.execute();
             fail("expected CommandException was not thrown.");
         } catch (CommandException e) {
             assertEquals(expectedMessage, e.getMessage());
-            assertEquals(expectedAddressBook, model.getAddressBook());
-            assertEquals(expectedFilteredList, model.getFilteredPersonList());
+            assertEquals(expectedModel, model);
         }
     }
 }

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -1,0 +1,53 @@
+package seedu.address.model;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+import org.junit.Test;
+
+import seedu.address.testutil.AddressBookBuilder;
+import seedu.address.testutil.TypicalPersons;
+
+public class ModelManagerTest {
+
+    private TypicalPersons typicalPersons = new TypicalPersons();
+
+    @Test
+    public void equals() throws Exception {
+        AddressBook addressBook = new AddressBookBuilder().withPerson(typicalPersons.alice)
+                .withPerson(typicalPersons.benson).build();
+        AddressBook differentAddressBook = new AddressBook();
+        UserPrefs userPrefs = new UserPrefs();
+
+        // same values -> returns true
+        ModelManager modelManager = new ModelManager(addressBook, userPrefs);
+        ModelManager modelManagerCopy = new ModelManager(addressBook, userPrefs);
+        assertTrue(modelManager.equals(modelManagerCopy));
+
+        // same object -> returns true
+        assertTrue(modelManager.equals(modelManager));
+
+        // null -> returns false
+        assertFalse(modelManager.equals(null));
+
+        // different types -> returns false
+        assertFalse(modelManager.equals(5));
+
+        // different addressBook -> returns false
+        assertFalse(modelManager.equals(new ModelManager(differentAddressBook, userPrefs)));
+
+        // different filteredList -> returns false
+        modelManager.updateFilteredPersonList(new HashSet<>(
+                Arrays.asList(typicalPersons.alice.getName().fullName.split(" "))));
+        assertFalse(modelManager.equals(new ModelManager(addressBook, userPrefs)));
+        modelManager.updateFilteredListToShowAll(); // resets modelManager to initial state for upcoming tests
+
+        // different userPrefs -> returns true
+        UserPrefs differentUserPrefs = new UserPrefs();
+        differentUserPrefs.setAddressBookName("differentName");
+        assertTrue(modelManager.equals(new ModelManager(addressBook, differentUserPrefs)));
+    }
+}

--- a/src/test/java/seedu/address/testutil/AddressBookBuilder.java
+++ b/src/test/java/seedu/address/testutil/AddressBookBuilder.java
@@ -15,6 +15,10 @@ public class AddressBookBuilder {
 
     private AddressBook addressBook;
 
+    public AddressBookBuilder() {
+        addressBook = new AddressBook();
+    }
+
     public AddressBookBuilder(AddressBook addressBook) {
         this.addressBook = addressBook;
     }


### PR DESCRIPTION
Fixes #456 

Proposed merge commit message:
```
Update tests to use assertEquals(Model, Model)

Tests check for equality of the individual components of Model 
(AddressBook and FilteredList). The following code snippet shows an 
example:

assertEquals(expectedAddressBook, model.getAddressBook());
assertEquals(expectedFilteredList, model.getFilteredPersonList());

This can be simplified by checking for equality of the entire Model
directly using ModelManager#equals().

Let's implement Model#equals() and update the tests to check for
equality of Model using assertEquals(expectedModel, model).
```