### PR TITLE
Allow up and down buttons to get previous and next input respectively

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -155,6 +155,11 @@ Selects the 1st person in the results of the `find` command.
 Lists all the commands that you have entered in chronological order. +
 Format: `history`
 
+[NOTE]
+====
+Pressing the kbd:[&uarr;] and kbd:[&darr;] arrows will display the previous and next input respectively in the command box.
+====
+
 === Clearing all entries : `clear`
 
 Clears all entries from the address book. +

--- a/src/main/java/seedu/address/logic/ListElementPointer.java
+++ b/src/main/java/seedu/address/logic/ListElementPointer.java
@@ -1,0 +1,110 @@
+package seedu.address.logic;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+/**
+ * Has a cursor that points to an element in the list, and is able to iterate through the list.
+ * This is different from {@code ListIterator}, which has a cursor that points in between elements.
+ * The {@code ListIterator}'s behaviour: when making alternating calls of {@code next()} and
+ * {@code previous()}, the same element is returned on both calls.
+ * In contrast, {@code ListElementPointer}'s behaviour: when making alternating calls of
+ * {@code next()} and {@code previous()}, the next and previous elements are returned respectively.
+ */
+public class ListElementPointer {
+    private List<String> list;
+    private int index;
+
+    /**
+     * Constructs {@code ListElementPointer} which is backed by a defensive copy of {@code list}.
+     * The cursor points to the last element in {@code list}.
+     */
+    public ListElementPointer(List<String> list) {
+        this.list = list;
+        index = this.list.size() - 1;
+    }
+
+    /**
+     * Appends {@code element} to the end of the list.
+     */
+    public void add(String element) {
+        list.add(element);
+    }
+
+    /**
+     * Returns true if calling {@code #next()} does not throw an {@code NoSuchElementException}.
+     */
+    public boolean hasNext() {
+        int nextIndex = index + 1;
+        return isWithinBounds(nextIndex);
+    }
+
+    /**
+     * Returns true if calling {@code #previous()} does not throw an {@code NoSuchElementException}.
+     */
+    public boolean hasPrevious() {
+        int previousIndex = index - 1;
+        return isWithinBounds(previousIndex);
+    }
+
+    /**
+     * Returns true if calling {@code #current()} does not throw an {@code NoSuchElementException}.
+     */
+    public boolean hasCurrent() {
+        return isWithinBounds(index);
+    }
+
+    private boolean isWithinBounds(int index) {
+        return index >= 0 && index < list.size();
+    }
+
+    /**
+     * Returns the next element in the list and advances the cursor position.
+     * @throws NoSuchElementException if there is no more next element in the list.
+     */
+    public String next() {
+        if (!hasNext()) {
+            throw new NoSuchElementException();
+        }
+        return list.get(++index);
+    }
+
+    /**
+     * Returns the previous element in the list and moves the cursor position backwards.
+     * @throws NoSuchElementException if there is no more previous element in the list.
+     */
+    public String previous() {
+        if (!hasPrevious()) {
+            throw new NoSuchElementException();
+        }
+        return list.get(--index);
+    }
+
+    /**
+     * Returns the current element in the list.
+     * @throws NoSuchElementException if the list is empty.
+     */
+    public String current() {
+        if (!hasCurrent()) {
+            throw new NoSuchElementException();
+        }
+        return list.get(index);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof ListElementPointer)) {
+            return false;
+        }
+
+        // state check
+        ListElementPointer iterator = (ListElementPointer) other;
+        return list.equals(iterator.list) && index == iterator.index;
+    }
+}

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -22,4 +22,6 @@ public interface Logic {
     /** Returns the filtered list of persons */
     ObservableList<ReadOnlyPerson> getFilteredPersonList();
 
+    /** Returns the list of input entered by the user, encapsulated in a {@code ListElementPointer} object */
+    ListElementPointer getHistorySnapshot();
 }

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -45,4 +45,9 @@ public class LogicManager extends ComponentManager implements Logic {
     public ObservableList<ReadOnlyPerson> getFilteredPersonList() {
         return model.getFilteredPersonList();
     }
+
+    @Override
+    public ListElementPointer getHistorySnapshot() {
+        return new ListElementPointer(history.getHistory());
+    }
 }

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -5,9 +5,11 @@ import java.util.logging.Logger;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.TextField;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.Region;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.events.ui.NewResultAvailableEvent;
+import seedu.address.logic.ListElementPointer;
 import seedu.address.logic.Logic;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -20,6 +22,7 @@ public class CommandBox extends UiPart<Region> {
 
     private final Logger logger = LogsCenter.getLogger(CommandBox.class);
     private final Logic logic;
+    private ListElementPointer historySnapshot;
 
     @FXML
     private TextField commandTextField;
@@ -29,19 +32,76 @@ public class CommandBox extends UiPart<Region> {
         this.logic = logic;
         // calls #setStyleToDefault() whenever there is a change to the text of the command box.
         commandTextField.textProperty().addListener((unused1, unused2, unused3) -> setStyleToDefault());
+        historySnapshot = logic.getHistorySnapshot();
+    }
+
+    @FXML
+    private void handleKeyPress(KeyEvent keyEvent) {
+        switch (keyEvent.getCode()) {
+        case UP:
+            // As up and down buttons will alter the position of the caret,
+            // consuming it causes the caret's position to remain unchanged
+            keyEvent.consume();
+
+            navigateToPreviousInput();
+            break;
+        case DOWN:
+            keyEvent.consume();
+            navigateToNextInput();
+            break;
+        default:
+            // let JavaFx handle the keypress
+        }
+    }
+
+    /**
+     * Updates the text field with the previous input in {@code historySnapshot},
+     * if there exists a previous input in {@code historySnapshot}
+     */
+    private void navigateToPreviousInput() {
+        assert historySnapshot != null;
+        if (!historySnapshot.hasPrevious()) {
+            return;
+        }
+
+        replaceText(historySnapshot.previous());
+    }
+
+    /**
+     * Updates the text field with the next input in {@code historySnapshot},
+     * if there exists a next input in {@code historySnapshot}
+     */
+    private void navigateToNextInput() {
+        assert historySnapshot != null;
+        if (!historySnapshot.hasNext()) {
+            return;
+        }
+
+        replaceText(historySnapshot.next());
+    }
+
+    /**
+     * Sets {@code CommandBox}'s text field with {@code text} and
+     * positions the caret to the end of the {@code text}.
+     */
+    private void replaceText(String text) {
+        commandTextField.setText(text);
+        commandTextField.positionCaret(commandTextField.getText().length());
     }
 
     @FXML
     private void handleCommandInputChanged() {
         try {
             CommandResult commandResult = logic.execute(commandTextField.getText());
-
+            initHistory();
+            historySnapshot.next();
             // process result of the command
             commandTextField.setText("");
             logger.info("Result: " + commandResult.feedbackToUser);
             raise(new NewResultAvailableEvent(commandResult.feedbackToUser));
 
         } catch (CommandException | ParseException e) {
+            initHistory();
             // handle command failure
             setStyleToIndicateCommandFailure();
             logger.info("Invalid command: " + commandTextField.getText());
@@ -49,6 +109,12 @@ public class CommandBox extends UiPart<Region> {
         }
     }
 
+    private void initHistory() {
+        historySnapshot = logic.getHistorySnapshot();
+        // add an empty string to represent the most-recent end of historySnapshot, to be shown to
+        // the user if she tries to navigate past the most-recent end of the historySnapshot.
+        historySnapshot.add("");
+    }
 
     /**
      * Sets the command box style to use the default style.

--- a/src/main/resources/view/CommandBox.fxml
+++ b/src/main/resources/view/CommandBox.fxml
@@ -4,6 +4,6 @@
 <?import javafx.scene.layout.StackPane?>
 
 <StackPane styleClass="anchor-pane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
-  <TextField fx:id="commandTextField" onAction="#handleCommandInputChanged" promptText="Enter command here..."/>
+  <TextField fx:id="commandTextField" onAction="#handleCommandInputChanged" onKeyPressed="#handleKeyPress" promptText="Enter command here..."/>
 </StackPane>
 

--- a/src/test/java/guitests/CommandBoxTest.java
+++ b/src/test/java/guitests/CommandBoxTest.java
@@ -53,14 +53,13 @@ public class CommandBoxTest extends AddressBookGuiTest {
 
     @Test
     public void commandBox_handleKeyPress() {
-        GuiRobot robot = new GuiRobot();
         commandBox.runCommand(COMMAND_THAT_FAILS);
         assertEquals(errorStyleOfCommandBox, commandBox.getStyleClass());
-        robot.push(KeyCode.ESCAPE);
+        guiRobot.push(KeyCode.ESCAPE);
         assertEquals(errorStyleOfCommandBox, commandBox.getStyleClass());
 
-        robot.push(KeyCode.A);
-        robot.pauseForHuman();
+        guiRobot.push(KeyCode.A);
+        guiRobot.pauseForHuman();
         assertEquals(defaultStyleOfCommandBox, commandBox.getStyleClass());
     }
 

--- a/src/test/java/guitests/CommandBoxTest.java
+++ b/src/test/java/guitests/CommandBoxTest.java
@@ -18,6 +18,7 @@ public class CommandBoxTest extends AddressBookGuiTest {
     private static final String COMMAND_THAT_SUCCEEDS = SelectCommand.COMMAND_WORD + " 3";
     private static final String COMMAND_THAT_FAILS = "invalid command";
 
+    private GuiRobot guiRobot = new GuiRobot();
     private ArrayList<String> defaultStyleOfCommandBox;
     private ArrayList<String> errorStyleOfCommandBox;
 
@@ -63,6 +64,62 @@ public class CommandBoxTest extends AddressBookGuiTest {
         assertEquals(defaultStyleOfCommandBox, commandBox.getStyleClass());
     }
 
+    @Test
+    public void handleKeyPress_startingWithUp() {
+        // empty history
+        assertInputHistory(KeyCode.UP, "");
+        assertInputHistory(KeyCode.DOWN, "");
+
+        // one command
+        commandBox.runCommand(COMMAND_THAT_SUCCEEDS);
+        assertInputHistory(KeyCode.UP, COMMAND_THAT_SUCCEEDS);
+        assertInputHistory(KeyCode.DOWN, "");
+
+        // two commands
+        commandBox.runCommand(COMMAND_THAT_FAILS);
+        assertInputHistory(KeyCode.UP, COMMAND_THAT_SUCCEEDS);
+        assertInputHistory(KeyCode.UP, COMMAND_THAT_SUCCEEDS);
+        assertInputHistory(KeyCode.DOWN, COMMAND_THAT_FAILS);
+        assertInputHistory(KeyCode.DOWN, "");
+        assertInputHistory(KeyCode.DOWN, "");
+        assertInputHistory(KeyCode.UP, COMMAND_THAT_FAILS);
+
+        // insert command in the middle of retrieving previous commands
+        guiRobot.push(KeyCode.UP);
+        String thirdCommand = "list";
+        commandBox.runCommand(thirdCommand);
+        assertInputHistory(KeyCode.UP, thirdCommand);
+        assertInputHistory(KeyCode.UP, COMMAND_THAT_FAILS);
+        assertInputHistory(KeyCode.UP, COMMAND_THAT_SUCCEEDS);
+        assertInputHistory(KeyCode.DOWN, COMMAND_THAT_FAILS);
+        assertInputHistory(KeyCode.DOWN, thirdCommand);
+        assertInputHistory(KeyCode.DOWN, "");
+    }
+
+    @Test
+    public void handleKeyPress_startingWithDown() {
+        // empty history
+        assertInputHistory(KeyCode.DOWN, "");
+        assertInputHistory(KeyCode.UP, "");
+
+        // one command
+        commandBox.runCommand(COMMAND_THAT_SUCCEEDS);
+        assertInputHistory(KeyCode.DOWN, "");
+        assertInputHistory(KeyCode.UP, COMMAND_THAT_SUCCEEDS);
+
+        // two commands
+        commandBox.runCommand(COMMAND_THAT_FAILS);
+        assertInputHistory(KeyCode.DOWN, "");
+        assertInputHistory(KeyCode.UP, COMMAND_THAT_FAILS);
+
+        // insert command in the middle of retrieving previous commands
+        guiRobot.push(KeyCode.UP);
+        String thirdCommand = "list";
+        commandBox.runCommand(thirdCommand);
+        assertInputHistory(KeyCode.DOWN, "");
+        assertInputHistory(KeyCode.UP, thirdCommand);
+    }
+
     /**
      * Runs a command that fails, then verifies that
      * - the return value of runCommand(...) is false,
@@ -87,4 +144,11 @@ public class CommandBoxTest extends AddressBookGuiTest {
         assertEquals(defaultStyleOfCommandBox, commandBox.getStyleClass());
     }
 
+    /**
+     * Pushes {@code keycode} and checks that the input in the {@code commandBox} equals to {@code expectedCommand}.
+     */
+    private void assertInputHistory(KeyCode keycode, String expectedCommand) {
+        guiRobot.push(keycode);
+        assertEquals(expectedCommand, commandBox.getCommandInput());
+    }
 }

--- a/src/test/java/seedu/address/logic/ListElementPointerTest.java
+++ b/src/test/java/seedu/address/logic/ListElementPointerTest.java
@@ -1,0 +1,166 @@
+package seedu.address.logic;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class ListElementPointerTest {
+    private static final String FIRST_ELEMENT = "first";
+    private static final String SECOND_ELEMENT = "second";
+    private List<String> pointerElements;
+    private ListElementPointer pointer;
+
+    @Before
+    public void setUp() {
+        pointerElements = new ArrayList<>();
+        pointerElements.add(FIRST_ELEMENT);
+        pointerElements.add(SECOND_ELEMENT);
+    }
+
+    @Test
+    public void emptyList() {
+        pointer = new ListElementPointer(new ArrayList<>());
+        assertCurrentFailure();
+        assertPreviousFailure();
+        assertNextFailure();
+
+        pointer.add(FIRST_ELEMENT);
+        assertNextSuccess(FIRST_ELEMENT);
+    }
+
+    @Test
+    public void singleElementList() {
+        List<String> list = new ArrayList<>();
+        list.add(FIRST_ELEMENT);
+        pointer = new ListElementPointer(list);
+
+        assertCurrentSuccess(FIRST_ELEMENT);
+        assertPreviousFailure();
+        assertCurrentSuccess(FIRST_ELEMENT);
+        assertNextFailure();
+        assertCurrentSuccess(FIRST_ELEMENT);
+
+        pointer.add(SECOND_ELEMENT);
+        assertNextSuccess(SECOND_ELEMENT);
+    }
+
+    @Test
+    public void multipleElementsList() {
+        pointer = new ListElementPointer(pointerElements);
+        String thirdElement = "third";
+        pointer.add(thirdElement);
+
+        assertCurrentSuccess(SECOND_ELEMENT);
+
+        assertNextSuccess(thirdElement);
+        assertNextFailure();
+
+        assertPreviousSuccess(SECOND_ELEMENT);
+        assertPreviousSuccess(FIRST_ELEMENT);
+        assertPreviousFailure();
+    }
+
+    @Test
+    public void equals() {
+        ListElementPointer firstPointer = new ListElementPointer(pointerElements);
+
+        // same object -> returns true
+        assertTrue(firstPointer.equals(firstPointer));
+
+        // same values -> returns true
+        ListElementPointer firstPointerCopy = new ListElementPointer(pointerElements);
+        assertTrue(firstPointer.equals(firstPointerCopy));
+
+        // different types -> returns false
+        assertFalse(firstPointer.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPointer.equals(null));
+
+        // different elements -> returns false
+        ListElementPointer differentElementPointer = new ListElementPointer(Collections.singletonList(SECOND_ELEMENT));
+        assertFalse(firstPointer.equals(differentElementPointer));
+
+        // different index -> returns false
+        firstPointerCopy.previous();
+        assertFalse(firstPointer.equals(firstPointerCopy));
+    }
+
+    /**
+     * Asserts that {@code pointer#hasNext()} returns true and the return value
+     * of {@code pointer#next()} equals to {@code element}.
+     */
+    private void assertNextSuccess(String element) {
+        assertTrue(pointer.hasNext());
+        assertEquals(element, pointer.next());
+    }
+
+    /**
+     * Asserts that {@code pointer#hasPrevious()} returns true and the return value
+     * of {@code pointer#previous()} equals to {@code element}.
+     */
+    private void assertPreviousSuccess(String element) {
+        assertTrue(pointer.hasPrevious());
+        assertEquals(element, pointer.previous());
+    }
+
+    /**
+     * Asserts that {@code pointer#hasCurrent()} returns true and the return value
+     * of {@code pointer#current()} equals to {@code element}.
+     */
+    private void assertCurrentSuccess(String element) {
+        assertTrue(pointer.hasCurrent());
+        assertEquals(element, pointer.current());
+    }
+
+    /**
+     * Asserts that {@code pointer#hasNext()} returns false and the following
+     * {@code pointer#next()} call throws {@code NoSuchElementException}.
+     */
+    private void assertNextFailure() {
+        assertFalse(pointer.hasNext());
+        try {
+            pointer.next();
+            fail("The expected NoSuchElementException was not thrown");
+        } catch (NoSuchElementException e) {
+            // expected exception thrown
+        }
+    }
+
+    /**
+     * Asserts that {@code pointer#hasPrevious()} returns false and the following
+     * {@code pointer#previous()} call throws {@code NoSuchElementException}.
+     */
+    private void assertPreviousFailure() {
+        assertFalse(pointer.hasPrevious());
+        try {
+            pointer.previous();
+            fail("The expected NoSuchElementException was not thrown");
+        } catch (NoSuchElementException e) {
+            // expected exception thrown
+        }
+    }
+
+    /**
+     * Asserts that {@code pointer#hasCurrent()} returns false and the following
+     * {@code pointer#current()} call throws {@code NoSuchElementException}.
+     */
+    private void assertCurrentFailure() {
+        assertFalse(pointer.hasCurrent());
+        try {
+            pointer.current();
+            fail("The expected NoSuchElementException was not thrown");
+        } catch (NoSuchElementException e) {
+            // expected exception thrown
+        }
+    }
+}


### PR DESCRIPTION
```
The user is only able to see their previously typed commands through
the history command.

The user may need to access their previously typed commands quickly in
order to fix a previous typo, or to reuse the input for another
variation.

Let's add a function that allows users to retrieve the previous and
next input in the history by pressing the up and down arrow keys
respectively.
```