### PR TITLE
Clean LogicManagerTest #327

### DIFF
--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.HistoryCommand;
+import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
@@ -38,6 +39,11 @@ public class LogicManagerTest {
     public void execute_commandExecutionError_throwsCommandException() {
         String deleteCommand = "delete 9";
         assertCommandException(deleteCommand, MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validCommand_success() {
+        assertCommandSuccess(ListCommand.COMMAND_WORD, ListCommand.MESSAGE_SUCCESS, model);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -58,7 +58,7 @@ public class LogicManagerTest {
      * Executes the command, confirms that the exception is thrown and that the result message is correct.
      * @see #assertCommandBehavior(Class, String, String, Model)
      */
-    private <T> void assertCommandFailure(String inputCommand, Class<T> expectedException, String expectedMessage) {
+    private void assertCommandFailure(String inputCommand, Class<?> expectedException, String expectedMessage) {
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         assertCommandBehavior(expectedException, inputCommand, expectedMessage, expectedModel);
     }
@@ -69,7 +69,7 @@ public class LogicManagerTest {
      *      - the internal model manager data are same as those in the {@code expectedModel} <br>
      *      - {@code expectedModel}'s address book was saved to the storage file.
      */
-    private <T> void assertCommandBehavior(Class<T> expectedException, String inputCommand,
+    private void assertCommandBehavior(Class<?> expectedException, String inputCommand,
                                            String expectedMessage, Model expectedModel) {
 
         try {

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -6,59 +6,28 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 
-import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
-import com.google.common.eventbus.Subscribe;
-
-import seedu.address.commons.core.EventsCenter;
-import seedu.address.commons.events.model.AddressBookChangedEvent;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.HistoryCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
-import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.UserPrefs;
 
 
 public class LogicManagerTest {
 
-    /**
-     * See https://github.com/junit-team/junit4/wiki/rules#temporaryfolder-rule
-     */
-    @Rule
-    public TemporaryFolder saveFolder = new TemporaryFolder();
-
     private Model model;
     private Logic logic;
-
-    //These are for checking the correctness of the events raised
-    private ReadOnlyAddressBook latestSavedAddressBook;
-
-    @Subscribe
-    private void handleLocalModelChangedEvent(AddressBookChangedEvent abce) {
-        latestSavedAddressBook = new AddressBook(abce.data);
-    }
 
     @Before
     public void setUp() {
         model = new ModelManager();
         logic = new LogicManager(model);
-        EventsCenter.getInstance().registerHandler(this);
-
-        latestSavedAddressBook = new AddressBook(model.getAddressBook()); // last saved assumed to be up to date
-    }
-
-    @After
-    public void tearDown() {
-        EventsCenter.clearSubscribers();
     }
 
     @Test
@@ -113,7 +82,6 @@ public class LogicManagerTest {
         }
 
         assertEquals(expectedModel, model);
-        assertEquals(expectedModel.getAddressBook(), latestSavedAddressBook);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -29,9 +29,9 @@ public class LogicManagerTest {
     }
 
     @Test
-    public void execute_unknownCommandWord_throwsParseException() {
-        String unknownCommand = "uicfhmowqewca";
-        assertParseException(unknownCommand, MESSAGE_UNKNOWN_COMMAND);
+    public void execute_invalidCommandFormat_throwsParseException() {
+        String invalidCommand = "uicfhmowqewca";
+        assertParseException(invalidCommand, MESSAGE_UNKNOWN_COMMAND);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -30,13 +30,6 @@ public class LogicManagerTest {
         logic = new LogicManager(model);
     }
 
-    @Test
-    public void execute_invalid() {
-        String invalidCommand = "       ";
-        assertParseException(invalidCommand,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
-    }
-
     /**
      * Executes the command, confirms that no exceptions are thrown and that the result message is correct.
      * Also confirms that {@code expectedModel} is as specified.
@@ -85,7 +78,7 @@ public class LogicManagerTest {
     }
 
     @Test
-    public void execute_unknownCommandWord() {
+    public void execute_unknownCommandWord_throwsParseException() {
         String unknownCommand = "uicfhmowqewca";
         assertParseException(unknownCommand, MESSAGE_UNKNOWN_COMMAND);
     }

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -5,19 +5,6 @@ import static org.junit.Assert.fail;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
-import static seedu.address.model.util.SampleDataUtil.getTagSet;
-import static seedu.address.testutil.TypicalPersons.INDEX_THIRD_PERSON;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
 
 import org.junit.After;
 import org.junit.Before;
@@ -29,7 +16,6 @@ import com.google.common.eventbus.Subscribe;
 
 import seedu.address.commons.core.EventsCenter;
 import seedu.address.commons.events.model.AddressBookChangedEvent;
-import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.HistoryCommand;
@@ -40,12 +26,6 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.UserPrefs;
-import seedu.address.model.person.Address;
-import seedu.address.model.person.Email;
-import seedu.address.model.person.Name;
-import seedu.address.model.person.Person;
-import seedu.address.model.person.Phone;
-import seedu.address.model.tag.Tag;
 
 
 public class LogicManagerTest {
@@ -98,14 +78,6 @@ public class LogicManagerTest {
     }
 
     /**
-     * Executes the command, confirms that a CommandException is thrown and that the result message is correct.
-     * @see #assertCommandBehavior(Class, String, String, Model)
-     */
-    private void assertCommandException(String inputCommand, String expectedMessage) {
-        assertCommandFailure(inputCommand, CommandException.class, expectedMessage);
-    }
-
-    /**
      * Executes the command, confirms that a ParseException is thrown and that the result message is correct.
      * @see #assertCommandBehavior(Class, String, String, Model)
      */
@@ -150,41 +122,6 @@ public class LogicManagerTest {
         assertParseException(unknownCommand, MESSAGE_UNKNOWN_COMMAND);
     }
 
-    /**
-     * Confirms the 'invalid argument index number behaviour' for the given command
-     * targeting a single person in the shown list, using visible index.
-     * @param commandWord to test assuming it targets a single person in the last shown list
-     *                    based on visible index.
-     */
-    private void assertIncorrectIndexFormatBehaviorForCommand(String commandWord, String expectedMessage)
-            throws Exception {
-        assertParseException(commandWord , expectedMessage); //index missing
-        assertParseException(commandWord + " +1", expectedMessage); //index should be unsigned
-        assertParseException(commandWord + " -1", expectedMessage); //index should be unsigned
-        assertParseException(commandWord + " 0", expectedMessage); //index cannot be 0
-        assertParseException(commandWord + " not_a_number", expectedMessage);
-    }
-
-    /**
-     * Confirms the 'invalid argument index number behaviour' for the given command
-     * targeting a single person in the shown list, using visible index.
-     * @param commandWord to test assuming it targets a single person in the last shown list
-     *                    based on visible index.
-     */
-    private void assertIndexNotFoundBehaviorForCommand(String commandWord) throws Exception {
-        String expectedMessage = MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
-        TestDataHelper helper = new TestDataHelper();
-        List<Person> personList = helper.generatePersonList(2);
-
-        // set AB state to 2 persons
-        model.resetData(new AddressBook());
-        for (Person p : personList) {
-            model.addPerson(p);
-        }
-
-        assertCommandException(commandWord + " " + INDEX_THIRD_PERSON.getOneBased(), expectedMessage);
-    }
-
     @Test
     public void execute_verifyHistory_success() throws Exception {
         String validCommand = "clear";
@@ -209,126 +146,5 @@ public class LogicManagerTest {
         String expectedMessage = String.format(HistoryCommand.MESSAGE_SUCCESS,
                 String.join("\n", validCommand, invalidCommandParse, invalidCommandExecute));
         assertCommandSuccess("history", expectedMessage, model);
-    }
-
-    /**
-     * A utility class to generate test data.
-     */
-    class TestDataHelper {
-
-        Person adam() throws Exception {
-            Name name = new Name("Adam Brown");
-            Phone privatePhone = new Phone("111111");
-            Email email = new Email("adam@example.com");
-            Address privateAddress = new Address("111, alpha street");
-
-            return new Person(name, privatePhone, email, privateAddress,
-                    getTagSet("tag1", "longertag2"));
-        }
-
-        /**
-         * Generates a valid person using the given seed.
-         * Running this function with the same parameter values guarantees the returned person will have the same state.
-         * Each unique seed will generate a unique Person object.
-         *
-         * @param seed used to generate the person data field values
-         */
-        Person generatePerson(int seed) throws Exception {
-            // to ensure that phone numbers are at least 3 digits long, when seed is less than 3 digits
-            String phoneNumber = String.join("", Collections.nCopies(3, String.valueOf(Math.abs(seed))));
-
-            return new Person(
-                    new Name("Person " + seed),
-                    new Phone(phoneNumber),
-                    new Email(seed + "@email"),
-                    new Address("House of " + seed),
-                    getTagSet("tag" + Math.abs(seed), "tag" + Math.abs(seed + 1)));
-        }
-
-        /** Generates the correct add command based on the person given */
-        String generateAddCommand(Person p) {
-            StringBuffer cmd = new StringBuffer();
-
-            cmd.append(AddCommand.COMMAND_WORD);
-
-            cmd.append(" " + PREFIX_NAME.getPrefix()).append(p.getName());
-            cmd.append(" " + PREFIX_EMAIL.getPrefix()).append(p.getEmail());
-            cmd.append(" " + PREFIX_PHONE.getPrefix()).append(p.getPhone());
-            cmd.append(" " + PREFIX_ADDRESS.getPrefix()).append(p.getAddress());
-
-            Set<Tag> tags = p.getTags();
-            for (Tag t: tags) {
-                cmd.append(" " + PREFIX_TAG.getPrefix()).append(t.tagName);
-            }
-
-            return cmd.toString();
-        }
-
-        /**
-         * Generates an AddressBook with auto-generated persons.
-         */
-        AddressBook generateAddressBook(int numGenerated) throws Exception {
-            AddressBook addressBook = new AddressBook();
-            addToAddressBook(addressBook, numGenerated);
-            return addressBook;
-        }
-
-        /**
-         * Generates an AddressBook based on the list of Persons given.
-         */
-        AddressBook generateAddressBook(List<Person> persons) throws Exception {
-            AddressBook addressBook = new AddressBook();
-            addToAddressBook(addressBook, persons);
-            return addressBook;
-        }
-
-        /**
-         * Adds auto-generated Person objects to the given AddressBook
-         * @param addressBook The AddressBook to which the Persons will be added
-         */
-        void addToAddressBook(AddressBook addressBook, int numGenerated) throws Exception {
-            addToAddressBook(addressBook, generatePersonList(numGenerated));
-        }
-
-        /**
-         * Adds the given list of Persons to the given AddressBook
-         */
-        void addToAddressBook(AddressBook addressBook, List<Person> personsToAdd) throws Exception {
-            for (Person p: personsToAdd) {
-                addressBook.addPerson(p);
-            }
-        }
-
-        /**
-         * Adds auto-generated Person objects to the given model
-         * @param model The model to which the Persons will be added
-         */
-        void addToModel(Model model, int numGenerated) throws Exception {
-            addToModel(model, generatePersonList(numGenerated));
-        }
-
-        /**
-         * Adds the given list of Persons to the given model
-         */
-        void addToModel(Model model, List<Person> personsToAdd) throws Exception {
-            for (Person p: personsToAdd) {
-                model.addPerson(p);
-            }
-        }
-
-        /**
-         * Generates a list of Persons based on the flags.
-         */
-        List<Person> generatePersonList(int numGenerated) throws Exception {
-            List<Person> persons = new ArrayList<>();
-            for (int i = 1; i <= numGenerated; i++) {
-                persons.add(generatePerson(i));
-            }
-            return persons;
-        }
-
-        List<Person> generatePersonList(Person... persons) {
-            return Arrays.asList(persons);
-        }
     }
 }

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -35,6 +35,12 @@ public class LogicManagerTest {
     }
 
     @Test
+    public void execute_commandExecutionError_throwsCommandException() {
+        String deleteCommand = "delete 9";
+        assertCommandException(deleteCommand, MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
     public void execute_verifyHistory_success() throws Exception {
         String validCommand = "clear";
         logic.execute(validCommand);
@@ -75,6 +81,14 @@ public class LogicManagerTest {
      */
     private void assertParseException(String inputCommand, String expectedMessage) {
         assertCommandFailure(inputCommand, ParseException.class, expectedMessage);
+    }
+
+    /**
+     * Executes the command, confirms that a CommandException is thrown and that the result message is correct.
+     * @see #assertCommandBehavior(Class, String, String, Model)
+     */
+    private void assertCommandException(String inputCommand, String expectedMessage) {
+        assertCommandFailure(inputCommand, CommandException.class, expectedMessage);
     }
 
     /**

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertEquals;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 
-import org.junit.Before;
 import org.junit.Test;
 
 import seedu.address.logic.commands.CommandResult;
@@ -19,14 +18,8 @@ import seedu.address.model.UserPrefs;
 
 public class LogicManagerTest {
 
-    private Model model;
-    private Logic logic;
-
-    @Before
-    public void setUp() {
-        model = new ModelManager();
-        logic = new LogicManager(model);
-    }
+    private Model model = new ModelManager();
+    private Logic logic = new LogicManager(model);
 
     @Test
     public void execute_invalidCommandFormat_throwsParseException() throws Exception {

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -2,7 +2,6 @@ package seedu.address.logic;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 
@@ -10,7 +9,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import seedu.address.logic.commands.CommandResult;
-import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.HistoryCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -28,6 +26,38 @@ public class LogicManagerTest {
     public void setUp() {
         model = new ModelManager();
         logic = new LogicManager(model);
+    }
+
+    @Test
+    public void execute_unknownCommandWord_throwsParseException() {
+        String unknownCommand = "uicfhmowqewca";
+        assertParseException(unknownCommand, MESSAGE_UNKNOWN_COMMAND);
+    }
+
+    @Test
+    public void execute_verifyHistory_success() throws Exception {
+        String validCommand = "clear";
+        logic.execute(validCommand);
+
+        String invalidCommandParse = "   adds   Bob   ";
+        try {
+            logic.execute(invalidCommandParse);
+            fail("The expected ParseException was not thrown.");
+        } catch (ParseException pe) {
+            assertEquals(MESSAGE_UNKNOWN_COMMAND, pe.getMessage());
+        }
+
+        String invalidCommandExecute = "delete 1"; // address book is of size 0; index out of bounds
+        try {
+            logic.execute(invalidCommandExecute);
+            fail("The expected CommandException was not thrown.");
+        } catch (CommandException ce) {
+            assertEquals(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX, ce.getMessage());
+        }
+
+        String expectedMessage = String.format(HistoryCommand.MESSAGE_SUCCESS,
+                String.join("\n", validCommand, invalidCommandParse, invalidCommandExecute));
+        assertCommandSuccess("history", expectedMessage, model);
     }
 
     /**
@@ -75,37 +105,5 @@ public class LogicManagerTest {
         }
 
         assertEquals(expectedModel, model);
-    }
-
-    @Test
-    public void execute_unknownCommandWord_throwsParseException() {
-        String unknownCommand = "uicfhmowqewca";
-        assertParseException(unknownCommand, MESSAGE_UNKNOWN_COMMAND);
-    }
-
-    @Test
-    public void execute_verifyHistory_success() throws Exception {
-        String validCommand = "clear";
-        logic.execute(validCommand);
-
-        String invalidCommandParse = "   adds   Bob   ";
-        try {
-            logic.execute(invalidCommandParse);
-            fail("The expected ParseException was not thrown.");
-        } catch (ParseException pe) {
-            assertEquals(MESSAGE_UNKNOWN_COMMAND, pe.getMessage());
-        }
-
-        String invalidCommandExecute = "delete 1"; // address book is of size 0; index out of bounds
-        try {
-            logic.execute(invalidCommandExecute);
-            fail("The expected CommandException was not thrown.");
-        } catch (CommandException ce) {
-            assertEquals(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX, ce.getMessage());
-        }
-
-        String expectedMessage = String.format(HistoryCommand.MESSAGE_SUCCESS,
-                String.join("\n", validCommand, invalidCommandParse, invalidCommandExecute));
-        assertCommandSuccess("history", expectedMessage, model);
     }
 }

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -1,7 +1,6 @@
 package seedu.address.logic;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 
@@ -30,46 +29,24 @@ public class LogicManagerTest {
     }
 
     @Test
-    public void execute_invalidCommandFormat_throwsParseException() {
+    public void execute_invalidCommandFormat_throwsParseException() throws Exception {
         String invalidCommand = "uicfhmowqewca";
         assertParseException(invalidCommand, MESSAGE_UNKNOWN_COMMAND);
+        assertHistoryCorrect(invalidCommand);
     }
 
     @Test
-    public void execute_commandExecutionError_throwsCommandException() {
+    public void execute_commandExecutionError_throwsCommandException() throws Exception {
         String deleteCommand = "delete 9";
         assertCommandException(deleteCommand, MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertHistoryCorrect(deleteCommand);
     }
 
     @Test
-    public void execute_validCommand_success() {
-        assertCommandSuccess(ListCommand.COMMAND_WORD, ListCommand.MESSAGE_SUCCESS, model);
-    }
-
-    @Test
-    public void execute_verifyHistory_success() throws Exception {
-        String validCommand = "clear";
-        logic.execute(validCommand);
-
-        String invalidCommandParse = "   adds   Bob   ";
-        try {
-            logic.execute(invalidCommandParse);
-            fail("The expected ParseException was not thrown.");
-        } catch (ParseException pe) {
-            assertEquals(MESSAGE_UNKNOWN_COMMAND, pe.getMessage());
-        }
-
-        String invalidCommandExecute = "delete 1"; // address book is of size 0; index out of bounds
-        try {
-            logic.execute(invalidCommandExecute);
-            fail("The expected CommandException was not thrown.");
-        } catch (CommandException ce) {
-            assertEquals(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX, ce.getMessage());
-        }
-
-        String expectedMessage = String.format(HistoryCommand.MESSAGE_SUCCESS,
-                String.join("\n", validCommand, invalidCommandParse, invalidCommandExecute));
-        assertCommandSuccess("history", expectedMessage, model);
+    public void execute_validCommand_success() throws Exception {
+        String listCommand = ListCommand.COMMAND_WORD;
+        assertCommandSuccess(listCommand, ListCommand.MESSAGE_SUCCESS, model);
+        assertHistoryCorrect(listCommand);
     }
 
     /**
@@ -125,5 +102,12 @@ public class LogicManagerTest {
         }
 
         assertEquals(expectedModel, model);
+    }
+
+    private void assertHistoryCorrect(String... expectedCommands) throws Exception {
+        CommandResult result = logic.execute(HistoryCommand.COMMAND_WORD);
+        String expectedMessage = String.format(HistoryCommand.MESSAGE_SUCCESS,
+                String.join("\n", expectedCommands));
+        assertEquals(expectedMessage, result.feedbackToUser);
     }
 }


### PR DESCRIPTION
Part of #327 

```
LogicManagerTest contains unit tests for XCommand and XCommandParser.

LogicManagerTest should only be testing the code flow in LogicManager.
Unit tests for XCommand and XCommandParser should instead be written
in XCommandTest and XCommandParserTest respectively.

As these unit tests for XCommand and XCommandParser have been written
already, let's delete the tests that are not relevant to 
LogicManagerTest.
```