### PR TITLE
Make ReadOnlyPerson observable #292

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,7 @@ allprojects {
     }
 
     dependencies {
+        compile group: 'org.fxmisc.easybind', name: 'easybind', version: '1.0.3'
         compile "org.controlsfx:controlsfx:$controlsFxVersion"
         compile "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
         compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonDataTypeVersion"

--- a/src/main/java/seedu/address/commons/events/ui/PersonPanelSelectionChangedEvent.java
+++ b/src/main/java/seedu/address/commons/events/ui/PersonPanelSelectionChangedEvent.java
@@ -1,7 +1,7 @@
 package seedu.address.commons.events.ui;
 
 import seedu.address.commons.events.BaseEvent;
-import seedu.address.model.person.ReadOnlyPerson;
+import seedu.address.ui.PersonCard;
 
 /**
  * Represents a selection change in the Person List Panel
@@ -9,9 +9,9 @@ import seedu.address.model.person.ReadOnlyPerson;
 public class PersonPanelSelectionChangedEvent extends BaseEvent {
 
 
-    private final ReadOnlyPerson newSelection;
+    private final PersonCard newSelection;
 
-    public PersonPanelSelectionChangedEvent(ReadOnlyPerson newSelection) {
+    public PersonPanelSelectionChangedEvent(PersonCard newSelection) {
         this.newSelection = newSelection;
     }
 
@@ -20,7 +20,7 @@ public class PersonPanelSelectionChangedEvent extends BaseEvent {
         return this.getClass().getSimpleName();
     }
 
-    public ReadOnlyPerson getNewSelection() {
+    public PersonCard getNewSelection() {
         return newSelection;
     }
 }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -7,6 +7,8 @@ import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
 
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.tag.UniqueTagList;
 
@@ -16,23 +18,24 @@ import seedu.address.model.tag.UniqueTagList;
  */
 public class Person implements ReadOnlyPerson {
 
-    private Name name;
-    private Phone phone;
-    private Email email;
-    private Address address;
+    private ObjectProperty<Name> name;
+    private ObjectProperty<Phone> phone;
+    private ObjectProperty<Email> email;
+    private ObjectProperty<Address> address;
 
-    private UniqueTagList tags;
+    private ObjectProperty<UniqueTagList> tags;
 
     /**
      * Every field must be present and not null.
      */
     public Person(Name name, Phone phone, Email email, Address address, Set<Tag> tags) {
         requireAllNonNull(name, phone, email, address, tags);
-        this.name = name;
-        this.phone = phone;
-        this.email = email;
-        this.address = address;
-        this.tags = new UniqueTagList(tags); // protect internal tags from changes in the arg list
+        this.name = new SimpleObjectProperty<>(name);
+        this.phone = new SimpleObjectProperty<>(phone);
+        this.email = new SimpleObjectProperty<>(email);
+        this.address = new SimpleObjectProperty<>(address);
+        // protect internal tags from changes in the arg list
+        this.tags = new SimpleObjectProperty<>(new UniqueTagList(tags));
     }
 
     /**
@@ -44,39 +47,59 @@ public class Person implements ReadOnlyPerson {
     }
 
     public void setName(Name name) {
-        this.name = requireNonNull(name);
+        this.name.set(requireNonNull(name));
+    }
+
+    @Override
+    public ObjectProperty<Name> nameProperty() {
+        return name;
     }
 
     @Override
     public Name getName() {
-        return name;
+        return name.get();
     }
 
     public void setPhone(Phone phone) {
-        this.phone = requireNonNull(phone);
+        this.phone.set(requireNonNull(phone));
+    }
+
+    @Override
+    public ObjectProperty<Phone> phoneProperty() {
+        return phone;
     }
 
     @Override
     public Phone getPhone() {
-        return phone;
+        return phone.get();
     }
 
     public void setEmail(Email email) {
-        this.email = requireNonNull(email);
+        this.email.set(requireNonNull(email));
+    }
+
+    @Override
+    public ObjectProperty<Email> emailProperty() {
+        return email;
     }
 
     @Override
     public Email getEmail() {
-        return email;
+        return email.get();
     }
 
     public void setAddress(Address address) {
-        this.address = requireNonNull(address);
+        this.address.set(requireNonNull(address));
+    }
+
+    @Override
+    public ObjectProperty<Address> addressProperty() {
+        return address;
     }
 
     @Override
     public Address getAddress() {
-        return address;
+        return address.get();
     }
 
     /**
@@ -85,14 +108,18 @@ public class Person implements ReadOnlyPerson {
      */
     @Override
     public Set<Tag> getTags() {
-        return Collections.unmodifiableSet(tags.toSet());
+        return Collections.unmodifiableSet(tags.get().toSet());
+    }
+
+    public ObjectProperty<UniqueTagList> tagProperty() {
+        return tags;
     }
 
     /**
      * Replaces this person's tags with the tags in the argument tag set.
      */
     public void setTags(Set<Tag> replacement) {
-        tags.setTags(replacement);
+        tags.set(new UniqueTagList(replacement));
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/ReadOnlyPerson.java
+++ b/src/main/java/seedu/address/model/person/ReadOnlyPerson.java
@@ -2,7 +2,9 @@ package seedu.address.model.person;
 
 import java.util.Set;
 
+import javafx.beans.property.ObjectProperty;
 import seedu.address.model.tag.Tag;
+import seedu.address.model.tag.UniqueTagList;
 
 /**
  * A read-only immutable interface for a Person in the addressbook.
@@ -10,10 +12,15 @@ import seedu.address.model.tag.Tag;
  */
 public interface ReadOnlyPerson {
 
+    ObjectProperty<Name> nameProperty();
     Name getName();
+    ObjectProperty<Phone> phoneProperty();
     Phone getPhone();
+    ObjectProperty<Email> emailProperty();
     Email getEmail();
+    ObjectProperty<Address> addressProperty();
     Address getAddress();
+    ObjectProperty<UniqueTagList> tagProperty();
     Set<Tag> getTags();
 
     /**

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -67,10 +67,6 @@ public class UniquePersonList implements Iterable<Person> {
         }
 
         personToUpdate.resetData(editedPerson);
-        // TODO: The code below is just a workaround to notify observers of the updated person.
-        // The right way is to implement observable properties in the Person class.
-        // Then, PersonCard should then bind its text labels to those observable properties.
-        internalList.set(index, personToUpdate);
     }
 
     /**

--- a/src/main/java/seedu/address/ui/BrowserPanel.java
+++ b/src/main/java/seedu/address/ui/BrowserPanel.java
@@ -63,6 +63,6 @@ public class BrowserPanel extends UiPart<Region> {
     @Subscribe
     private void handlePersonPanelSelectionChangedEvent(PersonPanelSelectionChangedEvent event) {
         logger.info(LogsCenter.getEventHandlingLogMessage(event));
-        loadPersonPage(event.getNewSelection());
+        loadPersonPage(event.getNewSelection().person);
     }
 }

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -1,5 +1,6 @@
 package seedu.address.ui;
 
+import javafx.beans.binding.Bindings;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.layout.FlowPane;
@@ -19,6 +20,8 @@ public class PersonCard extends UiPart<Region> {
      * @see <a href="https://github.com/se-edu/addressbook-level4/issues/336">The issue on AddressBook level 4</a>
      */
 
+    public final ReadOnlyPerson person;
+
     @FXML
     private HBox cardPane;
     @FXML
@@ -36,12 +39,25 @@ public class PersonCard extends UiPart<Region> {
 
     public PersonCard(ReadOnlyPerson person, int displayedIndex) {
         super(FXML);
-        name.setText(person.getName().fullName);
+        this.person = person;
         id.setText(displayedIndex + ". ");
-        phone.setText(person.getPhone().value);
-        address.setText(person.getAddress().value);
-        email.setText(person.getEmail().value);
         initTags(person);
+        bindListeners(person);
+    }
+
+    /**
+     * Binds the individual UI elements to observe their respective {@code Person} properties
+     * so that they will be notified of any changes.
+     */
+    private void bindListeners(ReadOnlyPerson person) {
+        name.textProperty().bind(Bindings.convert(person.nameProperty()));
+        phone.textProperty().bind(Bindings.convert(person.phoneProperty()));
+        address.textProperty().bind(Bindings.convert(person.addressProperty()));
+        email.textProperty().bind(Bindings.convert(person.emailProperty()));
+        person.tagProperty().addListener((observable, oldValue, newValue) -> {
+            tags.getChildren().clear();
+            person.getTags().forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
+        });
     }
 
     private void initTags(ReadOnlyPerson person) {

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -63,4 +63,22 @@ public class PersonCard extends UiPart<Region> {
     private void initTags(ReadOnlyPerson person) {
         person.getTags().forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
     }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof PersonCard)) {
+            return false;
+        }
+
+        // state check
+        PersonCard card = (PersonCard) other;
+        return id.getText().equals(card.id.getText())
+                && person.equals(card.person);
+    }
 }

--- a/src/main/java/seedu/address/ui/PersonListPanel.java
+++ b/src/main/java/seedu/address/ui/PersonListPanel.java
@@ -2,6 +2,8 @@ package seedu.address.ui;
 
 import java.util.logging.Logger;
 
+import org.fxmisc.easybind.EasyBind;
+
 import com.google.common.eventbus.Subscribe;
 
 import javafx.application.Platform;
@@ -23,7 +25,7 @@ public class PersonListPanel extends UiPart<Region> {
     private final Logger logger = LogsCenter.getLogger(PersonListPanel.class);
 
     @FXML
-    private ListView<ReadOnlyPerson> personListView;
+    private ListView<PersonCard> personListView;
 
     public PersonListPanel(ObservableList<ReadOnlyPerson> personList) {
         super(FXML);
@@ -32,7 +34,9 @@ public class PersonListPanel extends UiPart<Region> {
     }
 
     private void setConnections(ObservableList<ReadOnlyPerson> personList) {
-        personListView.setItems(personList);
+        ObservableList<PersonCard> mappedList = EasyBind.map(
+                personList, (person) -> new PersonCard(person, personList.indexOf(person) + 1));
+        personListView.setItems(mappedList);
         personListView.setCellFactory(listView -> new PersonListViewCell());
         setEventHandlerForSelectionChangeEvent();
     }
@@ -60,17 +64,17 @@ public class PersonListPanel extends UiPart<Region> {
         scrollTo(event.targetIndex);
     }
 
-    class PersonListViewCell extends ListCell<ReadOnlyPerson> {
+    class PersonListViewCell extends ListCell<PersonCard> {
 
         @Override
-        protected void updateItem(ReadOnlyPerson person, boolean empty) {
+        protected void updateItem(PersonCard person, boolean empty) {
             super.updateItem(person, empty);
 
             if (empty || person == null) {
                 setGraphic(null);
                 setText(null);
             } else {
-                setGraphic(new PersonCard(person, getIndex() + 1).getRoot());
+                setGraphic(person.getRoot());
             }
         }
     }

--- a/src/test/java/guitests/AddCommandTest.java
+++ b/src/test/java/guitests/AddCommandTest.java
@@ -45,7 +45,7 @@ public class AddCommandTest extends AddressBookGuiTest {
         runCommand(PersonUtil.getAddCommand(personToAdd));
 
         //confirm the new card contains the right data
-        getPersonListPanel().navigateToPerson(personToAdd);
+        getPersonListPanel().navigateToCard(personToAdd);
         PersonCardHandle addedCard = getPersonListPanel().getPersonCardHandle(personToAdd);
         assertCardMatchesPerson(addedCard, personToAdd);
 

--- a/src/test/java/guitests/AddressBookGuiTest.java
+++ b/src/test/java/guitests/AddressBookGuiTest.java
@@ -134,7 +134,7 @@ public abstract class AddressBookGuiTest {
      * Asserts the size of the person list is equal to the given number.
      */
     protected void assertListSize(int size) {
-        int numberOfPeople = getPersonListPanel().getNumberOfPeople();
+        int numberOfPeople = getPersonListPanel().getListSize();
         assertEquals(size, numberOfPeople);
     }
 

--- a/src/test/java/guitests/EditCommandTest.java
+++ b/src/test/java/guitests/EditCommandTest.java
@@ -145,7 +145,7 @@ public class EditCommandTest extends AddressBookGuiTest {
                 + filteredPersonListIndex.getOneBased() + " " + detailsToEdit);
 
         // confirm the new card contains the right data
-        getPersonListPanel().navigateToPerson(editedPerson);
+        getPersonListPanel().navigateToCard(editedPerson);
         PersonCardHandle editedCard = getPersonListPanel().getPersonCardHandle(editedPerson);
         assertCardMatchesPerson(editedCard, editedPerson);
 

--- a/src/test/java/guitests/SelectCommandTest.java
+++ b/src/test/java/guitests/SelectCommandTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.SelectCommand;
-import seedu.address.model.person.ReadOnlyPerson;
+import seedu.address.ui.PersonCard;
 
 public class SelectCommandTest extends AddressBookGuiTest {
 
@@ -18,7 +18,7 @@ public class SelectCommandTest extends AddressBookGuiTest {
     public void selectPerson_nonEmptyList() {
 
         assertSelectionInvalid(Index.fromOneBased(10)); // invalid index
-        assertNoPersonSelected();
+        assertNoCardSelected();
 
         assertSelectionSuccess(INDEX_FIRST_PERSON); // first person in the list
         Index personCount = Index.fromOneBased(td.getTypicalPersons().length);
@@ -27,7 +27,7 @@ public class SelectCommandTest extends AddressBookGuiTest {
         assertSelectionSuccess(middleIndex); // a person in the middle of the list
 
         assertSelectionInvalid(Index.fromOneBased(personCount.getOneBased() + 1)); // invalid index
-        assertPersonSelected(middleIndex); // assert previous selection remains
+        assertCardSelected(middleIndex); // assert previous selection remains
 
         /* Testing other invalid indexes such as -1 should be done when testing the SelectCommand */
     }
@@ -47,17 +47,17 @@ public class SelectCommandTest extends AddressBookGuiTest {
     private void assertSelectionSuccess(Index index) {
         runCommand(SelectCommand.COMMAND_WORD + " " + index.getOneBased());
         assertResultMessage("Selected Person: " + index.getOneBased());
-        assertPersonSelected(index);
+        assertCardSelected(index);
     }
 
-    private void assertPersonSelected(Index index) {
-        ReadOnlyPerson selectedPerson = getPersonListPanel().getSelectedPerson().get();
-        assertEquals(getPersonListPanel().getPerson(index.getZeroBased()), selectedPerson);
+    private void assertCardSelected(Index index) {
+        PersonCard selectedCard = getPersonListPanel().getSelectedCard().get();
+        assertEquals(getPersonListPanel().getCard(index.getZeroBased()), selectedCard);
         //TODO: confirm the correct page is loaded in the Browser Panel
     }
 
-    private void assertNoPersonSelected() {
-        assertFalse(getPersonListPanel().getSelectedPerson().isPresent());
+    private void assertNoCardSelected() {
+        assertFalse(getPersonListPanel().getSelectedCard().isPresent());
     }
 
 }

--- a/src/test/java/guitests/guihandles/PersonListPanelHandle.java
+++ b/src/test/java/guitests/guihandles/PersonListPanelHandle.java
@@ -5,9 +5,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
-import javafx.scene.Node;
 import javafx.scene.control.ListView;
 import seedu.address.model.person.ReadOnlyPerson;
 import seedu.address.model.person.exceptions.PersonNotFoundException;
@@ -25,16 +23,16 @@ public class PersonListPanelHandle extends NodeHandle<ListView<PersonCard>> {
     }
 
     /**
-     * Returns the selected person in the list view. A maximum of 1 item can be selected at any time.
+     * Returns the selected {@code PersonCard} in the list view. A maximum of 1 item can be selected at any time.
      */
-    public Optional<ReadOnlyPerson> getSelectedPerson() {
+    public Optional<PersonCard> getSelectedCard() {
         List<PersonCard> personList = getRootNode().getSelectionModel().getSelectedItems();
 
         if (personList.size() > 1) {
             throw new AssertionError("Person list size expected 0 or 1.");
         }
 
-        return personList.isEmpty() ? Optional.empty() : Optional.of(personList.get(0).person);
+        return personList.isEmpty() ? Optional.empty() : Optional.of(personList.get(0));
     }
 
     /**
@@ -60,7 +58,7 @@ public class PersonListPanelHandle extends NodeHandle<ListView<PersonCard>> {
     /**
      * Navigates the listview to display and select the person.
      */
-    public void navigateToPerson(ReadOnlyPerson person) throws PersonNotFoundException {
+    public void navigateToCard(ReadOnlyPerson person) throws PersonNotFoundException {
         List<PersonCard> cards = getRootNode().getItems();
         Optional<PersonCard> matchingCard = cards.stream().filter(card -> card.person.equals(person)).findFirst();
 
@@ -76,17 +74,17 @@ public class PersonListPanelHandle extends NodeHandle<ListView<PersonCard>> {
     }
 
     /**
-     * Returns the person at the specified {@code index} in the list.
+     * Returns the {@code PersonCard} at the specified {@code index} in the list.
      */
-    public ReadOnlyPerson getPerson(int index) {
-        return getRootNode().getItems().get(index).person;
+    public PersonCard getCard(int index) {
+        return getRootNode().getItems().get(index);
     }
 
     /**
      * Returns the person card handle of a person associated with the {@code index} in the list.
      */
     private PersonCardHandle getPersonCardHandle(int index) throws PersonNotFoundException {
-        return getPersonCardHandle(getPerson(index));
+        return getPersonCardHandle(getCard(index).person);
     }
 
     /**
@@ -101,9 +99,9 @@ public class PersonListPanelHandle extends NodeHandle<ListView<PersonCard>> {
     }
 
     /**
-     * Returns the total number of people in the list.
+     * Returns the size of the list.
      */
-    public int getNumberOfPeople() {
+    public int getListSize() {
         return getRootNode().getItems().size();
     }
 }

--- a/src/test/java/guitests/guihandles/PersonListPanelHandle.java
+++ b/src/test/java/guitests/guihandles/PersonListPanelHandle.java
@@ -12,16 +12,15 @@ import javafx.scene.control.ListView;
 import seedu.address.model.person.ReadOnlyPerson;
 import seedu.address.model.person.exceptions.PersonNotFoundException;
 import seedu.address.testutil.TestUtil;
+import seedu.address.ui.PersonCard;
 
 /**
  * Provides a handle for the panel containing the person list.
  */
-public class PersonListPanelHandle extends NodeHandle<ListView<ReadOnlyPerson>> {
+public class PersonListPanelHandle extends NodeHandle<ListView<PersonCard>> {
     public static final String PERSON_LIST_VIEW_ID = "#personListView";
 
-    private static final String CARD_PANE_ID = "#cardPane";
-
-    public PersonListPanelHandle(ListView<ReadOnlyPerson> personListPanelNode) {
+    public PersonListPanelHandle(ListView<PersonCard> personListPanelNode) {
         super(personListPanelNode);
     }
 
@@ -29,13 +28,13 @@ public class PersonListPanelHandle extends NodeHandle<ListView<ReadOnlyPerson>> 
      * Returns the selected person in the list view. A maximum of 1 item can be selected at any time.
      */
     public Optional<ReadOnlyPerson> getSelectedPerson() {
-        List<ReadOnlyPerson> personList = getRootNode().getSelectionModel().getSelectedItems();
+        List<PersonCard> personList = getRootNode().getSelectionModel().getSelectedItems();
 
         if (personList.size() > 1) {
             throw new AssertionError("Person list size expected 0 or 1.");
         }
 
-        return personList.isEmpty() ? Optional.empty() : Optional.of(personList.get(0));
+        return personList.isEmpty() ? Optional.empty() : Optional.of(personList.get(0).person);
     }
 
     /**
@@ -43,7 +42,7 @@ public class PersonListPanelHandle extends NodeHandle<ListView<ReadOnlyPerson>> 
      * @param persons A list of person in the correct order.
      */
     public boolean isListMatching(ReadOnlyPerson... persons) throws PersonNotFoundException {
-        List<ReadOnlyPerson> personList = getRootNode().getItems();
+        List<PersonCard> personList = getRootNode().getItems();
         checkArgument(personList.size() == persons.length,
                 "List size mismatched\nExpected " + personList.size() + " persons");
 
@@ -62,13 +61,16 @@ public class PersonListPanelHandle extends NodeHandle<ListView<ReadOnlyPerson>> 
      * Navigates the listview to display and select the person.
      */
     public void navigateToPerson(ReadOnlyPerson person) throws PersonNotFoundException {
-        if (!getRootNode().getItems().contains(person)) {
+        List<PersonCard> cards = getRootNode().getItems();
+        Optional<PersonCard> matchingCard = cards.stream().filter(card -> card.person.equals(person)).findFirst();
+
+        if (!matchingCard.isPresent()) {
             throw new PersonNotFoundException();
         }
 
         guiRobot.interact(() -> {
-            getRootNode().scrollTo(person);
-            getRootNode().getSelectionModel().select(person);
+            getRootNode().scrollTo(matchingCard.get());
+            getRootNode().getSelectionModel().select(matchingCard.get());
         });
         guiRobot.pauseForHuman();
     }
@@ -77,7 +79,7 @@ public class PersonListPanelHandle extends NodeHandle<ListView<ReadOnlyPerson>> 
      * Returns the person at the specified {@code index} in the list.
      */
     public ReadOnlyPerson getPerson(int index) {
-        return getRootNode().getItems().get(index);
+        return getRootNode().getItems().get(index).person;
     }
 
     /**
@@ -91,16 +93,11 @@ public class PersonListPanelHandle extends NodeHandle<ListView<ReadOnlyPerson>> 
      * Returns the {@code PersonCardHandle} of the specified {@code person} in the list.
      */
     public PersonCardHandle getPersonCardHandle(ReadOnlyPerson person) throws PersonNotFoundException {
-        Set<Node> nodes = getAllCardNodes();
-        Optional<PersonCardHandle> personCardNode = nodes.stream()
-                .map(PersonCardHandle::new)
-                .filter(handle -> handle.isSamePerson(person))
+        Optional<PersonCardHandle> handle = getRootNode().getItems().stream()
+                .filter(card -> card.person.equals(person))
+                .map(card -> new PersonCardHandle(card.getRoot()))
                 .findFirst();
-        return personCardNode.orElseThrow(PersonNotFoundException::new);
-    }
-
-    private Set<Node> getAllCardNodes() {
-        return guiRobot.lookup(CARD_PANE_ID).queryAll();
+        return handle.orElseThrow(PersonNotFoundException::new);
     }
 
     /**

--- a/src/test/java/seedu/address/ui/PersonCardTest.java
+++ b/src/test/java/seedu/address/ui/PersonCardTest.java
@@ -1,6 +1,7 @@
 package seedu.address.ui;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Rule;
@@ -31,6 +32,32 @@ public class PersonCardTest {
         Person personWithTags = new PersonBuilder().build();
         assertCardDisplay(2, personWithTags);
         guiRobot.pauseForHuman();
+    }
+
+    @Test
+    public void equals() throws Exception {
+        Person person = new PersonBuilder().build();
+        PersonCard personCard = new PersonCard(person, 0);
+
+        // same person, same index -> returns true
+        PersonCard copy = new PersonCard(person, 0);
+        assertTrue(personCard.equals(copy));
+
+        // same object -> returns true
+        assertTrue(personCard.equals(personCard));
+
+        // null -> returns false
+        assertFalse(personCard.equals(null));
+
+        // different types -> returns false
+        assertFalse(personCard.equals(0));
+
+        // different person, same index -> returns false
+        Person differentPerson = new PersonBuilder().withName("differentName").build();
+        assertFalse(personCard.equals(new PersonCard(differentPerson, 0)));
+
+        // same person, different index -> returns false
+        assertFalse(personCard.equals(new PersonCard(person, 1)));
     }
 
     /**


### PR DESCRIPTION
Fixes #292. Note that tags are still not completely binded and we still have to manually initialize it, though it now updates automatically whenever there are changes made to the tags.

```
ReadOnlyPerson is not observable. Whenever a ReadOnlyPerson is added 
or updated, PersonListPanel creates a new PersonCard and initialises 
it with the ReadOnlyPerson's details.

This is inefficient as multiple cards have to be deleted and
re-created whenever a ReadOnlyPerson is updated. Also, there is an
additional call to set the ReadOnlyPerson in the list of PersonCards
to update the view i.e updating the ReadOnlyPerson does not 
automatically update the view.

Let's update ReadOnlyPerson to be observable and teach PersonCard
to bind its view to the ReadOnlyPerson objects so that whenever they
are updated, the view is automatically updated. As such, the cards
do not need to be deleted and re-created.
```