### PR TITLE
Clean up AddressbookGuiTest #459

### DIFF
--- a/src/test/java/guitests/AddCommandTest.java
+++ b/src/test/java/guitests/AddCommandTest.java
@@ -47,7 +47,7 @@ public class AddCommandTest extends AddressBookGuiTest {
         //confirm the new card contains the right data
         personListPanel.navigateToPerson(personToAdd);
         PersonCardHandle addedCard = personListPanel.getPersonCardHandle(personToAdd);
-        assertMatching(personToAdd, addedCard);
+        assertCardMatchesPerson(addedCard, personToAdd);
 
         //confirm the list now contains all previous persons plus the new person
         Person[] expectedList = TestUtil.addPersonsToList(currentList, personToAdd);

--- a/src/test/java/guitests/AddressBookGuiTest.java
+++ b/src/test/java/guitests/AddressBookGuiTest.java
@@ -102,7 +102,7 @@ public abstract class AddressBookGuiTest {
     }
 
     @After
-    public void cleanup() throws TimeoutException {
+    public void cleanup() throws Exception {
         FxToolkit.cleanupStages();
     }
 

--- a/src/test/java/guitests/AddressBookGuiTest.java
+++ b/src/test/java/guitests/AddressBookGuiTest.java
@@ -80,7 +80,6 @@ public abstract class AddressBookGuiTest {
         EventsCenter.clearSubscribers();
         FxToolkit.setupApplication(() -> new TestApp(this::getInitialData, getDataFileLocation()));
         FxToolkit.showStage();
-        while (!stage.isShowing());
         mainGui.focusOnMainApp();
     }
 

--- a/src/test/java/guitests/AddressBookGuiTest.java
+++ b/src/test/java/guitests/AddressBookGuiTest.java
@@ -57,7 +57,7 @@ public abstract class AddressBookGuiTest {
     protected Stage stage;
 
     @BeforeClass
-    public static void setupSpec() {
+    public static void setupOnce() {
         try {
             FxToolkit.registerPrimaryStage();
             FxToolkit.hideStage();

--- a/src/test/java/guitests/AddressBookGuiTest.java
+++ b/src/test/java/guitests/AddressBookGuiTest.java
@@ -128,8 +128,8 @@ public abstract class AddressBookGuiTest {
         assertEquals(expected, resultDisplay.getText());
     }
 
-    public void raise(BaseEvent e) {
+    public void raise(BaseEvent event) {
         //JUnit doesn't run its test cases on the UI thread. Platform.runLater is used to post event on the UI thread.
-        Platform.runLater(() -> EventsCenter.getInstance().post(e));
+        Platform.runLater(() -> EventsCenter.getInstance().post(event));
     }
 }

--- a/src/test/java/guitests/AddressBookGuiTest.java
+++ b/src/test/java/guitests/AddressBookGuiTest.java
@@ -109,7 +109,7 @@ public abstract class AddressBookGuiTest {
     /**
      * Asserts the person shown in the card is same as the given person
      */
-    protected void assertMatching(ReadOnlyPerson person, PersonCardHandle card) {
+    protected void assertCardMatchesPerson(PersonCardHandle card, ReadOnlyPerson person) {
         assertTrue(TestUtil.compareCardAndPerson(card, person));
     }
 

--- a/src/test/java/guitests/AddressBookGuiTest.java
+++ b/src/test/java/guitests/AddressBookGuiTest.java
@@ -109,7 +109,7 @@ public abstract class AddressBookGuiTest {
     /**
      * Asserts the person shown in the card is same as the given person
      */
-    public void assertMatching(ReadOnlyPerson person, PersonCardHandle card) {
+    protected void assertMatching(ReadOnlyPerson person, PersonCardHandle card) {
         assertTrue(TestUtil.compareCardAndPerson(card, person));
     }
 
@@ -128,7 +128,7 @@ public abstract class AddressBookGuiTest {
         assertEquals(expected, resultDisplay.getText());
     }
 
-    public void raise(BaseEvent event) {
+    protected void raise(BaseEvent event) {
         //JUnit doesn't run its test cases on the UI thread. Platform.runLater is used to post event on the UI thread.
         Platform.runLater(() -> EventsCenter.getInstance().post(event));
     }

--- a/src/test/java/guitests/AddressBookGuiTest.java
+++ b/src/test/java/guitests/AddressBookGuiTest.java
@@ -40,6 +40,7 @@ public abstract class AddressBookGuiTest {
     public TestName name = new TestName();
 
     protected TypicalPersons td = new TypicalPersons();
+    protected GuiRobot guiRobot = new GuiRobot();
 
     /*
      *   Handles to GUI elements present at the start up are created in advance

--- a/src/test/java/guitests/EditCommandTest.java
+++ b/src/test/java/guitests/EditCommandTest.java
@@ -147,7 +147,7 @@ public class EditCommandTest extends AddressBookGuiTest {
         // confirm the new card contains the right data
         personListPanel.navigateToPerson(editedPerson);
         PersonCardHandle editedCard = personListPanel.getPersonCardHandle(editedPerson);
-        assertMatching(editedPerson, editedCard);
+        assertCardMatchesPerson(editedCard, editedPerson);
 
         // confirm the list now contains all previous persons plus the person with updated details
         expectedPersonsList[addressBookIndex.getZeroBased()] = editedPerson;

--- a/src/test/java/guitests/ErrorDialogGuiTest.java
+++ b/src/test/java/guitests/ErrorDialogGuiTest.java
@@ -15,8 +15,6 @@ public class ErrorDialogGuiTest extends AddressBookGuiTest {
 
     @Test
     public void showErrorDialogs() throws InterruptedException {
-        GuiRobot guiRobot = new GuiRobot();
-
         raise(new DataSavingExceptionEvent(new IOException("Stub")));
 
         guiRobot.waitForEvent(() -> guiRobot.isWindowShown(ERROR_DIALOG_STAGE_TITLE));


### PR DESCRIPTION
Part of #459.

Proposed merge commit message:
```
Let's clean up AddressBookGuiTest by:

- Removing the while loop that waits for the stage to show in the 
  setup() phase. FxToolkit#showStage() automatically blocks until
  the stage shows, so the wait is unnecessary.
- Creating the guiRobot only in AddressBookGuiTest. It need not be
  recreated and can be shared by everyone.
- Reducing the visibility of assertMatching(...) and raise(...) from 
  public to private.
- Renaming method parameters that does not conform to coding standards.
- Renaming setupSpec() to setupOnce().
- Changing cleanup()'s throws declaration from TimeoutException to 
  Exception.
- Renaming assertMatching(...) to assertCardMatchesPerson(...).
```