### PR TITLE
PersonListPanelHandle: No longer returns PersonCard #563

### DIFF
--- a/src/test/java/guitests/DeleteCommandTest.java
+++ b/src/test/java/guitests/DeleteCommandTest.java
@@ -23,18 +23,21 @@ public class DeleteCommandTest extends AddressBookGuiTest {
         //delete the first in the list
         ArrayList<ReadOnlyPerson> expectedList = new ArrayList<>(Arrays.asList(TYPICAL_PERSONS));
         Index targetIndex = INDEX_FIRST_PERSON;
+        ReadOnlyPerson toDelete = expectedList.get(targetIndex.getZeroBased());
         expectedList.remove(targetIndex.getZeroBased());
-        assertDeleteSuccess(targetIndex, expectedList);
+        assertDeleteSuccess(targetIndex, toDelete, expectedList);
 
         //delete the last in the list
         targetIndex = Index.fromOneBased(expectedList.size());
+        toDelete = expectedList.get(targetIndex.getZeroBased());
         expectedList.remove(targetIndex.getZeroBased());
-        assertDeleteSuccess(targetIndex, expectedList);
+        assertDeleteSuccess(targetIndex, toDelete, expectedList);
 
         //delete from the middle of the list
         targetIndex = Index.fromOneBased(expectedList.size() / 2);
+        toDelete = expectedList.get(targetIndex.getZeroBased());
         expectedList.remove(targetIndex.getZeroBased());
-        assertDeleteSuccess(targetIndex, expectedList);
+        assertDeleteSuccess(targetIndex, toDelete, expectedList);
 
         //invalid index
         runCommand(DeleteCommand.COMMAND_WORD + " " + expectedList.size() + 1);
@@ -45,10 +48,10 @@ public class DeleteCommandTest extends AddressBookGuiTest {
     /**
      * Runs the delete command to delete the person at {@code index} and confirms resulting list equals to
      * {@code expectedList} and that the displayed result message is correct.
+     * @param personToDelete the person located at {@code index} of the original list
      */
-    private void assertDeleteSuccess(Index index, final List<ReadOnlyPerson> expectedList) throws Exception {
-        ReadOnlyPerson personToDelete = getPersonListPanel().getCard(index.getZeroBased()).person;
-
+    private void assertDeleteSuccess(Index index, ReadOnlyPerson personToDelete,
+                                     final List<ReadOnlyPerson> expectedList) throws Exception {
         runCommand(DeleteCommand.COMMAND_WORD + " " + index.getOneBased());
 
         //confirm the list now contains all previous persons except the deleted person

--- a/src/test/java/guitests/SelectCommandTest.java
+++ b/src/test/java/guitests/SelectCommandTest.java
@@ -1,22 +1,22 @@
 package guitests;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static seedu.address.testutil.TypicalPersons.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.TYPICAL_PERSONS;
+import static seedu.address.ui.testutil.GuiTestAssert.assertCardEquals;
 
 import org.junit.Test;
 
+import guitests.guihandles.PersonCardHandle;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.SelectCommand;
-import seedu.address.ui.PersonCard;
 
 public class SelectCommandTest extends AddressBookGuiTest {
 
 
     @Test
-    public void selectPerson_nonEmptyList() {
+    public void selectPerson_nonEmptyList() throws Exception {
 
         assertSelectionInvalid(Index.fromOneBased(10)); // invalid index
         assertNoCardSelected();
@@ -45,20 +45,21 @@ public class SelectCommandTest extends AddressBookGuiTest {
         assertResultMessage("The person index provided is invalid");
     }
 
-    private void assertSelectionSuccess(Index index) {
+    private void assertSelectionSuccess(Index index) throws Exception {
         runCommand(SelectCommand.COMMAND_WORD + " " + index.getOneBased());
         assertResultMessage("Selected Person: " + index.getOneBased());
         assertCardSelected(index);
     }
 
-    private void assertCardSelected(Index index) {
-        PersonCard selectedCard = getPersonListPanel().getSelectedCard().get();
-        assertEquals(getPersonListPanel().getCard(index.getZeroBased()), selectedCard);
+    private void assertCardSelected(Index index) throws Exception {
+        PersonCardHandle expectedCard = getPersonListPanel().getPersonCardHandle(index.getZeroBased());
+        PersonCardHandle selectedCard = getPersonListPanel().getHandleToSelectedCard().get();
+        assertCardEquals(expectedCard, selectedCard);
         //TODO: confirm the correct page is loaded in the Browser Panel
     }
 
     private void assertNoCardSelected() {
-        assertFalse(getPersonListPanel().getSelectedCard().isPresent());
+        assertFalse(getPersonListPanel().getHandleToSelectedCard().isPresent());
     }
 
 }

--- a/src/test/java/guitests/guihandles/PersonListPanelHandle.java
+++ b/src/test/java/guitests/guihandles/PersonListPanelHandle.java
@@ -82,8 +82,8 @@ public class PersonListPanelHandle extends NodeHandle<ListView<PersonCard>> {
     /**
      * Returns the person card handle of a person associated with the {@code index} in the list.
      */
-    private PersonCardHandle getPersonCardHandle(int index) throws PersonNotFoundException {
-        return getPersonCardHandle(getCard(index).person);
+    public PersonCardHandle getPersonCardHandle(int index) throws PersonNotFoundException {
+        return getPersonCardHandle(getRootNode().getItems().get(index).person);
     }
 
     /**

--- a/src/test/java/guitests/guihandles/PersonListPanelHandle.java
+++ b/src/test/java/guitests/guihandles/PersonListPanelHandle.java
@@ -74,13 +74,6 @@ public class PersonListPanelHandle extends NodeHandle<ListView<PersonCard>> {
     }
 
     /**
-     * Returns the {@code PersonCard} at the specified {@code index} in the list.
-     */
-    public PersonCard getCard(int index) {
-        return getRootNode().getItems().get(index);
-    }
-
-    /**
      * Returns the person card handle of a person associated with the {@code index} in the list.
      */
     public PersonCardHandle getPersonCardHandle(int index) throws PersonNotFoundException {

--- a/src/test/java/guitests/guihandles/PersonListPanelHandle.java
+++ b/src/test/java/guitests/guihandles/PersonListPanelHandle.java
@@ -22,16 +22,17 @@ public class PersonListPanelHandle extends NodeHandle<ListView<PersonCard>> {
     }
 
     /**
-     * Returns the selected {@code PersonCard} in the list view. A maximum of 1 item can be selected at any time.
+     * Returns a handle to the selected {@code PersonCardHandle}.
+     * A maximum of 1 item can be selected at any time.
      */
-    public Optional<PersonCard> getSelectedCard() {
+    public Optional<PersonCardHandle> getHandleToSelectedCard() {
         List<PersonCard> personList = getRootNode().getSelectionModel().getSelectedItems();
 
         if (personList.size() > 1) {
             throw new AssertionError("Person list size expected 0 or 1.");
         }
 
-        return personList.isEmpty() ? Optional.empty() : Optional.of(personList.get(0));
+        return personList.isEmpty() ? Optional.empty() : Optional.of(new PersonCardHandle(personList.get(0).getRoot()));
     }
 
     /**

--- a/src/test/java/seedu/address/ui/PersonListPanelTest.java
+++ b/src/test/java/seedu/address/ui/PersonListPanelTest.java
@@ -3,12 +3,14 @@ package seedu.address.ui;
 import static org.junit.Assert.assertEquals;
 import static seedu.address.testutil.EventsUtil.post;
 import static seedu.address.testutil.TypicalPersons.INDEX_SECOND_PERSON;
+import static seedu.address.ui.testutil.GuiTestAssert.assertCardEquals;
 
 import java.util.Arrays;
 
 import org.junit.Before;
 import org.junit.Test;
 
+import guitests.guihandles.PersonCardHandle;
 import guitests.guihandles.PersonListPanelHandle;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -42,11 +44,12 @@ public class PersonListPanelTest extends GuiUnitTest {
     }
 
     @Test
-    public void handleJumpToListRequestEvent() {
+    public void handleJumpToListRequestEvent() throws Exception {
         post(JUMP_TO_SECOND_EVENT);
         guiRobot.pauseForHuman();
 
-        PersonCard selectedCard = personListPanelHandle.getSelectedCard().get();
-        assertEquals(personListPanelHandle.getCard(INDEX_SECOND_PERSON.getZeroBased()), selectedCard);
+        PersonCardHandle expectedCard = personListPanelHandle.getPersonCardHandle(INDEX_SECOND_PERSON.getZeroBased());
+        PersonCardHandle selectedCard = personListPanelHandle.getHandleToSelectedCard().get();
+        assertCardEquals(expectedCard, selectedCard);
     }
 }

--- a/src/test/java/seedu/address/ui/PersonListPanelTest.java
+++ b/src/test/java/seedu/address/ui/PersonListPanelTest.java
@@ -6,6 +6,7 @@ import static seedu.address.testutil.TypicalPersons.INDEX_SECOND_PERSON;
 import static seedu.address.ui.testutil.GuiTestAssert.assertCardEquals;
 
 import java.util.Arrays;
+import java.util.stream.Collectors;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -39,8 +40,24 @@ public class PersonListPanelTest extends GuiUnitTest {
     public void display() throws Exception {
         for (int i = 0; i < TYPICAL_PERSONS.size(); i++) {
             personListPanelHandle.navigateToCard(TYPICAL_PERSONS.get(i));
-            assertEquals(TYPICAL_PERSONS.get(i), personListPanelHandle.getCard(i).person);
+            ReadOnlyPerson expectedPerson = TYPICAL_PERSONS.get(i);
+            PersonCardHandle actualCard = personListPanelHandle.getPersonCardHandle(i);
+
+            assertCardDisplaysPerson(expectedPerson, actualCard);
+            assertEquals(Integer.toString(i + 1) + ". ", actualCard.getId());
         }
+    }
+
+    /**
+     * Asserts that {@code actualCard} displays the details of {@code expectedPerson}.
+     */
+    private void assertCardDisplaysPerson(ReadOnlyPerson expectedPerson, PersonCardHandle actualCard) {
+        assertEquals(expectedPerson.getName().fullName, actualCard.getName());
+        assertEquals(expectedPerson.getPhone().value, actualCard.getPhone());
+        assertEquals(expectedPerson.getEmail().value, actualCard.getEmail());
+        assertEquals(expectedPerson.getAddress().value, actualCard.getAddress());
+        assertEquals(expectedPerson.getTags().stream().map(tag -> tag.tagName).collect(Collectors.toList()),
+                actualCard.getTags());
     }
 
     @Test

--- a/src/test/java/seedu/address/ui/testutil/GuiTestAssert.java
+++ b/src/test/java/seedu/address/ui/testutil/GuiTestAssert.java
@@ -1,0 +1,22 @@
+package seedu.address.ui.testutil;
+
+import static org.junit.Assert.assertEquals;
+
+import guitests.guihandles.PersonCardHandle;
+
+/**
+ * A set of assertion methods useful for writing GUI tests.
+ */
+public class GuiTestAssert {
+    /**
+     * Asserts that {@code actualCard} displays the same values as {@code expectedCard}.
+     */
+    public static void assertCardEquals(PersonCardHandle expectedCard, PersonCardHandle actualCard) {
+        assertEquals(expectedCard.getId(), actualCard.getId());
+        assertEquals(expectedCard.getAddress(), actualCard.getAddress());
+        assertEquals(expectedCard.getEmail(), actualCard.getEmail());
+        assertEquals(expectedCard.getName(), actualCard.getName());
+        assertEquals(expectedCard.getPhone(), actualCard.getPhone());
+        assertEquals(expectedCard.getTags(), actualCard.getTags());
+    }
+}


### PR DESCRIPTION
Fixes #563 

```
PersonListPanelHandle is a test helper class that encapsulates
PersonListPanel. It has methods that return PersonCard.

Tests should not directly interact with Node objects such as PersonCard
as it breaks the encapsulation of the PersonCard object.

Let's teach existing methods in PersonListPanelHandle to return 
PersonCardHandle instead of PersonCard. 
```