### PR TITLE
DeveloperGuide.adoc: Add step for updating version number in MainApp

### DIFF
--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -284,6 +284,7 @@ See <<UsingGithubPages#, UsingGithubPages.adoc>> to learn how to use GitHub Page
 
 Here are the steps to create a new release.
 
+.  Update the version number in link:{repoURL}/src/main/java/seedu/address/MainApp.java[`MainApp.java`].
 .  Generate a JAR file <<UsingGradle#creating-the-jar-file, using Gradle>>.
 .  Tag the repo with the version number. e.g. `v0.1`
 .  https://help.github.com/articles/creating-releases/[Create a new release using GitHub] and upload the JAR file you created.


### PR DESCRIPTION
When doing a new release, MainApp#VERSION needs to be updated to match
the release version number.

This step is not reflected in DeveloperGuide.adoc's release devops
procedure.

Let's add the step for updating the version number in MainApp.