### PR TITLE
Remove unnecessary pauses after pressing keys with GuiRobot #459

### DIFF
--- a/src/test/java/guitests/guihandles/CommandBoxHandle.java
+++ b/src/test/java/guitests/guihandles/CommandBoxHandle.java
@@ -33,7 +33,7 @@ public class CommandBoxHandle extends NodeHandle<TextField> {
         guiRobot.pauseForHuman();
 
         guiRobot.type(KeyCode.ENTER);
-        guiRobot.pauseForHuman();
+
         return !getStyleClass().contains(CommandBox.ERROR_STYLE_CLASS);
     }
 

--- a/src/test/java/guitests/guihandles/MainMenuHandle.java
+++ b/src/test/java/guitests/guihandles/MainMenuHandle.java
@@ -28,7 +28,6 @@ public class MainMenuHandle extends NodeHandle<Node> {
      */
     public void openHelpWindowUsingAccelerator() {
         guiRobot.push(KeyCode.F1);
-        guiRobot.pauseForHuman();
     }
 
     /**

--- a/src/test/java/seedu/address/ui/CommandBoxTest.java
+++ b/src/test/java/seedu/address/ui/CommandBoxTest.java
@@ -66,7 +66,6 @@ public class CommandBoxTest extends GuiUnitTest {
         assertEquals(errorStyleOfCommandBox, commandBoxHandle.getStyleClass());
 
         guiRobot.push(KeyCode.A);
-        guiRobot.pauseForHuman();
         assertEquals(defaultStyleOfCommandBox, commandBoxHandle.getStyleClass());
     }
 


### PR DESCRIPTION
Part of #459.

Proposed merge commit message:
```
guiRobot#type(...) and guiRobot#push(...) internally pauses after
pressing the given keys.

We do not need to call guiRobot#pauseForHuman() ourselves after calling
these two key pressing methods.

Let's remove the redundant guiRobot#pauseForHuman() calls.
```