### PR TITLE
Developer Guide: Fix formatting errors in the use case #608

### DIFF
--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -716,21 +716,23 @@ Priorities: High (must have) - `* * \*`, Medium (nice to have) - `* \*`, Low (un
 1.  User requests to list persons
 2.  AddressBook shows a list of persons
 3.  User requests to delete a specific person in the list
-4.  AddressBook deletes the person Use case ends.
+4.  AddressBook deletes the person
++
+Use case ends.
 
 *Extensions*
 
 [none]
 * 2a. The list is empty.
 +
-[none]
-** Use case ends.
+Use case ends.
 
 * 3a. The given index is invalid.
 +
 [none]
 ** 3a1. AddressBook shows an error message.
-** Use case resumes at step 2.
++
+Use case resumes at step 2.
 
 {More to be added}
 


### PR DESCRIPTION
Fixes #608 

```
There are formatting errors in the use cases. For example, some use
cases are not properly indented.

Let's fix them.
```