### PR TITLE
gitignore: Ignore 'out/' build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ classes/
 /data/
 /bin/
 src/main/resources/docs/
+out/


### PR DESCRIPTION
When running the application/tests in IntelliJ, a new 'out/' directory
will be created.

The 'out/' directory contains build files. They should not be included
in the repository.

Let's update .gitignore to ignore the 'out/' build directory.