### PR TITLE
GuiUnitTest: Clears subscribers from EventsCenter after each test #675

### DIFF
--- a/src/test/java/seedu/address/ui/GuiUnitTest.java
+++ b/src/test/java/seedu/address/ui/GuiUnitTest.java
@@ -2,11 +2,13 @@ package seedu.address.ui;
 
 import java.util.Optional;
 
+import org.junit.After;
 import org.junit.Rule;
 
 import guitests.GuiRobot;
 import guitests.guihandles.exceptions.NodeNotFoundException;
 import javafx.scene.Node;
+import seedu.address.commons.core.EventsCenter;
 import seedu.address.ui.testutil.UiPartRule;
 
 /**
@@ -17,6 +19,11 @@ public abstract class GuiUnitTest {
     public final UiPartRule uiPartRule = new UiPartRule();
 
     protected final GuiRobot guiRobot = new GuiRobot();
+
+    @After
+    public void tearDown() {
+        EventsCenter.clearSubscribers();
+    }
 
     /**
      * Retrieves the {@code query} node owned by the {@code rootNode}.


### PR DESCRIPTION
Fixes #675

```
EventsCenter is a Singleton object, which is a possible cause of state
leaks between tests as the state of the static objects are preserved
across tests.

EventsCenter isn’t cleared after each GuiUnitTest is executed, as such
it stores a reference to its subscribers, which causes these objects
to not be removed by Garbage Collection after the test is done
executing. These extra objects can possibly cause future tests to fail.
Currently, AddCommandTest fails when run locally on IntelliJ together
with other tests.

Let’s update GuiUnitTest to clears subscribers from EventsCenter after
each test.

Credits of debugging this issue goes to @pyokagan.
```