### PR TITLE
Revamp sleep() for Gui tests #502

### DIFF
--- a/src/test/java/guitests/ErrorDialogGuiTest.java
+++ b/src/test/java/guitests/ErrorDialogGuiTest.java
@@ -11,14 +11,17 @@ import seedu.address.commons.events.storage.DataSavingExceptionEvent;
 
 public class ErrorDialogGuiTest extends AddressBookGuiTest {
 
+    private static final String ERROR_DIALOG_STAGE_TITLE = "File Op Error";
+
     @Test
     public void showErrorDialogs() throws InterruptedException {
-        //Test DataSavingExceptionEvent dialog
+        GuiRobot guiRobot = new GuiRobot();
+
         raise(new DataSavingExceptionEvent(new IOException("Stub")));
 
-        GuiRobot guiRobot = new GuiRobot();
-        guiRobot.sleep(500); // wait for the alert dialog box to launch
-        AlertDialogHandle alertDialog = new AlertDialogHandle(new GuiRobot(), stage, "File Op Error");
+        int eventWaitTimeout = 5000;
+        guiRobot.waitForEvent(() -> guiRobot.isWindowShown(ERROR_DIALOG_STAGE_TITLE), eventWaitTimeout);
+        AlertDialogHandle alertDialog = new AlertDialogHandle(new GuiRobot(), stage, ERROR_DIALOG_STAGE_TITLE);
         assertTrue(alertDialog.isMatching("Could not save data", "Could not save data to file" + ":\n"
                                                                          + "java.io.IOException: Stub"));
 

--- a/src/test/java/guitests/ErrorDialogGuiTest.java
+++ b/src/test/java/guitests/ErrorDialogGuiTest.java
@@ -19,8 +19,7 @@ public class ErrorDialogGuiTest extends AddressBookGuiTest {
 
         raise(new DataSavingExceptionEvent(new IOException("Stub")));
 
-        int eventWaitTimeout = 5000;
-        guiRobot.waitForEvent(() -> guiRobot.isWindowShown(ERROR_DIALOG_STAGE_TITLE), eventWaitTimeout);
+        guiRobot.waitForEvent(() -> guiRobot.isWindowShown(ERROR_DIALOG_STAGE_TITLE));
         AlertDialogHandle alertDialog = new AlertDialogHandle(new GuiRobot(), stage, ERROR_DIALOG_STAGE_TITLE);
         assertTrue(alertDialog.isMatching("Could not save data", "Could not save data to file" + ":\n"
                                                                          + "java.io.IOException: Stub"));

--- a/src/test/java/guitests/GuiRobot.java
+++ b/src/test/java/guitests/GuiRobot.java
@@ -13,6 +13,7 @@ import javafx.stage.Stage;
 public class GuiRobot extends FxRobot {
 
     public static final int PAUSE_FOR_HUMAN_DELAY_MILLISECONDS = 250;
+    public static final int DEFAULT_WAIT_FOR_EVENT_TIMEOUT_MILLISECONDS = 5000;
 
     private static final String PROPERTY_TESTFX_HEADLESS = "testfx.headless";
 
@@ -34,6 +35,16 @@ public class GuiRobot extends FxRobot {
         }
 
         sleep(PAUSE_FOR_HUMAN_DELAY_MILLISECONDS);
+    }
+
+    /**
+     * Waits for {@code event} to be true by {@code DEFAULT_WAIT_FOR_EVENT_TIMEOUT_MILLISECONDS} milliseconds.
+     *
+     * @throws EventTimeoutException if the time taken exceeds {@code DEFAULT_WAIT_FOR_EVENT_TIMEOUT_MILLISECONDS}
+     * milliseconds.
+     */
+    public void waitForEvent(BooleanSupplier event) {
+        waitForEvent(event, DEFAULT_WAIT_FOR_EVENT_TIMEOUT_MILLISECONDS);
     }
 
     /**

--- a/src/test/java/guitests/GuiRobot.java
+++ b/src/test/java/guitests/GuiRobot.java
@@ -1,6 +1,10 @@
 package guitests;
 
+import java.util.function.BooleanSupplier;
+
 import org.testfx.api.FxRobot;
+
+import javafx.stage.Stage;
 
 /**
  * Robot used to simulate user actions on the GUI.
@@ -29,5 +33,42 @@ public class GuiRobot extends FxRobot {
         }
 
         sleep(duration);
+    }
+
+    /**
+     * Waits for {@code event} to be true.
+     *
+     * @param timeOut in milliseconds
+     * @throws EventTimeoutException if the time taken exceeds {@code timeOut}.
+     */
+    public void waitForEvent(BooleanSupplier event, int timeOut) {
+        int timePassed = 0;
+        final int retryInterval = 50;
+
+        while (!event.getAsBoolean()) {
+            sleep(retryInterval);
+            timePassed += retryInterval;
+
+            if (timePassed >= timeOut) {
+                throw new EventTimeoutException();
+            }
+        }
+
+        pauseForHuman(1000);
+    }
+
+    /**
+     * Returns true if the window with {@code stageTitle} is currently open.
+     */
+    public boolean isWindowShown(String stageTitle) {
+        return listTargetWindows().stream()
+                .filter(window -> window instanceof Stage && ((Stage) window).getTitle().equals(stageTitle))
+                .count() >= 1;
+    }
+
+    /**
+     * Represents an error which occurs when a timeout occurs when waiting for an event.
+     */
+    private class EventTimeoutException extends RuntimeException {
     }
 }

--- a/src/test/java/guitests/GuiRobot.java
+++ b/src/test/java/guitests/GuiRobot.java
@@ -12,6 +12,8 @@ import javafx.stage.Stage;
  */
 public class GuiRobot extends FxRobot {
 
+    public static final int PAUSE_FOR_HUMAN_DELAY_MILLISECONDS = 250;
+
     private static final String PROPERTY_TESTFX_HEADLESS = "testfx.headless";
 
     private final boolean isHeadlessMode;
@@ -22,17 +24,16 @@ public class GuiRobot extends FxRobot {
     }
 
     /**
-     * Pauses execution for a human to examine the effects of the test. This method will be disabled
-     * when the GUI tests are executed in headless mode to avoid unnecessary delays.
-     *
-     * @param duration in milliseconds
+     * Pauses execution for {@code PAUSE_FOR_HUMAN_DELAY_MILLISECONDS} milliseconds for a human to examine the
+     * effects of the test. This method will be disabled when the GUI tests are executed in headless mode to avoid
+     * unnecessary delays.
      */
-    public void pauseForHuman(int duration) {
+    public void pauseForHuman() {
         if (isHeadlessMode) {
             return;
         }
 
-        sleep(duration);
+        sleep(PAUSE_FOR_HUMAN_DELAY_MILLISECONDS);
     }
 
     /**
@@ -54,7 +55,7 @@ public class GuiRobot extends FxRobot {
             }
         }
 
-        pauseForHuman(1000);
+        pauseForHuman();
     }
 
     /**

--- a/src/test/java/guitests/GuiRobot.java
+++ b/src/test/java/guitests/GuiRobot.java
@@ -7,4 +7,27 @@ import org.testfx.api.FxRobot;
  * Extends {@link FxRobot} by adding some customized functionality and workarounds.
  */
 public class GuiRobot extends FxRobot {
+
+    private static final String PROPERTY_TESTFX_HEADLESS = "testfx.headless";
+
+    private final boolean isHeadlessMode;
+
+    public GuiRobot() {
+        String headlessPropertyValue = System.getProperty(PROPERTY_TESTFX_HEADLESS);
+        isHeadlessMode = headlessPropertyValue != null && headlessPropertyValue.equals("true");
+    }
+
+    /**
+     * Pauses execution for a human to examine the effects of the test. This method will be disabled
+     * when the GUI tests are executed in headless mode to avoid unnecessary delays.
+     *
+     * @param duration in milliseconds
+     */
+    public void pauseForHuman(int duration) {
+        if (isHeadlessMode) {
+            return;
+        }
+
+        sleep(duration);
+    }
 }

--- a/src/test/java/guitests/guihandles/CommandBoxHandle.java
+++ b/src/test/java/guitests/guihandles/CommandBoxHandle.java
@@ -40,7 +40,7 @@ public class CommandBoxHandle extends GuiHandle {
     public boolean runCommand(String command) {
         enterCommand(command);
         pressEnter();
-        guiRobot.sleep(200); //Give time for the command to take effect
+        guiRobot.pauseForHuman(200);
         return !getStyleClass().contains(CommandBox.ERROR_STYLE_CLASS);
     }
 

--- a/src/test/java/guitests/guihandles/CommandBoxHandle.java
+++ b/src/test/java/guitests/guihandles/CommandBoxHandle.java
@@ -40,7 +40,7 @@ public class CommandBoxHandle extends GuiHandle {
     public boolean runCommand(String command) {
         enterCommand(command);
         pressEnter();
-        guiRobot.pauseForHuman(200);
+        guiRobot.pauseForHuman();
         return !getStyleClass().contains(CommandBox.ERROR_STYLE_CLASS);
     }
 

--- a/src/test/java/guitests/guihandles/GuiHandle.java
+++ b/src/test/java/guitests/guihandles/GuiHandle.java
@@ -63,11 +63,12 @@ public class GuiHandle {
         guiRobot.clickOn(textFieldId);
         TextField textField = getNode(textFieldId);
         guiRobot.interact(() -> textField.setText(newText));
-        guiRobot.sleep(500); // so that the texts stays visible on the GUI for a short period
+        guiRobot.pauseForHuman(500);
     }
 
     public void pressEnter() {
-        guiRobot.type(KeyCode.ENTER).sleep(500);
+        guiRobot.type(KeyCode.ENTER);
+        guiRobot.pauseForHuman(500);
     }
 
     protected String getTextFromLabel(String fieldId, Node parentNode) {

--- a/src/test/java/guitests/guihandles/GuiHandle.java
+++ b/src/test/java/guitests/guihandles/GuiHandle.java
@@ -63,12 +63,12 @@ public class GuiHandle {
         guiRobot.clickOn(textFieldId);
         TextField textField = getNode(textFieldId);
         guiRobot.interact(() -> textField.setText(newText));
-        guiRobot.pauseForHuman(500);
+        guiRobot.pauseForHuman();
     }
 
     public void pressEnter() {
         guiRobot.type(KeyCode.ENTER);
-        guiRobot.pauseForHuman(500);
+        guiRobot.pauseForHuman();
     }
 
     protected String getTextFromLabel(String fieldId, Node parentNode) {

--- a/src/test/java/guitests/guihandles/HelpWindowHandle.java
+++ b/src/test/java/guitests/guihandles/HelpWindowHandle.java
@@ -13,7 +13,7 @@ public class HelpWindowHandle extends GuiHandle {
 
     public HelpWindowHandle(GuiRobot guiRobot, Stage primaryStage) {
         super(guiRobot, primaryStage, HELP_WINDOW_TITLE);
-        guiRobot.sleep(1000);
+        guiRobot.pauseForHuman(1000);
     }
 
     public boolean isWindowOpen() {
@@ -22,7 +22,7 @@ public class HelpWindowHandle extends GuiHandle {
 
     public void closeWindow() {
         super.closeWindow();
-        guiRobot.sleep(500);
+        guiRobot.pauseForHuman(500);
     }
 
 }

--- a/src/test/java/guitests/guihandles/HelpWindowHandle.java
+++ b/src/test/java/guitests/guihandles/HelpWindowHandle.java
@@ -13,7 +13,7 @@ public class HelpWindowHandle extends GuiHandle {
 
     public HelpWindowHandle(GuiRobot guiRobot, Stage primaryStage) {
         super(guiRobot, primaryStage, HELP_WINDOW_TITLE);
-        guiRobot.pauseForHuman(1000);
+        guiRobot.pauseForHuman();
     }
 
     public boolean isWindowOpen() {
@@ -22,7 +22,7 @@ public class HelpWindowHandle extends GuiHandle {
 
     public void closeWindow() {
         super.closeWindow();
-        guiRobot.pauseForHuman(500);
+        guiRobot.pauseForHuman();
     }
 
 }

--- a/src/test/java/guitests/guihandles/MainMenuHandle.java
+++ b/src/test/java/guitests/guihandles/MainMenuHandle.java
@@ -32,6 +32,6 @@ public class MainMenuHandle extends GuiHandle {
 
     private void useF1Accelerator() {
         guiRobot.push(KeyCode.F1);
-        guiRobot.sleep(500);
+        guiRobot.pauseForHuman(500);
     }
 }

--- a/src/test/java/guitests/guihandles/MainMenuHandle.java
+++ b/src/test/java/guitests/guihandles/MainMenuHandle.java
@@ -32,6 +32,6 @@ public class MainMenuHandle extends GuiHandle {
 
     private void useF1Accelerator() {
         guiRobot.push(KeyCode.F1);
-        guiRobot.pauseForHuman(500);
+        guiRobot.pauseForHuman();
     }
 }

--- a/src/test/java/guitests/guihandles/PersonListPanelHandle.java
+++ b/src/test/java/guitests/guihandles/PersonListPanelHandle.java
@@ -62,7 +62,7 @@ public class PersonListPanelHandle extends GuiHandle {
         for (int i = 0; i < persons.length; i++) {
             final int scrollTo = i + startPosition;
             guiRobot.interact(() -> getListView().scrollTo(scrollTo));
-            guiRobot.sleep(200);
+            guiRobot.pauseForHuman(200);
             if (!TestUtil.compareCardAndPerson(getPersonCardHandle(startPosition + i), persons[i])) {
                 return false;
             }
@@ -100,7 +100,7 @@ public class PersonListPanelHandle extends GuiHandle {
     }
 
     public PersonCardHandle navigateToPerson(String name) {
-        guiRobot.sleep(500); //Allow a bit of time for the list to be updated
+        guiRobot.pauseForHuman(500);
         final Optional<ReadOnlyPerson> person = getListView().getItems().stream()
                                                     .filter(p -> p.getName().fullName.equals(name))
                                                     .findAny();
@@ -119,10 +119,10 @@ public class PersonListPanelHandle extends GuiHandle {
 
         guiRobot.interact(() -> {
             getListView().scrollTo(index);
-            guiRobot.sleep(150);
+            guiRobot.pauseForHuman(150);
             getListView().getSelectionModel().select(index);
         });
-        guiRobot.sleep(100);
+        guiRobot.pauseForHuman(100);
         return getPersonCardHandle(person);
     }
 

--- a/src/test/java/guitests/guihandles/PersonListPanelHandle.java
+++ b/src/test/java/guitests/guihandles/PersonListPanelHandle.java
@@ -62,7 +62,7 @@ public class PersonListPanelHandle extends GuiHandle {
         for (int i = 0; i < persons.length; i++) {
             final int scrollTo = i + startPosition;
             guiRobot.interact(() -> getListView().scrollTo(scrollTo));
-            guiRobot.pauseForHuman(200);
+            guiRobot.pauseForHuman();
             if (!TestUtil.compareCardAndPerson(getPersonCardHandle(startPosition + i), persons[i])) {
                 return false;
             }
@@ -100,7 +100,7 @@ public class PersonListPanelHandle extends GuiHandle {
     }
 
     public PersonCardHandle navigateToPerson(String name) {
-        guiRobot.pauseForHuman(500);
+        guiRobot.pauseForHuman();
         final Optional<ReadOnlyPerson> person = getListView().getItems().stream()
                                                     .filter(p -> p.getName().fullName.equals(name))
                                                     .findAny();
@@ -119,10 +119,10 @@ public class PersonListPanelHandle extends GuiHandle {
 
         guiRobot.interact(() -> {
             getListView().scrollTo(index);
-            guiRobot.pauseForHuman(150);
+            guiRobot.pauseForHuman();
             getListView().getSelectionModel().select(index);
         });
-        guiRobot.pauseForHuman(100);
+        guiRobot.pauseForHuman();
         return getPersonCardHandle(person);
     }
 


### PR DESCRIPTION
Fixes #502.
Fixes #139.

Proposed merge commit message:

```
The current uses of `guiRobot.sleep()` in our gui tests can be
categorized into two groups:

  (A) To prevent the tests from executing too fast, as that prevents us
      from visually examining the progression of the test.

  (B) To wait for something to happen on the JavaFX Application thread.

Both types of uses of `guiRobot.sleep()` are undesirable. Group (A)
unfairly makes our GUI tests slower in headless mode, as in headless
mode we can't visually examine GUI test progression anyway. Group (B)
is wrong and can lead to flaky tests, as sleeping for a set amount of
time does not guarantee that what we are waiting for actually occurs on
the JavaFX Application thread.

Let's
- Add GuiRobot#pauseForHuman() (for group A) for pauses that are merely
  for human observations. We are able to disable these pauses in 
  headless mode.
- Add guiRobot.waitForEvent() (for group B) with incremental waits, so
  that we are able to wait for events in JavaFX Application thread,
  instead of waiting for a fixed interval and assuming that the events
  happened.
```