### PR TITLE
Clean up ErrorDialogGuiTest #459

### DIFF
--- a/src/main/java/seedu/address/ui/UiManager.java
+++ b/src/main/java/seedu/address/ui/UiManager.java
@@ -28,6 +28,10 @@ public class UiManager extends ComponentManager implements Ui {
 
     public static final String ALERT_DIALOG_PANE_FIELD_ID = "alertDialogPane";
 
+    public static final String FILE_OPS_ERROR_DIALOG_STAGE_TITLE = "File Op Error";
+    public static final String FILE_OPS_ERROR_DIALOG_HEADER_MESSAGE = "Could not save data";
+    public static final String FILE_OPS_ERROR_DIALOG_CONTENT_MESSAGE = "Could not save data to file";
+
     private static final Logger logger = LogsCenter.getLogger(UiManager.class);
     private static final String ICON_APPLICATION = "/images/address_book_32.png";
 
@@ -71,7 +75,7 @@ public class UiManager extends ComponentManager implements Ui {
 
     private void showFileOperationAlertAndWait(String description, String details, Throwable cause) {
         final String content = details + ":\n" + cause.toString();
-        showAlertDialogAndWait(AlertType.ERROR, "File Op Error", description, content);
+        showAlertDialogAndWait(AlertType.ERROR, FILE_OPS_ERROR_DIALOG_STAGE_TITLE, description, content);
     }
 
     private Image getImage(String imagePath) {
@@ -106,7 +110,8 @@ public class UiManager extends ComponentManager implements Ui {
     @Subscribe
     private void handleDataSavingExceptionEvent(DataSavingExceptionEvent event) {
         logger.info(LogsCenter.getEventHandlingLogMessage(event));
-        showFileOperationAlertAndWait("Could not save data", "Could not save data to file", event.exception);
+        showFileOperationAlertAndWait(FILE_OPS_ERROR_DIALOG_HEADER_MESSAGE, FILE_OPS_ERROR_DIALOG_CONTENT_MESSAGE,
+                event.exception);
     }
 
     @Subscribe

--- a/src/test/java/guitests/ErrorDialogGuiTest.java
+++ b/src/test/java/guitests/ErrorDialogGuiTest.java
@@ -1,6 +1,6 @@
 package guitests;
 
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static seedu.address.ui.UiManager.FILE_OPS_ERROR_DIALOG_CONTENT_MESSAGE;
 import static seedu.address.ui.UiManager.FILE_OPS_ERROR_DIALOG_HEADER_MESSAGE;
 import static seedu.address.ui.UiManager.FILE_OPS_ERROR_DIALOG_STAGE_TITLE;
@@ -21,10 +21,11 @@ public class ErrorDialogGuiTest extends AddressBookGuiTest {
         raise(new DataSavingExceptionEvent(IO_EXCEPTION_STUB));
 
         guiRobot.waitForEvent(() -> guiRobot.isWindowShown(FILE_OPS_ERROR_DIALOG_STAGE_TITLE));
-        AlertDialogHandle alertDialog = new AlertDialogHandle(FILE_OPS_ERROR_DIALOG_STAGE_TITLE);
-        assertTrue(alertDialog.isMatching(FILE_OPS_ERROR_DIALOG_HEADER_MESSAGE,
-                FILE_OPS_ERROR_DIALOG_CONTENT_MESSAGE + ":\n" + IO_EXCEPTION_STUB.toString()));
 
+        AlertDialogHandle alertDialog = new AlertDialogHandle(FILE_OPS_ERROR_DIALOG_STAGE_TITLE);
+        assertEquals(FILE_OPS_ERROR_DIALOG_HEADER_MESSAGE, alertDialog.getHeaderText());
+        assertEquals(FILE_OPS_ERROR_DIALOG_CONTENT_MESSAGE + ":\n" + IO_EXCEPTION_STUB.toString(),
+                alertDialog.getContentText());
     }
 
 }

--- a/src/test/java/guitests/ErrorDialogGuiTest.java
+++ b/src/test/java/guitests/ErrorDialogGuiTest.java
@@ -15,7 +15,7 @@ import seedu.address.commons.events.storage.DataSavingExceptionEvent;
 public class ErrorDialogGuiTest extends AddressBookGuiTest {
 
     @Test
-    public void showErrorDialogs() throws InterruptedException {
+    public void showErrorDialogs() {
         raise(new DataSavingExceptionEvent(new IOException("Stub")));
 
         guiRobot.waitForEvent(() -> guiRobot.isWindowShown(FILE_OPS_ERROR_DIALOG_STAGE_TITLE));

--- a/src/test/java/guitests/ErrorDialogGuiTest.java
+++ b/src/test/java/guitests/ErrorDialogGuiTest.java
@@ -1,6 +1,9 @@
 package guitests;
 
 import static junit.framework.TestCase.assertTrue;
+import static seedu.address.ui.UiManager.FILE_OPS_ERROR_DIALOG_CONTENT_MESSAGE;
+import static seedu.address.ui.UiManager.FILE_OPS_ERROR_DIALOG_HEADER_MESSAGE;
+import static seedu.address.ui.UiManager.FILE_OPS_ERROR_DIALOG_STAGE_TITLE;
 
 import java.io.IOException;
 
@@ -11,16 +14,14 @@ import seedu.address.commons.events.storage.DataSavingExceptionEvent;
 
 public class ErrorDialogGuiTest extends AddressBookGuiTest {
 
-    private static final String ERROR_DIALOG_STAGE_TITLE = "File Op Error";
-
     @Test
     public void showErrorDialogs() throws InterruptedException {
         raise(new DataSavingExceptionEvent(new IOException("Stub")));
 
-        guiRobot.waitForEvent(() -> guiRobot.isWindowShown(ERROR_DIALOG_STAGE_TITLE));
-        AlertDialogHandle alertDialog = new AlertDialogHandle(ERROR_DIALOG_STAGE_TITLE);
-        assertTrue(alertDialog.isMatching("Could not save data", "Could not save data to file" + ":\n"
-                                                                         + "java.io.IOException: Stub"));
+        guiRobot.waitForEvent(() -> guiRobot.isWindowShown(FILE_OPS_ERROR_DIALOG_STAGE_TITLE));
+        AlertDialogHandle alertDialog = new AlertDialogHandle(FILE_OPS_ERROR_DIALOG_STAGE_TITLE);
+        assertTrue(alertDialog.isMatching(FILE_OPS_ERROR_DIALOG_HEADER_MESSAGE,
+                FILE_OPS_ERROR_DIALOG_CONTENT_MESSAGE + ":\n" + "java.io.IOException: Stub"));
 
     }
 

--- a/src/test/java/guitests/ErrorDialogGuiTest.java
+++ b/src/test/java/guitests/ErrorDialogGuiTest.java
@@ -14,14 +14,16 @@ import seedu.address.commons.events.storage.DataSavingExceptionEvent;
 
 public class ErrorDialogGuiTest extends AddressBookGuiTest {
 
+    private static final IOException IO_EXCEPTION_STUB = new IOException("Stub");
+
     @Test
     public void showErrorDialogs() {
-        raise(new DataSavingExceptionEvent(new IOException("Stub")));
+        raise(new DataSavingExceptionEvent(IO_EXCEPTION_STUB));
 
         guiRobot.waitForEvent(() -> guiRobot.isWindowShown(FILE_OPS_ERROR_DIALOG_STAGE_TITLE));
         AlertDialogHandle alertDialog = new AlertDialogHandle(FILE_OPS_ERROR_DIALOG_STAGE_TITLE);
         assertTrue(alertDialog.isMatching(FILE_OPS_ERROR_DIALOG_HEADER_MESSAGE,
-                FILE_OPS_ERROR_DIALOG_CONTENT_MESSAGE + ":\n" + "java.io.IOException: Stub"));
+                FILE_OPS_ERROR_DIALOG_CONTENT_MESSAGE + ":\n" + IO_EXCEPTION_STUB.toString()));
 
     }
 

--- a/src/test/java/guitests/guihandles/AlertDialogHandle.java
+++ b/src/test/java/guitests/guihandles/AlertDialogHandle.java
@@ -1,7 +1,5 @@
 package guitests.guihandles;
 
-import static seedu.address.commons.util.AppUtil.checkArgument;
-
 import javafx.scene.control.DialogPane;
 import seedu.address.ui.UiManager;
 
@@ -30,11 +28,5 @@ public class AlertDialogHandle extends GuiHandle {
      */
     public String getContentText() {
         return getDialogPane().getContentText();
-    }
-
-    public boolean isMatching(String headerMessage, String contentMessage) {
-        checkArgument(intermediateStage.isPresent(), "Alert dialog is not present");
-        boolean isMatching = getHeaderText().equals(headerMessage) && getContentText().equals(contentMessage);
-        return isMatching;
     }
 }

--- a/src/test/java/guitests/guihandles/AlertDialogHandle.java
+++ b/src/test/java/guitests/guihandles/AlertDialogHandle.java
@@ -14,11 +14,27 @@ public class AlertDialogHandle extends GuiHandle {
         super(dialogTitle);
     }
 
+    private DialogPane getDialogPane() {
+        return getNode("#" + UiManager.ALERT_DIALOG_PANE_FIELD_ID);
+    }
+
+    /**
+     * Returns the text of the header in the {@code AlertDialog}.
+     */
+    public String getHeaderText() {
+        return getDialogPane().getHeaderText();
+    }
+
+    /**
+     * Returns the text of the content in the {@code AlertDialog}.
+     */
+    public String getContentText() {
+        return getDialogPane().getContentText();
+    }
+
     public boolean isMatching(String headerMessage, String contentMessage) {
         checkArgument(intermediateStage.isPresent(), "Alert dialog is not present");
-        DialogPane dialogPane = getNode("#" + UiManager.ALERT_DIALOG_PANE_FIELD_ID);
-        boolean isMatching = dialogPane.getHeaderText().equals(headerMessage)
-                && dialogPane.getContentText().equals(contentMessage);
+        boolean isMatching = getHeaderText().equals(headerMessage) && getContentText().equals(contentMessage);
         return isMatching;
     }
 }


### PR DESCRIPTION
Part of #459.

Proposed merge commit message:
```
Let's

- Extract out commonly used strings and objects as constants to avoid
  violating DRY principle.
- Remove unnecessary declaration of runtime exception 
  InterruptedException.
- Create methods in AlertDialogHandle, allowing us to verify the contents
  of the error dialog box.
- Inline AlertDialogHandle#isMatching(String, String), as it should be
  the responsibility of ErrorDialogGuiTest to verify the content.
```