### PR TITLE
DeleteCommandSystemTest: Replace Assume with Assert

### DIFF
--- a/src/test/java/systemtests/DeleteCommandSystemTest.java
+++ b/src/test/java/systemtests/DeleteCommandSystemTest.java
@@ -1,6 +1,6 @@
 package systemtests;
 
-import static org.junit.Assume.assumeTrue;
+import static org.junit.Assert.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS;
@@ -62,7 +62,7 @@ public class DeleteCommandSystemTest extends AddressBookSystemTest {
         /* Case: filtered person list, delete index within bounds of address book and person list -> deleted */
         showPersonsWithName(KEYWORD_MATCHING_MEIER);
         Index index = INDEX_FIRST_PERSON;
-        assumeTrue(index.getZeroBased() < getModel().getFilteredPersonList().size());
+        assertTrue(index.getZeroBased() < getModel().getFilteredPersonList().size());
         assertCommandSuccess(index);
 
         /* Case: filtered person list, delete index within bounds of address book but out of bounds of person list


### PR DESCRIPTION
```
We use Assume to show that a precondition is met before executing a
test.

Assume should not be used in test cases as the Travis build passes even
if tests are ignored. This forces developers to have to manually
verify each Travis build to ensure that no tests are ignored.

Let’s replace Assume with Assert.
```