### PR TITLE
MainWindow: Remove browserPlaceholder #577

### DIFF
--- a/src/main/java/seedu/address/ui/BrowserPanel.java
+++ b/src/main/java/seedu/address/ui/BrowserPanel.java
@@ -8,8 +8,10 @@ import com.google.common.eventbus.Subscribe;
 import javafx.event.Event;
 import javafx.fxml.FXML;
 import javafx.scene.layout.Region;
+import javafx.scene.layout.StackPane;
 import javafx.scene.web.WebView;
 import seedu.address.MainApp;
+import seedu.address.commons.core.EventsCenter;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.events.ui.PersonPanelSelectionChangedEvent;
 import seedu.address.model.person.ReadOnlyPerson;
@@ -27,16 +29,27 @@ public class BrowserPanel extends UiPart<Region> {
     private final Logger logger = LogsCenter.getLogger(this.getClass());
 
     @FXML
+    private StackPane stackPane;
+
+    @FXML
     private WebView browser;
 
     public BrowserPanel() {
         super(FXML);
+        EventsCenter.getInstance().registerHandler(this);
+    }
 
+    @FXML
+    public void initialize() {
         // To prevent triggering events for typing inside the loaded Web page.
-        getRoot().setOnKeyPressed(Event::consume);
+        stackPane.setOnKeyPressed(Event::consume);
 
         loadDefaultPage();
-        registerAsAnEventHandler(this);
+    }
+
+    @Override
+    public Region getRoot() {
+        return stackPane;
     }
 
     private void loadPersonPage(ReadOnlyPerson person) {

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -40,13 +40,11 @@ public class MainWindow extends UiPart<Region> {
     private Logic logic;
 
     // Independent Ui parts residing in this Ui container
-    private BrowserPanel browserPanel;
+    @FXML private BrowserPanel browserPanelController;
+
     private PersonListPanel personListPanel;
     private Config config;
     private UserPrefs prefs;
-
-    @FXML
-    private StackPane browserPlaceholder;
 
     @FXML
     private StackPane commandBoxPlaceholder;
@@ -123,9 +121,6 @@ public class MainWindow extends UiPart<Region> {
     }
 
     void fillInnerParts() {
-        browserPanel = new BrowserPanel();
-        browserPlaceholder.getChildren().add(browserPanel.getRoot());
-
         personListPanel = new PersonListPanel(logic.getFilteredPersonList());
         personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
 
@@ -203,7 +198,7 @@ public class MainWindow extends UiPart<Region> {
     }
 
     void releaseResources() {
-        browserPanel.freeResources();
+        browserPanelController.freeResources();
     }
 
     @Subscribe

--- a/src/main/java/seedu/address/ui/UiPart.java
+++ b/src/main/java/seedu/address/ui/UiPart.java
@@ -32,6 +32,9 @@ public abstract class UiPart<T> {
         requireNonNull(fxmlFileUrl);
         fxmlLoader = new FXMLLoader(fxmlFileUrl);
         fxmlLoader.setController(this);
+        if (this instanceof BrowserPanel) {
+            return;
+        }
         try {
             fxmlLoader.load();
         } catch (IOException e) {

--- a/src/main/resources/view/BrowserPanel.fxml
+++ b/src/main/resources/view/BrowserPanel.fxml
@@ -3,6 +3,6 @@
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.web.WebView?>
 
-<StackPane xmlns:fx="http://javafx.com/fxml/1">
+<StackPane xmlns:fx="http://javafx.com/fxml/1" fx:controller="seedu.address.ui.BrowserPanel" fx:id="stackPane">
   <WebView fx:id="browser"/>
 </StackPane>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -45,11 +45,7 @@
       <StackPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
     </VBox>
 
-    <StackPane fx:id="browserPlaceholder" prefWidth="340" >
-      <padding>
-        <Insets top="10" right="10" bottom="10" left="10" />
-      </padding>
-    </StackPane>
+    <fx:include fx:id="browserPanel" source="BrowserPanel.fxml"/>
   </SplitPane>
 
   <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER" />


### PR DESCRIPTION
Part of #577. @damithc This PR is just a sample (because only one of the placeholders are removed). If this PR is merged, we have to remove all other placeholders as well (which I can do in this PR as well actually)

For more information, take a look at the header `Nested Controllers`: https://docs.oracle.com/javafx/2/api/javafx/fxml/doc-files/introduction_to_fxml.html#class_instance_elements.

If I am not wrong, we should only use `FXMLLoader` to manually create a View Controller when we are presenting another scene e.g presenting the `HelpWindow`. 