### PR TITLE
Clean up MainGuiHandle #459

### DIFF
--- a/src/test/java/guitests/AddressBookGuiTest.java
+++ b/src/test/java/guitests/AddressBookGuiTest.java
@@ -53,7 +53,7 @@ public abstract class AddressBookGuiTest {
     protected BrowserPanelHandle browserPanel;
     protected StatusBarFooterHandle statusBarFooter;
 
-    private Stage stage;
+    protected Stage stage;
 
     @BeforeClass
     public static void setupSpec() {

--- a/src/test/java/guitests/AddressBookGuiTest.java
+++ b/src/test/java/guitests/AddressBookGuiTest.java
@@ -14,8 +14,8 @@ import org.testfx.api.FxToolkit;
 
 import guitests.guihandles.BrowserPanelHandle;
 import guitests.guihandles.CommandBoxHandle;
-import guitests.guihandles.MainGuiHandle;
 import guitests.guihandles.MainMenuHandle;
+import guitests.guihandles.MainWindowHandle;
 import guitests.guihandles.PersonCardHandle;
 import guitests.guihandles.PersonListPanelHandle;
 import guitests.guihandles.ResultDisplayHandle;
@@ -45,7 +45,7 @@ public abstract class AddressBookGuiTest {
      *   Handles to GUI elements present at the start up are created in advance
      *   for easy access from child classes.
      */
-    protected MainGuiHandle mainGui;
+    protected MainWindowHandle mainGui;
     protected MainMenuHandle mainMenu;
     protected PersonListPanelHandle personListPanel;
     protected ResultDisplayHandle resultDisplay;
@@ -68,7 +68,7 @@ public abstract class AddressBookGuiTest {
     @Before
     public void setup() throws Exception {
         FxToolkit.setupStage((stage) -> {
-            mainGui = new MainGuiHandle(new GuiRobot(), stage);
+            mainGui = new MainWindowHandle(new GuiRobot(), stage);
             mainMenu = mainGui.getMainMenu();
             personListPanel = mainGui.getPersonListPanel();
             resultDisplay = mainGui.getResultDisplay();

--- a/src/test/java/guitests/ErrorDialogGuiTest.java
+++ b/src/test/java/guitests/ErrorDialogGuiTest.java
@@ -15,7 +15,10 @@ public class ErrorDialogGuiTest extends AddressBookGuiTest {
     public void showErrorDialogs() throws InterruptedException {
         //Test DataSavingExceptionEvent dialog
         raise(new DataSavingExceptionEvent(new IOException("Stub")));
-        AlertDialogHandle alertDialog = mainGui.getAlertDialog("File Op Error");
+
+        GuiRobot guiRobot = new GuiRobot();
+        guiRobot.sleep(500); // wait for the alert dialog box to launch
+        AlertDialogHandle alertDialog = new AlertDialogHandle(new GuiRobot(), stage, "File Op Error");
         assertTrue(alertDialog.isMatching("Could not save data", "Could not save data to file" + ":\n"
                                                                          + "java.io.IOException: Stub"));
 

--- a/src/test/java/guitests/guihandles/MainGuiHandle.java
+++ b/src/test/java/guitests/guihandles/MainGuiHandle.java
@@ -36,9 +36,4 @@ public class MainGuiHandle extends GuiHandle {
     public BrowserPanelHandle getBrowserPanel() {
         return new BrowserPanelHandle(guiRobot, primaryStage);
     }
-
-    public AlertDialogHandle getAlertDialog(String title) {
-        guiRobot.sleep(1000);
-        return new AlertDialogHandle(guiRobot, primaryStage, title);
-    }
 }

--- a/src/test/java/guitests/guihandles/MainGuiHandle.java
+++ b/src/test/java/guitests/guihandles/MainGuiHandle.java
@@ -9,31 +9,45 @@ import seedu.address.TestApp;
  */
 public class MainGuiHandle extends GuiHandle {
 
+    private final PersonListPanelHandle personListPanel;
+    private final ResultDisplayHandle resultDisplay;
+    private final CommandBoxHandle commandBox;
+    private final StatusBarFooterHandle statusBarFooter;
+    private final MainMenuHandle mainMenu;
+    private final BrowserPanelHandle browserPanel;
+
     public MainGuiHandle(GuiRobot guiRobot, Stage primaryStage) {
         super(guiRobot, primaryStage, TestApp.APP_TITLE);
+
+        personListPanel = new PersonListPanelHandle(guiRobot, primaryStage);
+        resultDisplay = new ResultDisplayHandle(guiRobot, primaryStage);
+        commandBox = new CommandBoxHandle(guiRobot, primaryStage, TestApp.APP_TITLE);
+        statusBarFooter = new StatusBarFooterHandle(guiRobot, primaryStage);
+        mainMenu = new MainMenuHandle(guiRobot, primaryStage);
+        browserPanel = new BrowserPanelHandle(guiRobot, primaryStage);
     }
 
     public PersonListPanelHandle getPersonListPanel() {
-        return new PersonListPanelHandle(guiRobot, primaryStage);
+        return personListPanel;
     }
 
     public ResultDisplayHandle getResultDisplay() {
-        return new ResultDisplayHandle(guiRobot, primaryStage);
+        return resultDisplay;
     }
 
     public CommandBoxHandle getCommandBox() {
-        return new CommandBoxHandle(guiRobot, primaryStage, TestApp.APP_TITLE);
+        return commandBox;
     }
 
     public StatusBarFooterHandle getStatusBarFooter() {
-        return new StatusBarFooterHandle(guiRobot, primaryStage);
+        return statusBarFooter;
     }
 
     public MainMenuHandle getMainMenu() {
-        return new MainMenuHandle(guiRobot, primaryStage);
+        return mainMenu;
     }
 
     public BrowserPanelHandle getBrowserPanel() {
-        return new BrowserPanelHandle(guiRobot, primaryStage);
+        return browserPanel;
     }
 }

--- a/src/test/java/guitests/guihandles/MainWindowHandle.java
+++ b/src/test/java/guitests/guihandles/MainWindowHandle.java
@@ -5,9 +5,9 @@ import javafx.stage.Stage;
 import seedu.address.TestApp;
 
 /**
- * Provides a handle for the main GUI.
+ * Provides a handle for {@code MainWindow}.
  */
-public class MainGuiHandle extends GuiHandle {
+public class MainWindowHandle extends GuiHandle {
 
     private final PersonListPanelHandle personListPanel;
     private final ResultDisplayHandle resultDisplay;
@@ -16,7 +16,7 @@ public class MainGuiHandle extends GuiHandle {
     private final MainMenuHandle mainMenu;
     private final BrowserPanelHandle browserPanel;
 
-    public MainGuiHandle(GuiRobot guiRobot, Stage primaryStage) {
+    public MainWindowHandle(GuiRobot guiRobot, Stage primaryStage) {
         super(guiRobot, primaryStage, TestApp.APP_TITLE);
 
         personListPanel = new PersonListPanelHandle(guiRobot, primaryStage);


### PR DESCRIPTION
Part of #459.

Proposed merge commit message:
```
MainGuiHandle recreates a new Handle whenever one is requested. It also
handles AlertDialog box, even though it is only responsible for the
MainWindow.

There is no need to recreate the handles. Furthermore, MainGuiHandle
should be the owner of all the handles to the components in MainWindow,
but not for any error dialog boxes.

Let's encapsulate the handles in MainGuiHandle. Let's also remove 
getAlertDialog(String), and make the callers create the handle on their
own instead.
```