### PR TITLE
EventsCenter: remove registerHandler method return type #598

### DIFF
--- a/src/main/java/seedu/address/commons/core/EventsCenter.java
+++ b/src/main/java/seedu/address/commons/core/EventsCenter.java
@@ -29,9 +29,8 @@ public class EventsCenter {
         instance = null;
     }
 
-    public EventsCenter registerHandler(Object handler) {
+    public void registerHandler(Object handler) {
         eventBus.register(handler);
-        return this;
     }
 
     /**


### PR DESCRIPTION
Fixes #598 
Cleaning up this issue so that I can skip adding header comment for this trivial method.