### PR TITLE
TypicalPersons: Make all methods and fields static #569

### DIFF
--- a/src/test/java/guitests/AddCommandTest.java
+++ b/src/test/java/guitests/AddCommandTest.java
@@ -4,7 +4,7 @@ import static org.junit.Assert.assertTrue;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.HOON;
 import static seedu.address.testutil.TypicalPersons.IDA;
-import static seedu.address.testutil.TypicalPersons.getTypicalPersons;
+import static seedu.address.testutil.TypicalPersons.TYPICAL_PERSONS;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -24,7 +24,7 @@ public class AddCommandTest extends AddressBookGuiTest {
     @Test
     public void add() throws Exception {
         //add one person
-        ArrayList<ReadOnlyPerson> expectedList = new ArrayList<>(Arrays.asList(getTypicalPersons()));
+        ArrayList<ReadOnlyPerson> expectedList = new ArrayList<>(Arrays.asList(TYPICAL_PERSONS));
         ReadOnlyPerson personToAdd = HOON;
         expectedList.add(personToAdd);
         assertAddSuccess(personToAdd, expectedList);

--- a/src/test/java/guitests/AddCommandTest.java
+++ b/src/test/java/guitests/AddCommandTest.java
@@ -1,6 +1,10 @@
 package guitests;
 
 import static org.junit.Assert.assertTrue;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.HOON;
+import static seedu.address.testutil.TypicalPersons.IDA;
+import static seedu.address.testutil.TypicalPersons.getTypicalPersons;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -12,6 +16,7 @@ import seedu.address.commons.core.Messages;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.ReadOnlyPerson;
 import seedu.address.testutil.PersonUtil;
 
 public class AddCommandTest extends AddressBookGuiTest {
@@ -19,34 +24,34 @@ public class AddCommandTest extends AddressBookGuiTest {
     @Test
     public void add() throws Exception {
         //add one person
-        ArrayList<Person> expectedList = new ArrayList<>(Arrays.asList(td.getTypicalPersons()));
-        Person personToAdd = td.hoon;
+        ArrayList<ReadOnlyPerson> expectedList = new ArrayList<>(Arrays.asList(getTypicalPersons()));
+        ReadOnlyPerson personToAdd = HOON;
         expectedList.add(personToAdd);
         assertAddSuccess(personToAdd, expectedList);
 
         //add another person
-        personToAdd = td.ida;
+        personToAdd = IDA;
         expectedList.add(personToAdd);
         assertAddSuccess(personToAdd, expectedList);
 
         //add duplicate person
-        runCommand(PersonUtil.getAddCommand(td.hoon));
+        runCommand(PersonUtil.getAddCommand(HOON));
         assertResultMessage(AddCommand.MESSAGE_DUPLICATE_PERSON);
         assertTrue(getPersonListPanel().isListMatching(expectedList.toArray(new Person[expectedList.size()])));
 
         //add to empty list
         runCommand(ClearCommand.COMMAND_WORD);
         expectedList.clear();
-        personToAdd = td.alice;
+        personToAdd = ALICE;
         expectedList.add(personToAdd);
-        assertAddSuccess(td.alice, expectedList);
+        assertAddSuccess(ALICE, expectedList);
 
         //invalid command
         runCommand("adds Johnny");
         assertResultMessage(Messages.MESSAGE_UNKNOWN_COMMAND);
     }
 
-    private void assertAddSuccess(Person personToAdd, ArrayList<Person> expectedList) throws Exception {
+    private void assertAddSuccess(ReadOnlyPerson personToAdd, ArrayList<ReadOnlyPerson> expectedList) throws Exception {
         runCommand(PersonUtil.getAddCommand(personToAdd));
 
         //confirm the new card contains the right data
@@ -55,7 +60,7 @@ public class AddCommandTest extends AddressBookGuiTest {
         assertCardMatchesPerson(addedCard, personToAdd);
 
         //confirm the list now contains all previous persons plus the new person
-        assertTrue(getPersonListPanel().isListMatching(expectedList.toArray(new Person[expectedList.size()])));
+        assertTrue(getPersonListPanel().isListMatching(expectedList.toArray(new ReadOnlyPerson[expectedList.size()])));
     }
 
 }

--- a/src/test/java/guitests/AddressBookGuiTest.java
+++ b/src/test/java/guitests/AddressBookGuiTest.java
@@ -38,7 +38,6 @@ public abstract class AddressBookGuiTest {
     @Rule
     public TestName name = new TestName();
 
-    protected TypicalPersons td = new TypicalPersons();
     protected GuiRobot guiRobot = new GuiRobot();
 
     protected Stage stage;

--- a/src/test/java/guitests/ClearCommandTest.java
+++ b/src/test/java/guitests/ClearCommandTest.java
@@ -1,6 +1,8 @@
 package guitests;
 
 import static org.junit.Assert.assertTrue;
+import static seedu.address.testutil.TypicalPersons.HOON;
+import static seedu.address.testutil.TypicalPersons.getTypicalPersons;
 
 import org.junit.Test;
 
@@ -14,12 +16,12 @@ public class ClearCommandTest extends AddressBookGuiTest {
     public void clear() throws Exception {
 
         //verify a non-empty list can be cleared
-        assertTrue(getPersonListPanel().isListMatching(td.getTypicalPersons()));
+        assertTrue(getPersonListPanel().isListMatching(getTypicalPersons()));
         assertClearCommandSuccess();
 
         //verify other commands can work after a clear command
-        runCommand(PersonUtil.getAddCommand(td.hoon));
-        assertTrue(getPersonListPanel().isListMatching(td.hoon));
+        runCommand(PersonUtil.getAddCommand(HOON));
+        assertTrue(getPersonListPanel().isListMatching(HOON));
         runCommand(DeleteCommand.COMMAND_WORD + " 1");
         assertListSize(0);
 

--- a/src/test/java/guitests/ClearCommandTest.java
+++ b/src/test/java/guitests/ClearCommandTest.java
@@ -2,7 +2,7 @@ package guitests;
 
 import static org.junit.Assert.assertTrue;
 import static seedu.address.testutil.TypicalPersons.HOON;
-import static seedu.address.testutil.TypicalPersons.getTypicalPersons;
+import static seedu.address.testutil.TypicalPersons.TYPICAL_PERSONS;
 
 import org.junit.Test;
 
@@ -16,7 +16,7 @@ public class ClearCommandTest extends AddressBookGuiTest {
     public void clear() throws Exception {
 
         //verify a non-empty list can be cleared
-        assertTrue(getPersonListPanel().isListMatching(getTypicalPersons()));
+        assertTrue(getPersonListPanel().isListMatching(TYPICAL_PERSONS));
         assertClearCommandSuccess();
 
         //verify other commands can work after a clear command

--- a/src/test/java/guitests/DeleteCommandTest.java
+++ b/src/test/java/guitests/DeleteCommandTest.java
@@ -3,7 +3,7 @@ package guitests;
 import static org.junit.Assert.assertTrue;
 import static seedu.address.logic.commands.DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS;
 import static seedu.address.testutil.TypicalPersons.INDEX_FIRST_PERSON;
-import static seedu.address.testutil.TypicalPersons.getTypicalPersons;
+import static seedu.address.testutil.TypicalPersons.TYPICAL_PERSONS;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -21,7 +21,7 @@ public class DeleteCommandTest extends AddressBookGuiTest {
     public void delete() throws Exception {
 
         //delete the first in the list
-        ArrayList<ReadOnlyPerson> expectedList = new ArrayList<>(Arrays.asList(getTypicalPersons()));
+        ArrayList<ReadOnlyPerson> expectedList = new ArrayList<>(Arrays.asList(TYPICAL_PERSONS));
         Index targetIndex = INDEX_FIRST_PERSON;
         expectedList.remove(targetIndex.getZeroBased());
         assertDeleteSuccess(targetIndex, expectedList);

--- a/src/test/java/guitests/DeleteCommandTest.java
+++ b/src/test/java/guitests/DeleteCommandTest.java
@@ -3,6 +3,7 @@ package guitests;
 import static org.junit.Assert.assertTrue;
 import static seedu.address.logic.commands.DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS;
 import static seedu.address.testutil.TypicalPersons.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalPersons;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -12,7 +13,6 @@ import org.junit.Test;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteCommand;
-import seedu.address.model.person.Person;
 import seedu.address.model.person.ReadOnlyPerson;
 
 public class DeleteCommandTest extends AddressBookGuiTest {
@@ -21,7 +21,7 @@ public class DeleteCommandTest extends AddressBookGuiTest {
     public void delete() throws Exception {
 
         //delete the first in the list
-        ArrayList<Person> expectedList = new ArrayList<>(Arrays.asList(td.getTypicalPersons()));
+        ArrayList<ReadOnlyPerson> expectedList = new ArrayList<>(Arrays.asList(getTypicalPersons()));
         Index targetIndex = INDEX_FIRST_PERSON;
         expectedList.remove(targetIndex.getZeroBased());
         assertDeleteSuccess(targetIndex, expectedList);
@@ -46,13 +46,13 @@ public class DeleteCommandTest extends AddressBookGuiTest {
      * Runs the delete command to delete the person at {@code index} and confirms resulting list equals to
      * {@code expectedList} and that the displayed result message is correct.
      */
-    private void assertDeleteSuccess(Index index, final List<Person> expectedList) throws Exception {
+    private void assertDeleteSuccess(Index index, final List<ReadOnlyPerson> expectedList) throws Exception {
         ReadOnlyPerson personToDelete = getPersonListPanel().getCard(index.getZeroBased()).person;
 
         runCommand(DeleteCommand.COMMAND_WORD + " " + index.getOneBased());
 
         //confirm the list now contains all previous persons except the deleted person
-        assertTrue(getPersonListPanel().isListMatching(expectedList.toArray(new Person[expectedList.size()])));
+        assertTrue(getPersonListPanel().isListMatching(expectedList.toArray(new ReadOnlyPerson[expectedList.size()])));
 
         //confirm the result message is correct
         assertResultMessage(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete));

--- a/src/test/java/guitests/EditCommandTest.java
+++ b/src/test/java/guitests/EditCommandTest.java
@@ -10,7 +10,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.testutil.TypicalPersons.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.INDEX_THIRD_PERSON;
-import static seedu.address.testutil.TypicalPersons.getTypicalPersons;
+import static seedu.address.testutil.TypicalPersons.TYPICAL_PERSONS;
 
 import org.junit.Test;
 
@@ -51,7 +51,7 @@ public class EditCommandTest extends AddressBookGuiTest {
                 + PREFIX_TAG + "bestie";
         Index addressBookIndex = INDEX_SECOND_PERSON;
 
-        ReadOnlyPerson personToEdit = getTypicalPersons()[addressBookIndex.getZeroBased()];
+        ReadOnlyPerson personToEdit = TYPICAL_PERSONS[addressBookIndex.getZeroBased()];
         Person editedPerson = new PersonBuilder(personToEdit).withTags("sweetie", "bestie").build();
 
         assertEditSuccess(addressBookIndex, addressBookIndex, detailsToEdit, editedPerson);
@@ -62,7 +62,7 @@ public class EditCommandTest extends AddressBookGuiTest {
         String detailsToEdit = PREFIX_TAG.getPrefix();
         Index addressBookIndex = INDEX_SECOND_PERSON;
 
-        ReadOnlyPerson personToEdit = getTypicalPersons()[addressBookIndex.getZeroBased()];
+        ReadOnlyPerson personToEdit = TYPICAL_PERSONS[addressBookIndex.getZeroBased()];
         Person editedPerson = new PersonBuilder(personToEdit).withTags().build();
 
         assertEditSuccess(addressBookIndex, addressBookIndex, detailsToEdit, editedPerson);
@@ -75,7 +75,7 @@ public class EditCommandTest extends AddressBookGuiTest {
         String detailsToEdit = PREFIX_NAME + "Carrle";
         Index addressBookIndex = INDEX_THIRD_PERSON;
 
-        ReadOnlyPerson personToEdit = getTypicalPersons()[addressBookIndex.getZeroBased()];
+        ReadOnlyPerson personToEdit = TYPICAL_PERSONS[addressBookIndex.getZeroBased()];
         Person editedPerson = new PersonBuilder(personToEdit).withName("Carrle").build();
 
         assertEditSuccess(INDEX_FIRST_PERSON, addressBookIndex, detailsToEdit, editedPerson);
@@ -148,8 +148,8 @@ public class EditCommandTest extends AddressBookGuiTest {
         assertCardMatchesPerson(editedCard, editedPerson);
 
         // confirm the list now contains all previous persons plus the person with updated details
-        getTypicalPersons()[addressBookIndex.getZeroBased()] = editedPerson;
-        assertTrue(getPersonListPanel().isListMatching(getTypicalPersons()));
+        TYPICAL_PERSONS[addressBookIndex.getZeroBased()] = editedPerson;
+        assertTrue(getPersonListPanel().isListMatching(TYPICAL_PERSONS));
         assertResultMessage(String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson));
     }
 }

--- a/src/test/java/guitests/EditCommandTest.java
+++ b/src/test/java/guitests/EditCommandTest.java
@@ -10,6 +10,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.testutil.TypicalPersons.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.INDEX_THIRD_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalPersons;
 
 import org.junit.Test;
 
@@ -23,15 +24,12 @@ import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.ReadOnlyPerson;
 import seedu.address.model.tag.Tag;
 import seedu.address.testutil.PersonBuilder;
 
 // TODO: reduce GUI tests by transferring some tests to be covered by lower level tests.
 public class EditCommandTest extends AddressBookGuiTest {
-
-    // The list of persons in the person list panel is expected to match this list.
-    // This list is updated with every successful call to assertEditSuccess().
-    private Person[] expectedPersonsList = td.getTypicalPersons();
 
     @Test
     public void edit_allFieldsSpecified_success() throws Exception {
@@ -53,7 +51,7 @@ public class EditCommandTest extends AddressBookGuiTest {
                 + PREFIX_TAG + "bestie";
         Index addressBookIndex = INDEX_SECOND_PERSON;
 
-        Person personToEdit = expectedPersonsList[addressBookIndex.getZeroBased()];
+        ReadOnlyPerson personToEdit = getTypicalPersons()[addressBookIndex.getZeroBased()];
         Person editedPerson = new PersonBuilder(personToEdit).withTags("sweetie", "bestie").build();
 
         assertEditSuccess(addressBookIndex, addressBookIndex, detailsToEdit, editedPerson);
@@ -64,7 +62,7 @@ public class EditCommandTest extends AddressBookGuiTest {
         String detailsToEdit = PREFIX_TAG.getPrefix();
         Index addressBookIndex = INDEX_SECOND_PERSON;
 
-        Person personToEdit = expectedPersonsList[addressBookIndex.getZeroBased()];
+        ReadOnlyPerson personToEdit = getTypicalPersons()[addressBookIndex.getZeroBased()];
         Person editedPerson = new PersonBuilder(personToEdit).withTags().build();
 
         assertEditSuccess(addressBookIndex, addressBookIndex, detailsToEdit, editedPerson);
@@ -77,7 +75,7 @@ public class EditCommandTest extends AddressBookGuiTest {
         String detailsToEdit = PREFIX_NAME + "Carrle";
         Index addressBookIndex = INDEX_THIRD_PERSON;
 
-        Person personToEdit = expectedPersonsList[addressBookIndex.getZeroBased()];
+        ReadOnlyPerson personToEdit = getTypicalPersons()[addressBookIndex.getZeroBased()];
         Person editedPerson = new PersonBuilder(personToEdit).withName("Carrle").build();
 
         assertEditSuccess(INDEX_FIRST_PERSON, addressBookIndex, detailsToEdit, editedPerson);
@@ -150,8 +148,8 @@ public class EditCommandTest extends AddressBookGuiTest {
         assertCardMatchesPerson(editedCard, editedPerson);
 
         // confirm the list now contains all previous persons plus the person with updated details
-        expectedPersonsList[addressBookIndex.getZeroBased()] = editedPerson;
-        assertTrue(getPersonListPanel().isListMatching(expectedPersonsList));
+        getTypicalPersons()[addressBookIndex.getZeroBased()] = editedPerson;
+        assertTrue(getPersonListPanel().isListMatching(getTypicalPersons()));
         assertResultMessage(String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson));
     }
 }

--- a/src/test/java/guitests/FindCommandTest.java
+++ b/src/test/java/guitests/FindCommandTest.java
@@ -1,6 +1,8 @@
 package guitests;
 
 import static org.junit.Assert.assertTrue;
+import static seedu.address.testutil.TypicalPersons.BENSON;
+import static seedu.address.testutil.TypicalPersons.DANIEL;
 
 import org.junit.Test;
 
@@ -8,18 +10,18 @@ import seedu.address.commons.core.Messages;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.FindCommand;
-import seedu.address.model.person.Person;
+import seedu.address.model.person.ReadOnlyPerson;
 
 public class FindCommandTest extends AddressBookGuiTest {
 
     @Test
     public void find_nonEmptyList() throws Exception {
         assertFindResult(FindCommand.COMMAND_WORD + " Mark"); // no results
-        assertFindResult(FindCommand.COMMAND_WORD + " Meier", td.benson, td.daniel); // multiple results
+        assertFindResult(FindCommand.COMMAND_WORD + " Meier", BENSON, DANIEL); // multiple results
 
         //find after deleting one result
         runCommand(DeleteCommand.COMMAND_WORD + " 1");
-        assertFindResult(FindCommand.COMMAND_WORD + " Meier", td.daniel);
+        assertFindResult(FindCommand.COMMAND_WORD + " Meier", DANIEL);
     }
 
     @Test
@@ -34,7 +36,7 @@ public class FindCommandTest extends AddressBookGuiTest {
         assertResultMessage(Messages.MESSAGE_UNKNOWN_COMMAND);
     }
 
-    private void assertFindResult(String command, Person... expectedHits) throws Exception {
+    private void assertFindResult(String command, ReadOnlyPerson... expectedHits) throws Exception {
         runCommand(command);
         assertListSize(expectedHits.length);
         assertResultMessage(expectedHits.length + " persons listed!");

--- a/src/test/java/guitests/SelectCommandTest.java
+++ b/src/test/java/guitests/SelectCommandTest.java
@@ -3,7 +3,7 @@ package guitests;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static seedu.address.testutil.TypicalPersons.INDEX_FIRST_PERSON;
-import static seedu.address.testutil.TypicalPersons.getTypicalPersons;
+import static seedu.address.testutil.TypicalPersons.TYPICAL_PERSONS;
 
 import org.junit.Test;
 
@@ -22,7 +22,7 @@ public class SelectCommandTest extends AddressBookGuiTest {
         assertNoCardSelected();
 
         assertSelectionSuccess(INDEX_FIRST_PERSON); // first person in the list
-        Index personCount = Index.fromOneBased(getTypicalPersons().length);
+        Index personCount = Index.fromOneBased(TYPICAL_PERSONS.length);
         assertSelectionSuccess(personCount); // last person in the list
         Index middleIndex = Index.fromOneBased(personCount.getOneBased() / 2);
         assertSelectionSuccess(middleIndex); // a person in the middle of the list

--- a/src/test/java/guitests/SelectCommandTest.java
+++ b/src/test/java/guitests/SelectCommandTest.java
@@ -3,6 +3,7 @@ package guitests;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static seedu.address.testutil.TypicalPersons.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalPersons;
 
 import org.junit.Test;
 
@@ -21,7 +22,7 @@ public class SelectCommandTest extends AddressBookGuiTest {
         assertNoCardSelected();
 
         assertSelectionSuccess(INDEX_FIRST_PERSON); // first person in the list
-        Index personCount = Index.fromOneBased(td.getTypicalPersons().length);
+        Index personCount = Index.fromOneBased(getTypicalPersons().length);
         assertSelectionSuccess(personCount); // last person in the list
         Index middleIndex = Index.fromOneBased(personCount.getOneBased() / 2);
         assertSelectionSuccess(middleIndex); // a person in the middle of the list

--- a/src/test/java/guitests/StatusBarFooterTest.java
+++ b/src/test/java/guitests/StatusBarFooterTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import static seedu.address.testutil.TypicalPersons.HOON;
 import static seedu.address.ui.StatusBarFooter.SYNC_STATUS_INITIAL;
 import static seedu.address.ui.StatusBarFooter.SYNC_STATUS_UPDATED;
 
@@ -49,7 +50,7 @@ public class StatusBarFooterTest extends AddressBookGuiTest {
     public void syncStatus_mutatingCommandSucceeds_syncStatusUpdated() {
         String timestamp = new Date(injectedClock.millis()).toString();
         String expected = String.format(SYNC_STATUS_UPDATED, timestamp);
-        assertTrue(runCommand(PersonUtil.getAddCommand(td.hoon))); // mutating command succeeds
+        assertTrue(runCommand(PersonUtil.getAddCommand(HOON))); // mutating command succeeds
         assertEquals(expected, getStatusBarFooter().getSyncStatus());
     }
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -12,7 +13,6 @@ import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.PersonBuilder;
-import seedu.address.testutil.TypicalPersons;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code AddCommand}.
@@ -23,7 +23,7 @@ public class AddCommandIntegrationTest {
 
     @Before
     public void setUp() {
-        model = new ModelManager(new TypicalPersons().getTypicalAddressBook(), new UserPrefs());
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.Test;
 
@@ -8,7 +9,6 @@ import seedu.address.logic.CommandHistory;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
-import seedu.address.testutil.TypicalPersons;
 
 public class ClearCommandTest {
 
@@ -20,7 +20,7 @@ public class ClearCommandTest {
 
     @Test
     public void execute_nonEmptyAddressBook_success() throws Exception {
-        Model model = new ModelManager(new TypicalPersons().getTypicalAddressBook(), new UserPrefs());
+        Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
         assertCommandSuccess(prepareCommand(model), model, ClearCommand.MESSAGE_SUCCESS, model);
     }
 

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showFirstPersonOnly;
 import static seedu.address.testutil.TypicalPersons.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.Test;
 
@@ -17,14 +18,13 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.ReadOnlyPerson;
-import seedu.address.testutil.TypicalPersons;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for {@code DeleteCommand}.
  */
 public class DeleteCommandTest {
 
-    private Model model = new ModelManager(new TypicalPersons().getTypicalAddressBook(), new UserPrefs());
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
     public void execute_validIndexUnfilteredList_success() throws Exception {

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -12,6 +12,7 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showFirstPersonOnly;
 import static seedu.address.testutil.TypicalPersons.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.Test;
 
@@ -27,14 +28,13 @@ import seedu.address.model.person.Person;
 import seedu.address.model.person.ReadOnlyPerson;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
-import seedu.address.testutil.TypicalPersons;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for EditCommand.
  */
 public class EditCommandTest {
 
-    private Model model = new ModelManager(new TypicalPersons().getTypicalAddressBook(), new UserPrefs());
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
     public void execute_allFieldsSpecifiedUnfilteredList_success() throws Exception {

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -4,6 +4,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
+import static seedu.address.testutil.TypicalPersons.CARL;
+import static seedu.address.testutil.TypicalPersons.ELLE;
+import static seedu.address.testutil.TypicalPersons.FIONA;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -18,14 +22,12 @@ import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.ReadOnlyPerson;
-import seedu.address.testutil.TypicalPersons;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.
  */
 public class FindCommandTest {
-    private TypicalPersons persons = new TypicalPersons();
-    private Model model = new ModelManager(persons.getTypicalAddressBook(), new UserPrefs());
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
     public void equals() {
@@ -65,7 +67,7 @@ public class FindCommandTest {
     public void execute_multipleKeywords_multiplePersonsFound() throws Exception {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
         FindCommand command = prepareCommand("Kurz Elle Kunz");
-        assertCommandSuccess(command, expectedMessage, Arrays.asList(persons.carl, persons.elle, persons.fiona));
+        assertCommandSuccess(command, expectedMessage, Arrays.asList(CARL, ELLE, FIONA));
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showFirstPersonOnly;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -10,7 +11,6 @@ import seedu.address.logic.CommandHistory;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
-import seedu.address.testutil.TypicalPersons;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for ListCommand.
@@ -23,7 +23,7 @@ public class ListCommandTest {
 
     @Before
     public void setUp() {
-        model = new ModelManager(new TypicalPersons().getTypicalAddressBook(), new UserPrefs());
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
         expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
 
         listCommand = new ListCommand();

--- a/src/test/java/seedu/address/logic/commands/SelectCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SelectCommandTest.java
@@ -8,6 +8,7 @@ import static seedu.address.logic.commands.CommandTestUtil.showFirstPersonOnly;
 import static seedu.address.testutil.TypicalPersons.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.INDEX_THIRD_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -21,7 +22,6 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.testutil.EventsCollector;
-import seedu.address.testutil.TypicalPersons;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code SelectCommand}.
@@ -32,7 +32,7 @@ public class SelectCommandTest {
 
     @Before
     public void setUp() {
-        model = new ModelManager(new TypicalPersons().getTypicalAddressBook(), new UserPrefs());
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
     }
 
     @Test

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -1,6 +1,8 @@
 package seedu.address.model;
 
 import static org.junit.Assert.assertEquals;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -17,7 +19,6 @@ import javafx.collections.ObservableList;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.ReadOnlyPerson;
 import seedu.address.model.tag.Tag;
-import seedu.address.testutil.TypicalPersons;
 
 public class AddressBookTest {
 
@@ -40,17 +41,16 @@ public class AddressBookTest {
 
     @Test
     public void resetData_withValidReadOnlyAddressBook_replacesData() {
-        AddressBook newData = new TypicalPersons().getTypicalAddressBook();
+        AddressBook newData = getTypicalAddressBook();
         addressBook.resetData(newData);
         assertEquals(newData, addressBook);
     }
 
     @Test
     public void resetData_withDuplicatePersons_throwsAssertionError() {
-        TypicalPersons td = new TypicalPersons();
-        // Repeat td.alice twice
-        List<Person> newPersons = Arrays.asList(new Person(td.alice), new Person(td.alice));
-        List<Tag> newTags = new ArrayList<>(td.alice.getTags());
+        // Repeat ALICE twice
+        List<Person> newPersons = Arrays.asList(new Person(ALICE), new Person(ALICE));
+        List<Tag> newTags = new ArrayList<>(ALICE.getTags());
         AddressBookStub newData = new AddressBookStub(newPersons, newTags);
 
         thrown.expect(AssertionError.class);

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -2,6 +2,8 @@ package seedu.address.model;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BENSON;
 
 import java.util.Arrays;
 
@@ -9,16 +11,12 @@ import org.junit.Test;
 
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.testutil.AddressBookBuilder;
-import seedu.address.testutil.TypicalPersons;
 
 public class ModelManagerTest {
 
-    private TypicalPersons typicalPersons = new TypicalPersons();
-
     @Test
     public void equals() throws Exception {
-        AddressBook addressBook = new AddressBookBuilder().withPerson(typicalPersons.alice)
-                .withPerson(typicalPersons.benson).build();
+        AddressBook addressBook = new AddressBookBuilder().withPerson(ALICE).withPerson(BENSON).build();
         AddressBook differentAddressBook = new AddressBook();
         UserPrefs userPrefs = new UserPrefs();
 
@@ -40,7 +38,7 @@ public class ModelManagerTest {
         assertFalse(modelManager.equals(new ModelManager(differentAddressBook, userPrefs)));
 
         // different filteredList -> returns false
-        String[] keywords = typicalPersons.alice.getName().fullName.split("\\s+");
+        String[] keywords = ALICE.getName().fullName.split("\\s+");
         modelManager.updateFilteredPersonList(new NameContainsKeywordsPredicate(Arrays.asList(keywords)));
         assertFalse(modelManager.equals(new ModelManager(addressBook, userPrefs)));
         modelManager.updateFilteredListToShowAll(); // resets modelManager to initial state for upcoming tests

--- a/src/test/java/seedu/address/storage/StorageManagerTest.java
+++ b/src/test/java/seedu/address/storage/StorageManagerTest.java
@@ -4,6 +4,7 @@ package seedu.address.storage;
 import static junit.framework.TestCase.assertNotNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.io.IOException;
 
@@ -18,7 +19,6 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.UserPrefs;
 import seedu.address.testutil.EventsCollector;
-import seedu.address.testutil.TypicalPersons;
 
 public class StorageManagerTest {
 
@@ -61,7 +61,7 @@ public class StorageManagerTest {
          * {@link XmlAddressBookStorage} class.
          * More extensive testing of UserPref saving/reading is done in {@link XmlAddressBookStorageTest} class.
          */
-        AddressBook original = new TypicalPersons().getTypicalAddressBook();
+        AddressBook original = getTypicalAddressBook();
         storageManager.saveAddressBook(original);
         ReadOnlyAddressBook retrieved = storageManager.readAddressBook().get();
         assertEquals(original, new AddressBook(retrieved));

--- a/src/test/java/seedu/address/storage/XmlAddressBookStorageTest.java
+++ b/src/test/java/seedu/address/storage/XmlAddressBookStorageTest.java
@@ -3,6 +3,10 @@ package seedu.address.storage;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.HOON;
+import static seedu.address.testutil.TypicalPersons.IDA;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.io.IOException;
 
@@ -16,7 +20,6 @@ import seedu.address.commons.util.FileUtil;
 import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Person;
-import seedu.address.testutil.TypicalPersons;
 
 public class XmlAddressBookStorageTest {
     private static final String TEST_DATA_FOLDER = FileUtil.getPath("./src/test/data/XmlAddressBookStorageTest/");
@@ -62,8 +65,7 @@ public class XmlAddressBookStorageTest {
     @Test
     public void readAndSaveAddressBook_allInOrder_success() throws Exception {
         String filePath = testFolder.getRoot().getPath() + "TempAddressBook.xml";
-        TypicalPersons td = new TypicalPersons();
-        AddressBook original = td.getTypicalAddressBook();
+        AddressBook original = getTypicalAddressBook();
         XmlAddressBookStorage xmlAddressBookStorage = new XmlAddressBookStorage(filePath);
 
         //Save in new file and read back
@@ -72,14 +74,14 @@ public class XmlAddressBookStorageTest {
         assertEquals(original, new AddressBook(readBack));
 
         //Modify data, overwrite exiting file, and read back
-        original.addPerson(new Person(td.hoon));
-        original.removePerson(new Person(td.alice));
+        original.addPerson(new Person(HOON));
+        original.removePerson(new Person(ALICE));
         xmlAddressBookStorage.saveAddressBook(original, filePath);
         readBack = xmlAddressBookStorage.readAddressBook(filePath).get();
         assertEquals(original, new AddressBook(readBack));
 
         //Save and read without specifying file path
-        original.addPerson(new Person(td.ida));
+        original.addPerson(new Person(IDA));
         xmlAddressBookStorage.saveAddressBook(original); //file path not specified
         readBack = xmlAddressBookStorage.readAddressBook().get(); //file path not specified
         assertEquals(original, new AddressBook(readBack));

--- a/src/test/java/seedu/address/testutil/AddressBookBuilder.java
+++ b/src/test/java/seedu/address/testutil/AddressBookBuilder.java
@@ -2,7 +2,7 @@ package seedu.address.testutil;
 
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.AddressBook;
-import seedu.address.model.person.Person;
+import seedu.address.model.person.ReadOnlyPerson;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.model.tag.Tag;
 
@@ -23,7 +23,7 @@ public class AddressBookBuilder {
         this.addressBook = addressBook;
     }
 
-    public AddressBookBuilder withPerson(Person person) throws DuplicatePersonException {
+    public AddressBookBuilder withPerson(ReadOnlyPerson person) throws DuplicatePersonException {
         addressBook.addPerson(person);
         return this;
     }

--- a/src/test/java/seedu/address/testutil/PersonUtil.java
+++ b/src/test/java/seedu/address/testutil/PersonUtil.java
@@ -7,7 +7,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import seedu.address.logic.commands.AddCommand;
-import seedu.address.model.person.Person;
+import seedu.address.model.person.ReadOnlyPerson;
 
 /**
  * A utility class for Person.
@@ -17,14 +17,14 @@ public class PersonUtil {
     /**
      * Returns an add command string for adding the {@code person}.
      */
-    public static String getAddCommand(Person person) {
+    public static String getAddCommand(ReadOnlyPerson person) {
         return AddCommand.COMMAND_WORD + " " + getPersonDetails(person);
     }
 
     /**
      * Returns the part of command string for the given {@code person}'s details.
      */
-    public static String getPersonDetails(Person person) {
+    public static String getPersonDetails(ReadOnlyPerson person) {
         StringBuilder sb = new StringBuilder();
         sb.append(PREFIX_NAME + person.getName().fullName + " ");
         sb.append(PREFIX_PHONE + person.getPhone().value + " ");

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -4,6 +4,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.ReadOnlyPerson;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 
 /**
@@ -15,32 +16,32 @@ public class TypicalPersons {
     public static final Index INDEX_SECOND_PERSON = Index.fromOneBased(2);
     public static final Index INDEX_THIRD_PERSON = Index.fromOneBased(3);
 
-    public final Person alice, benson, carl, daniel, elle, fiona, george, hoon, ida;
+    public static final ReadOnlyPerson ALICE, BENSON, CARL, DANIEL, ELLE, FIONA, GEORGE, HOON, IDA;
 
-    public TypicalPersons() {
+    static {
         try {
-            alice = new PersonBuilder().withName("Alice Pauline")
+            ALICE = new PersonBuilder().withName("Alice Pauline")
                     .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
                     .withPhone("85355255")
                     .withTags("friends").build();
-            benson = new PersonBuilder().withName("Benson Meier").withAddress("311, Clementi Ave 2, #02-25")
+            BENSON = new PersonBuilder().withName("Benson Meier").withAddress("311, Clementi Ave 2, #02-25")
                     .withEmail("johnd@example.com").withPhone("98765432")
                     .withTags("owesMoney", "friends").build();
-            carl = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
+            CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
                     .withEmail("heinz@example.com").withAddress("wall street").build();
-            daniel = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")
+            DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")
                     .withEmail("cornelia@example.com").withAddress("10th street").build();
-            elle = new PersonBuilder().withName("Elle Meyer").withPhone("9482224")
+            ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("9482224")
                     .withEmail("werner@example.com").withAddress("michegan ave").build();
-            fiona = new PersonBuilder().withName("Fiona Kunz").withPhone("9482427")
+            FIONA = new PersonBuilder().withName("Fiona Kunz").withPhone("9482427")
                     .withEmail("lydia@example.com").withAddress("little tokyo").build();
-            george = new PersonBuilder().withName("George Best").withPhone("9482442")
+            GEORGE = new PersonBuilder().withName("George Best").withPhone("9482442")
                     .withEmail("anna@example.com").withAddress("4th street").build();
 
             // Manually added
-            hoon = new PersonBuilder().withName("Hoon Meier").withPhone("8482424")
+            HOON = new PersonBuilder().withName("Hoon Meier").withPhone("8482424")
                     .withEmail("stefan@example.com").withAddress("little india").build();
-            ida = new PersonBuilder().withName("Ida Mueller").withPhone("8482131")
+            IDA = new PersonBuilder().withName("Ida Mueller").withPhone("8482131")
                     .withEmail("hans@example.com").withAddress("chicago ave").build();
         } catch (IllegalValueException e) {
             throw new AssertionError("Sample data cannot be invalid", e);
@@ -48,7 +49,7 @@ public class TypicalPersons {
     }
 
     public static void loadAddressBookWithSampleData(AddressBook ab) {
-        for (Person person : new TypicalPersons().getTypicalPersons()) {
+        for (ReadOnlyPerson person : getTypicalPersons()) {
             try {
                 ab.addPerson(new Person(person));
             } catch (DuplicatePersonException e) {
@@ -57,11 +58,11 @@ public class TypicalPersons {
         }
     }
 
-    public Person[] getTypicalPersons() {
-        return new Person[]{alice, benson, carl, daniel, elle, fiona, george};
+    public static ReadOnlyPerson[] getTypicalPersons() {
+        return new ReadOnlyPerson[]{ALICE, BENSON, CARL, DANIEL, ELLE, FIONA, GEORGE};
     }
 
-    public AddressBook getTypicalAddressBook() {
+    public static AddressBook getTypicalAddressBook() {
         AddressBook ab = new AddressBook();
         loadAddressBookWithSampleData(ab);
         return ab;

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -51,6 +51,8 @@ public class TypicalPersons {
     public static final ReadOnlyPerson[] TYPICAL_PERSONS =
             new ReadOnlyPerson[]{ALICE, BENSON, CARL, DANIEL, ELLE, FIONA, GEORGE};
 
+    private TypicalPersons() {} // prevents instantiation
+
     public static void loadAddressBookWithSampleData(AddressBook ab) {
         for (ReadOnlyPerson person : TYPICAL_PERSONS) {
             try {

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -48,18 +48,17 @@ public class TypicalPersons {
         }
     }
 
+    public static final ReadOnlyPerson[] TYPICAL_PERSONS =
+            new ReadOnlyPerson[]{ALICE, BENSON, CARL, DANIEL, ELLE, FIONA, GEORGE};
+
     public static void loadAddressBookWithSampleData(AddressBook ab) {
-        for (ReadOnlyPerson person : getTypicalPersons()) {
+        for (ReadOnlyPerson person : TYPICAL_PERSONS) {
             try {
                 ab.addPerson(new Person(person));
             } catch (DuplicatePersonException e) {
                 assert false : "not possible";
             }
         }
-    }
-
-    public static ReadOnlyPerson[] getTypicalPersons() {
-        return new ReadOnlyPerson[]{ALICE, BENSON, CARL, DANIEL, ELLE, FIONA, GEORGE};
     }
 
     public static AddressBook getTypicalAddressBook() {

--- a/src/test/java/seedu/address/ui/BrowserPanelTest.java
+++ b/src/test/java/seedu/address/ui/BrowserPanelTest.java
@@ -2,6 +2,7 @@ package seedu.address.ui;
 
 import static org.junit.Assert.assertEquals;
 import static seedu.address.testutil.EventsUtil.post;
+import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.ui.BrowserPanel.DEFAULT_PAGE;
 import static seedu.address.ui.BrowserPanel.GOOGLE_SEARCH_URL_PREFIX;
 import static seedu.address.ui.UiPart.FXML_FILE_FOLDER;
@@ -14,12 +15,8 @@ import org.junit.Test;
 import guitests.guihandles.BrowserPanelHandle;
 import seedu.address.MainApp;
 import seedu.address.commons.events.ui.PersonPanelSelectionChangedEvent;
-import seedu.address.model.person.Person;
-import seedu.address.testutil.TypicalPersons;
 
 public class BrowserPanelTest extends GuiUnitTest {
-
-    private static final Person ALICE = new TypicalPersons().alice;
 
     private PersonPanelSelectionChangedEvent selectionChangedEventStub;
 

--- a/src/test/java/seedu/address/ui/PersonCardTest.java
+++ b/src/test/java/seedu/address/ui/PersonCardTest.java
@@ -3,6 +3,7 @@ package seedu.address.ui;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static seedu.address.testutil.TypicalPersons.ALICE;
 
 import org.junit.Test;
 
@@ -10,7 +11,6 @@ import guitests.guihandles.PersonCardHandle;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.ReadOnlyPerson;
 import seedu.address.testutil.PersonBuilder;
-import seedu.address.testutil.TypicalPersons;
 
 public class PersonCardTest extends GuiUnitTest {
 
@@ -29,13 +29,12 @@ public class PersonCardTest extends GuiUnitTest {
         assertCardDisplay(personCard, personWithTags, 2);
 
         // changes made to Person reflects on card
-        Person alice = new TypicalPersons().alice;
         guiRobot.interact(() -> {
-            personWithTags.setName(alice.getName());
-            personWithTags.setAddress(alice.getAddress());
-            personWithTags.setEmail(alice.getEmail());
-            personWithTags.setPhone(alice.getPhone());
-            personWithTags.setTags(alice.getTags());
+            personWithTags.setName(ALICE.getName());
+            personWithTags.setAddress(ALICE.getAddress());
+            personWithTags.setEmail(ALICE.getEmail());
+            personWithTags.setPhone(ALICE.getPhone());
+            personWithTags.setTags(ALICE.getTags());
         });
         assertCardDisplay(personCard, personWithTags, 2);
     }

--- a/src/test/java/seedu/address/ui/PersonListPanelTest.java
+++ b/src/test/java/seedu/address/ui/PersonListPanelTest.java
@@ -3,6 +3,7 @@ package seedu.address.ui;
 import static org.junit.Assert.assertEquals;
 import static seedu.address.testutil.EventsUtil.post;
 import static seedu.address.testutil.TypicalPersons.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalPersons;
 
 import java.util.Arrays;
 
@@ -14,11 +15,10 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.commons.events.ui.JumpToListRequestEvent;
 import seedu.address.model.person.ReadOnlyPerson;
-import seedu.address.testutil.TypicalPersons;
 
 public class PersonListPanelTest extends GuiUnitTest {
     private static final ObservableList<ReadOnlyPerson> TYPICAL_PERSONS =
-            FXCollections.observableList(Arrays.asList(new TypicalPersons().getTypicalPersons()));
+            FXCollections.observableList(Arrays.asList(getTypicalPersons()));
 
     private static final JumpToListRequestEvent JUMP_TO_SECOND_EVENT = new JumpToListRequestEvent(INDEX_SECOND_PERSON);
 

--- a/src/test/java/seedu/address/ui/PersonListPanelTest.java
+++ b/src/test/java/seedu/address/ui/PersonListPanelTest.java
@@ -3,7 +3,6 @@ package seedu.address.ui;
 import static org.junit.Assert.assertEquals;
 import static seedu.address.testutil.EventsUtil.post;
 import static seedu.address.testutil.TypicalPersons.INDEX_SECOND_PERSON;
-import static seedu.address.testutil.TypicalPersons.getTypicalPersons;
 
 import java.util.Arrays;
 
@@ -15,10 +14,11 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.commons.events.ui.JumpToListRequestEvent;
 import seedu.address.model.person.ReadOnlyPerson;
+import seedu.address.testutil.TypicalPersons;
 
 public class PersonListPanelTest extends GuiUnitTest {
     private static final ObservableList<ReadOnlyPerson> TYPICAL_PERSONS =
-            FXCollections.observableList(Arrays.asList(getTypicalPersons()));
+            FXCollections.observableList(Arrays.asList(TypicalPersons.TYPICAL_PERSONS));
 
     private static final JumpToListRequestEvent JUMP_TO_SECOND_EVENT = new JumpToListRequestEvent(INDEX_SECOND_PERSON);
 


### PR DESCRIPTION
Fixes #569 

```
TypicalPersons is a utility class that creates preset Persons for tests
to use. Some methods and fields are non-static.

This makes it troublesome for test classes to access these preset
Persons as they have to create a TypicalPersons object prior to
accessing the Person objects.

Let's make all methods and fields in TypicalPersons to be static.
```