### PR TITLE
Tidy up System Tests #644

### DIFF
--- a/src/test/java/guitests/guihandles/BrowserPanelHandle.java
+++ b/src/test/java/guitests/guihandles/BrowserPanelHandle.java
@@ -16,7 +16,7 @@ public class BrowserPanelHandle extends NodeHandle<Node> {
 
     public static final String BROWSER_ID = "#browser";
 
-    private boolean isWebViewLoaded = false;
+    private boolean isWebViewLoaded = true;
 
     private URL lastRememberedUrl;
 
@@ -26,7 +26,9 @@ public class BrowserPanelHandle extends NodeHandle<Node> {
         WebView webView = getChildNode(BROWSER_ID);
         WebEngine engine = webView.getEngine();
         new GuiRobot().interact(() -> engine.getLoadWorker().stateProperty().addListener((obs, oldState, newState) -> {
-            if (newState == Worker.State.SUCCEEDED) {
+            if (newState == Worker.State.RUNNING) {
+                isWebViewLoaded = false;
+            } else if (newState == Worker.State.SUCCEEDED) {
                 isWebViewLoaded = true;
             }
         }));
@@ -54,11 +56,10 @@ public class BrowserPanelHandle extends NodeHandle<Node> {
         return !lastRememberedUrl.equals(getLoadedUrl());
     }
 
-    public boolean getIsWebViewLoaded() {
+    /**
+     * Returns true if the browser is done loading a page, or if this browser has yet to load any page.
+     */
+    public boolean isLoaded() {
         return isWebViewLoaded;
-    }
-
-    public void setIsWebViewLoaded(boolean isWebViewLoaded) {
-        this.isWebViewLoaded = isWebViewLoaded;
     }
 }

--- a/src/test/java/guitests/guihandles/WebViewUtil.java
+++ b/src/test/java/guitests/guihandles/WebViewUtil.java
@@ -19,10 +19,9 @@ public class WebViewUtil {
     }
 
     /**
-     * Sleeps the thread till the {@code browserPanelHandle}'s {@code WebView} is successfully loaded.
+     * If the {@code browserPanelHandle}'s {@code WebView} is loading, sleeps the thread till it is successfully loaded.
      */
     public static void waitUntilBrowserLoaded(BrowserPanelHandle browserPanelHandle) {
-        new GuiRobot().waitForEvent(browserPanelHandle::getIsWebViewLoaded);
-        browserPanelHandle.setIsWebViewLoaded(false);
+        new GuiRobot().waitForEvent(browserPanelHandle::isLoaded);
     }
 }

--- a/src/test/java/seedu/address/TestApp.java
+++ b/src/test/java/seedu/address/TestApp.java
@@ -13,7 +13,6 @@ import seedu.address.commons.util.FileUtil;
 import seedu.address.commons.util.XmlUtil;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
-import seedu.address.model.ModelManager;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.UserPrefs;
 import seedu.address.storage.UserPrefsStorage;
@@ -89,11 +88,8 @@ public class TestApp extends MainApp {
         return storage.getAddressBookFilePath();
     }
 
-    /**
-     * Returns a defensive copy of the model.
-     */
     public Model getModel() {
-        return new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        return model;
     }
 
     @Override

--- a/src/test/java/seedu/address/ui/BrowserPanelTest.java
+++ b/src/test/java/seedu/address/ui/BrowserPanelTest.java
@@ -1,5 +1,6 @@
 package seedu.address.ui;
 
+import static guitests.guihandles.WebViewUtil.waitUntilBrowserLoaded;
 import static org.junit.Assert.assertEquals;
 import static seedu.address.testutil.EventsUtil.postNow;
 import static seedu.address.testutil.TypicalPersons.ALICE;
@@ -13,7 +14,6 @@ import java.net.URL;
 import org.junit.Before;
 import org.junit.Test;
 
-import guitests.GuiRobot;
 import guitests.guihandles.BrowserPanelHandle;
 import seedu.address.MainApp;
 import seedu.address.commons.events.ui.PersonPanelSelectionChangedEvent;
@@ -45,7 +45,7 @@ public class BrowserPanelTest extends GuiUnitTest {
         URL expectedPersonUrl = new URL(GOOGLE_SEARCH_URL_PREFIX
                 + ALICE.getName().fullName.replaceAll(" ", "+") + GOOGLE_SEARCH_URL_SUFFIX);
 
-        new GuiRobot().waitForEvent(() -> browserPanelHandle.getIsWebViewLoaded());
+        waitUntilBrowserLoaded(browserPanelHandle);
         assertEquals(expectedPersonUrl, browserPanelHandle.getLoadedUrl());
     }
 }

--- a/src/test/java/systemtests/AddressBookSystemTest.java
+++ b/src/test/java/systemtests/AddressBookSystemTest.java
@@ -102,6 +102,10 @@ public abstract class AddressBookSystemTest {
      */
     protected void executeCommand(String command) throws Exception {
         rememberStates();
+        // Injects a fixed clock before executing a command so that the time stamp shown in the status bar
+        // after each command is predictable and also different from the previous command.
+        clockRule.setInjectedClockToCurrentTime();
+
         mainWindowHandle.getCommandBox().run(command);
 
         waitUntilBrowserLoaded(getBrowserPanel());

--- a/src/test/java/systemtests/AddressBookSystemTest.java
+++ b/src/test/java/systemtests/AddressBookSystemTest.java
@@ -35,8 +35,8 @@ import seedu.address.model.Model;
 import seedu.address.ui.CommandBox;
 
 /**
- * A system test class for AddressBook, which provides access to handles of GUI components, and
- * verifies that the starting state of the application is correct.
+ * A system test class for AddressBook, which provides access to handles of GUI components and helper methods
+ * for test verification.
  */
 public abstract class AddressBookSystemTest {
     @ClassRule

--- a/src/test/java/systemtests/AddressBookSystemTest.java
+++ b/src/test/java/systemtests/AddressBookSystemTest.java
@@ -1,5 +1,6 @@
 package systemtests;
 
+import static guitests.guihandles.WebViewUtil.waitUntilBrowserLoaded;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static seedu.address.ui.BrowserPanel.DEFAULT_PAGE;
@@ -96,10 +97,13 @@ public abstract class AddressBookSystemTest {
 
     /**
      * Executes {@code command} in the application's {@code CommandBox}.
+     * Method returns after UI components have been updated.
      */
     protected void executeCommand(String command) throws Exception {
         rememberStates();
         mainWindowHandle.getCommandBox().run(command);
+
+        waitUntilBrowserLoaded(getBrowserPanel());
     }
 
     /**

--- a/src/test/java/systemtests/AddressBookSystemTest.java
+++ b/src/test/java/systemtests/AddressBookSystemTest.java
@@ -62,6 +62,7 @@ public abstract class AddressBookSystemTest {
         testApp = setupHelper.setupApplication();
         mainWindowHandle = setupHelper.setupMainWindowHandle();
 
+        waitUntilBrowserLoaded(getBrowserPanel());
         assertApplicationStartingStateIsCorrect();
     }
 

--- a/src/test/java/systemtests/DeleteCommandSystemTest.java
+++ b/src/test/java/systemtests/DeleteCommandSystemTest.java
@@ -137,8 +137,6 @@ public class DeleteCommandSystemTest extends AddressBookSystemTest {
 
         assertCommandBoxStyleDefault();
         assertStatusBarUnchangedExceptSyncStatus();
-
-        clockRule.setInjectedClockToCurrentTime();
     }
 
     /**
@@ -158,7 +156,5 @@ public class DeleteCommandSystemTest extends AddressBookSystemTest {
         assertSelectedCardUnchanged();
         assertCommandBoxStyleError();
         assertStatusBarUnchanged();
-
-        clockRule.setInjectedClockToCurrentTime();
     }
 }

--- a/src/test/java/systemtests/DeleteCommandSystemTest.java
+++ b/src/test/java/systemtests/DeleteCommandSystemTest.java
@@ -1,6 +1,5 @@
 package systemtests;
 
-import static guitests.guihandles.WebViewUtil.waitUntilBrowserLoaded;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS;
@@ -131,7 +130,6 @@ public class DeleteCommandSystemTest extends AddressBookSystemTest {
         assertApplicationDisplaysExpected("", expectedResultMessage, expectedModel);
 
         if (expectedSelectedCardIndex != null) {
-            waitUntilBrowserLoaded(getBrowserPanel());
             assertSelectedCardChanged(expectedSelectedCardIndex);
         } else {
             assertSelectedCardUnchanged();


### PR DESCRIPTION
Fixes #644, also fixes #642 

```
There are some areas of code in system tests that have minor bugs and
code issues. For e.g. AddressBookSystemTest's header comments is
outdated and TestApp#getModel() is returning the wrong model.

Let's fix these minor issues.
```