### PR TITLE
ListElementPointer(List<String>): Update code to tally with comments

### DIFF
--- a/src/main/java/seedu/address/logic/ListElementPointer.java
+++ b/src/main/java/seedu/address/logic/ListElementPointer.java
@@ -1,5 +1,6 @@
 package seedu.address.logic;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
 
@@ -20,7 +21,7 @@ public class ListElementPointer {
      * The cursor points to the last element in {@code list}.
      */
     public ListElementPointer(List<String> list) {
-        this.list = list;
+        this.list = new ArrayList<>(list);
         index = this.list.size() - 1;
     }
 

--- a/src/test/java/seedu/address/logic/ListElementPointerTest.java
+++ b/src/test/java/seedu/address/logic/ListElementPointerTest.java
@@ -27,6 +27,16 @@ public class ListElementPointerTest {
     }
 
     @Test
+    public void constructor_defensiveCopy_backingListUnmodified() {
+        List<String> list = new ArrayList<>();
+        pointer = new ListElementPointer(list);
+        list.add(FIRST_ELEMENT);
+
+        ListElementPointer emptyPointer = new ListElementPointer(Collections.emptyList());
+        assertEquals(emptyPointer, pointer);
+    }
+
+    @Test
     public void emptyList() {
         pointer = new ListElementPointer(new ArrayList<>());
         assertCurrentFailure();


### PR DESCRIPTION
```
The constructor’s header comments state that this object is backed by
a defensive copy of the list that is passed in as parameter. However,
the code does not reflect this behaviour.

The constructor should use create a defensive copy of the list to
prevent unintentional modifications to the backing list whenever the
list passed in as parameter is modified.

Let’s update ListElementPointer(List<String>) to create a defensive copy
of the list.
```