### PR TITLE
Fix errors in GUI tests when upgrading to the new version (4.0.6-alpha) of TestFx #358

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,6 @@ deploy:
   on:
     branch: master
 
-before_install:
-          - "export DISPLAY=:99.0"
-          - "sh -e /etc/init.d/xvfb start"
-
 addons:
   apt:
     packages:

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ allprojects {
         jacksonVersion = '2.7.0'
         jacksonDataTypeVersion = '2.7.4'
         junitVersion = '4.12'
-        testFxVersion = '4.0.5-alpha'
+        testFxVersion = '4.0.7-alpha'
         monocleVersion = '1.8.0_20'
         checkstyleVersion = '8.1'
 


### PR DESCRIPTION
Fixes #358 

4.0.7-alpha has been released. Besides being the latest and greatest
version, 4.0.7-alpha also contains a proper working headless mode for
Linux.

Without this upgrade, attempting to run `./gradlew headless guiTests` on
Linux would result with the GUI tests failing with the following
exception:

        java.lang.RuntimeException: java.lang.RuntimeException: java.lang.IllegalAccessException: Class org.testfx.toolkit.impl.ApplicationLauncherImpl can not access a member of class com.sun.glass.ui.monocle.HeadlessPlatform with modifiers ""

            Caused by:
            java.lang.RuntimeException: java.lang.IllegalAccessException: Class org.testfx.toolkit.impl.ApplicationLauncherImpl can not access a member of class com.sun.glass.ui.monocle.HeadlessPlatform with modifiers ""

                Caused by:
                java.lang.IllegalAccessException: Class org.testfx.toolkit.impl.ApplicationLauncherImpl can not access a member of class com.sun.glass.ui.monocle.HeadlessPlatform with modifiers ""

Let's upgrade testfx to 4.0.7-alpha to have happy Linux developers.

This working headless mode was also present in the 4.0.6-alpha, but we
couldn't upgrade to it as it broke our gui tests. (See e1eafd1 ([#353]
All gui tests are failing  (#354), 2017-03-23))

Furthermore, since headless mode now works on Linux, our Travis CI
builds do not need to run xvfb any more. As such, let's remove its usage
from .travis.yml.