### PR TITLE
Use EventsCollector when testing commands #504

### DIFF
--- a/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
@@ -4,31 +4,20 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static seedu.address.logic.commands.ExitCommand.MESSAGE_EXIT_ACKNOWLEDGEMENT;
 
-import org.junit.Before;
 import org.junit.Test;
 
-import com.google.common.eventbus.Subscribe;
-
-import seedu.address.commons.core.EventsCenter;
 import seedu.address.commons.events.ui.ExitAppRequestEvent;
+import seedu.address.testutil.EventsCollector;
 
 public class ExitCommandTest {
-    private boolean isEventCaught = false;
-
-    @Subscribe
-    private void handleExitAppRequestEvent(ExitAppRequestEvent eare) {
-        isEventCaught = true;
-    }
-
-    @Before
-    public void setUp() {
-        EventsCenter.getInstance().registerHandler(this);
-    }
 
     @Test
     public void execute_exit_success() {
+        EventsCollector eventCollector = new EventsCollector();
+
         CommandResult result = new ExitCommand().execute();
         assertEquals(MESSAGE_EXIT_ACKNOWLEDGEMENT, result.feedbackToUser);
-        assertTrue(isEventCaught);
+        assertTrue(eventCollector.getMostRecent() instanceof ExitAppRequestEvent);
+        assertTrue(eventCollector.getSize() == 1);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
@@ -4,31 +4,20 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static seedu.address.logic.commands.HelpCommand.SHOWING_HELP_MESSAGE;
 
-import org.junit.Before;
 import org.junit.Test;
 
-import com.google.common.eventbus.Subscribe;
-
-import seedu.address.commons.core.EventsCenter;
 import seedu.address.commons.events.ui.ShowHelpRequestEvent;
+import seedu.address.testutil.EventsCollector;
 
 public class HelpCommandTest {
-    private boolean isEventCaught = false;
-
-    @Subscribe
-    private void handleShowHelpRequestEvent(ShowHelpRequestEvent shre) {
-        isEventCaught = true;
-    }
-
-    @Before
-    public void setUp() {
-        EventsCenter.getInstance().registerHandler(this);
-    }
 
     @Test
     public void execute_help_success() {
+        EventsCollector eventCollector = new EventsCollector();
+
         CommandResult result = new HelpCommand().execute();
         assertEquals(SHOWING_HELP_MESSAGE, result.feedbackToUser);
-        assertTrue(isEventCaught);
+        assertTrue(eventCollector.getMostRecent() instanceof ShowHelpRequestEvent);
+        assertTrue(eventCollector.getSize() == 1);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/SelectCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SelectCommandTest.java
@@ -112,7 +112,7 @@ public class SelectCommandTest {
             fail("The expected CommandException was not thrown.");
         } catch (CommandException ce) {
             assertEquals(expectedMessage, ce.getMessage());
-            assertTrue(eventCollector.getSize() == 0);
+            assertTrue(eventCollector.isEmpty());
         }
     }
 

--- a/src/test/java/seedu/address/logic/commands/SelectCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SelectCommandTest.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.commands;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static seedu.address.testutil.TypicalPersons.INDEX_FIRST_PERSON;
@@ -14,9 +13,6 @@ import java.util.HashSet;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.google.common.eventbus.Subscribe;
-
-import seedu.address.commons.core.EventsCenter;
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.events.ui.JumpToListRequestEvent;
@@ -26,6 +22,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.ReadOnlyPerson;
+import seedu.address.testutil.EventsCollector;
 import seedu.address.testutil.TypicalPersons;
 
 /**
@@ -35,16 +32,8 @@ public class SelectCommandTest {
 
     private Model model;
 
-    private Index eventTargetedJumpIndex;
-
-    @Subscribe
-    private void recordJumpToListRequestEvent(JumpToListRequestEvent je) {
-        eventTargetedJumpIndex = Index.fromZeroBased(je.targetIndex);
-    }
-
     @Before
     public void setUp() {
-        EventsCenter.getInstance().registerHandler(this);
         model = new ModelManager(new TypicalPersons().getTypicalAddressBook(), new UserPrefs());
     }
 
@@ -98,14 +87,16 @@ public class SelectCommandTest {
      * is raised with the correct index.
      */
     private void assertExecutionSuccess(Index index) throws Exception {
-        eventTargetedJumpIndex = null;
-
+        EventsCollector eventCollector = new EventsCollector();
         SelectCommand selectCommand = prepareCommand(index);
         CommandResult commandResult = selectCommand.execute();
 
         assertEquals(String.format(SelectCommand.MESSAGE_SELECT_PERSON_SUCCESS, index.getOneBased()),
                 commandResult.feedbackToUser);
-        assertEquals(index, eventTargetedJumpIndex);
+
+        JumpToListRequestEvent lastEvent = (JumpToListRequestEvent) eventCollector.getMostRecent();
+        assertEquals(index, Index.fromZeroBased(lastEvent.targetIndex));
+        assertTrue(eventCollector.getSize() == 1);
     }
 
     /**
@@ -113,8 +104,7 @@ public class SelectCommandTest {
      * is thrown with the {@code expectedMessage}.
      */
     private void assertExecutionFailure(Index index, String expectedMessage) {
-        eventTargetedJumpIndex = null;
-
+        EventsCollector eventCollector = new EventsCollector();
         SelectCommand selectCommand = prepareCommand(index);
 
         try {
@@ -122,7 +112,7 @@ public class SelectCommandTest {
             fail("The expected CommandException was not thrown.");
         } catch (CommandException ce) {
             assertEquals(expectedMessage, ce.getMessage());
-            assertNull(eventTargetedJumpIndex);
+            assertTrue(eventCollector.getSize() == 0);
         }
     }
 

--- a/src/test/java/seedu/address/storage/StorageManagerTest.java
+++ b/src/test/java/seedu/address/storage/StorageManagerTest.java
@@ -79,7 +79,7 @@ public class StorageManagerTest {
                                              new JsonUserPrefsStorage("dummy"));
         EventsCollector eventCollector = new EventsCollector();
         storage.handleAddressBookChangedEvent(new AddressBookChangedEvent(new AddressBook()));
-        assertTrue(eventCollector.get(0) instanceof DataSavingExceptionEvent);
+        assertTrue(eventCollector.getMostRecent() instanceof DataSavingExceptionEvent);
     }
 
 

--- a/src/test/java/seedu/address/testutil/EventsCollector.java
+++ b/src/test/java/seedu/address/testutil/EventsCollector.java
@@ -43,4 +43,15 @@ public class EventsCollector {
     public int getSize() {
         return events.size();
     }
+
+    /**
+     * Returns the most recent event collected
+     */
+    public BaseEvent getMostRecent() {
+        if (events.isEmpty()) {
+            return null;
+        }
+
+        return events.get(events.size() - 1);
+    }
 }

--- a/src/test/java/seedu/address/testutil/EventsCollector.java
+++ b/src/test/java/seedu/address/testutil/EventsCollector.java
@@ -54,4 +54,11 @@ public class EventsCollector {
 
         return events.get(events.size() - 1);
     }
+
+    /**
+     * Returns true if the collector did not receive any events
+     */
+    public boolean isEmpty() {
+        return events.isEmpty();
+    }
 }

--- a/src/test/java/seedu/address/testutil/EventsCollector.java
+++ b/src/test/java/seedu/address/testutil/EventsCollector.java
@@ -39,4 +39,8 @@ public class EventsCollector {
     public BaseEvent get(int index) {
         return events.get(index);
     }
+
+    public int getSize() {
+        return events.size();
+    }
 }

--- a/src/test/java/seedu/address/testutil/EventsCollector.java
+++ b/src/test/java/seedu/address/testutil/EventsCollector.java
@@ -33,13 +33,6 @@ public class EventsCollector {
         events.clear();
     }
 
-    /**
-     * Returns the event at the specified index
-     */
-    public BaseEvent get(int index) {
-        return events.get(index);
-    }
-
     public int getSize() {
         return events.size();
     }


### PR DESCRIPTION
Fixes #504.

Proposed merge commit message:
```
Some command tests check that the correct events are being triggered by
manually subscribing to the events that they are expecting.

We already have EventsCollector class in our codebase that catches all
possible events, and allows us to extract data from the triggered
events as well.

Let's replace all manual subscription of events with EventsCollector
instead.
```