### PR TITLE
Storage: Add backupAddressBook(ReadOnlyAddressBook)

### DIFF
--- a/src/main/java/seedu/address/storage/AddressBookStorage.java
+++ b/src/main/java/seedu/address/storage/AddressBookStorage.java
@@ -42,4 +42,5 @@ public interface AddressBookStorage {
      */
     void saveAddressBook(ReadOnlyAddressBook addressBook, Path filePath) throws IOException;
 
+    void backupAddressBook(ReadOnlyAddressBook addressBook) throws IOException;
 }

--- a/src/main/java/seedu/address/storage/StorageManager.java
+++ b/src/main/java/seedu/address/storage/StorageManager.java
@@ -78,6 +78,10 @@ public class StorageManager extends ComponentManager implements Storage {
         addressBookStorage.saveAddressBook(addressBook, filePath);
     }
 
+    @Override
+    public void backupAddressBook(ReadOnlyAddressBook addressBook) throws IOException {
+        addressBookStorage.backupAddressBook(addressBook);
+    }
 
     @Override
     @Subscribe

--- a/src/main/java/seedu/address/storage/XmlAddressBookStorage.java
+++ b/src/main/java/seedu/address/storage/XmlAddressBookStorage.java
@@ -6,6 +6,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Optional;
 import java.util.logging.Logger;
 
@@ -22,10 +23,12 @@ public class XmlAddressBookStorage implements AddressBookStorage {
 
     private static final Logger logger = LogsCenter.getLogger(XmlAddressBookStorage.class);
 
-    private Path filePath;
+    private final Path filePath;
+    private final Path backupFilePath;
 
     public XmlAddressBookStorage(Path filePath) {
         this.filePath = filePath;
+        backupFilePath = Paths.get(filePath.toString() + ".backup");
     }
 
     public Path getAddressBookFilePath() {
@@ -58,6 +61,11 @@ public class XmlAddressBookStorage implements AddressBookStorage {
             logger.info("Illegal values found in " + filePath + ": " + ive.getMessage());
             throw new DataConversionException(ive);
         }
+    }
+
+    @Override
+    public void backupAddressBook(ReadOnlyAddressBook addressBook) throws IOException {
+        saveAddressBook(addressBook, backupFilePath);
     }
 
     @Override


### PR DESCRIPTION
Part of #784. Rebased, fixed the compilation error.

Proposed commit message:
```
Storage saves to a single file path.

Users may want to do a backup of the address book in a different
location.

Let's add Storage#backupAddressBook(ReadOnlyAddressBook).
```

_Note:_ This PR is used as an example for future developers. Do not merge!