### PR TITLE
Clean up UniqueTagList #539

### DIFF
--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -2,7 +2,6 @@ package seedu.address.model;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -57,7 +56,7 @@ public class AddressBook implements ReadOnlyAddressBook {
         this.persons.setPersons(persons);
     }
 
-    public void setTags(Collection<Tag> tags) throws UniqueTagList.DuplicateTagException {
+    public void setTags(Set<Tag> tags) {
         this.tags.setTags(tags);
     }
 
@@ -68,11 +67,8 @@ public class AddressBook implements ReadOnlyAddressBook {
         } catch (DuplicatePersonException e) {
             assert false : "AddressBooks should not have duplicate persons";
         }
-        try {
-            setTags(newData.getTagList());
-        } catch (UniqueTagList.DuplicateTagException e) {
-            assert false : "AddressBooks should not have duplicate tags";
-        }
+
+        setTags(new HashSet<>(newData.getTagList()));
         syncMasterTagListWith(persons);
     }
 

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -92,7 +92,7 @@ public class Person implements ReadOnlyPerson {
      * Replaces this person's tags with the tags in the argument tag set.
      */
     public void setTags(Set<Tag> replacement) {
-        tags.setTags(new UniqueTagList(replacement));
+        tags.setTags(replacement);
     }
 
     /**

--- a/src/main/java/seedu/address/model/tag/UniqueTagList.java
+++ b/src/main/java/seedu/address/model/tag/UniqueTagList.java
@@ -54,8 +54,9 @@ public class UniqueTagList implements Iterable<Tag> {
     /**
      * Replaces the Tags in this list with those in the argument tag list.
      */
-    public void setTags(UniqueTagList replacement) {
-        this.internalList.setAll(replacement.internalList);
+    public void setTags(Set<Tag> tags) {
+        requireAllNonNull(tags);
+        internalList.setAll(tags);
         assert CollectionUtil.elementsAreUnique(internalList);
     }
 

--- a/src/main/java/seedu/address/model/tag/UniqueTagList.java
+++ b/src/main/java/seedu/address/model/tag/UniqueTagList.java
@@ -3,7 +3,6 @@ package seedu.address.model.tag;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
@@ -20,7 +19,6 @@ import seedu.address.commons.util.CollectionUtil;
  * Supports minimal set of list operations for the app's features.
  *
  * @see Tag#equals(Object)
- * @see CollectionUtil#elementsAreUnique(Collection)
  */
 public class UniqueTagList implements Iterable<Tag> {
 
@@ -57,16 +55,6 @@ public class UniqueTagList implements Iterable<Tag> {
     public void setTags(Set<Tag> tags) {
         requireAllNonNull(tags);
         internalList.setAll(tags);
-        assert CollectionUtil.elementsAreUnique(internalList);
-    }
-
-    public void setTags(Collection<Tag> tags) throws DuplicateTagException {
-        requireAllNonNull(tags);
-        if (!CollectionUtil.elementsAreUnique(tags)) {
-            throw new DuplicateTagException();
-        }
-        internalList.setAll(tags);
-
         assert CollectionUtil.elementsAreUnique(internalList);
     }
 

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -57,19 +57,6 @@ public class AddressBookTest {
         addressBook.resetData(newData);
     }
 
-    @Test
-    public void resetData_withDuplicateTags_throwsAssertionError() {
-        AddressBook typicalAddressBook = new TypicalPersons().getTypicalAddressBook();
-        List<ReadOnlyPerson> newPersons = typicalAddressBook.getPersonList();
-        List<Tag> newTags = new ArrayList<>(typicalAddressBook.getTagList());
-        // Repeat the first tag twice
-        newTags.add(newTags.get(0));
-        AddressBookStub newData = new AddressBookStub(newPersons, newTags);
-
-        thrown.expect(AssertionError.class);
-        addressBook.resetData(newData);
-    }
-
     /**
      * A stub ReadOnlyAddressBook whose persons and tags lists can violate interface constraints.
      */


### PR DESCRIPTION
Fixes #539

```
UniqueTagList has 2 overloaded methods to set tags:
setTags(UniqueTagList) and setTags(Collection).

Person#setTags(Set) constructs a UniqueTagList from the set of tags
passed in. It then calls UniqueTagList#setTags(UniqueTagList),
which then calls setAll(UniqueTagList#internalList).

This makes the construction of UniqueTagList unnecessary as no
other properties of UniqueTagList are required here.

Also, AddressBook#resetData(ReadOnlyAddressBook) calls 
setTags(Collection), followed by a catch clause asserting that 
AddressBooks should not have duplicate tags.

This makes the code unnecessarily long as there is a try-catch
block, where the catch block does not do anything significant.

Let’s replace these methods with UniqueTagList#setTags(Set<Tag>).
Person#setTags(Set<Tag>) will not need to construct a UniqueTagList,
and AddressBook#resetData(ReadOnlyAddressBook) will not need to
catch the DuplicateTagException as there are no duplicate tags in a
Set.
```