### PR TITLE
Simplify build.gradle file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,6 @@
  */
 
 plugins {
-    id 'idea'
     id 'java'
     id 'jacoco'
     id 'checkstyle'

--- a/build.gradle
+++ b/build.gradle
@@ -22,9 +22,7 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 repositories {
-    jcenter()
     mavenCentral()
-    maven { url "https://repo.eclipse.org/content/repositories/egit-releases/" }
     maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -29,13 +29,11 @@ repositories {
 // This part is similar to global variables
 // Access them by using double-quoted strings (GStrings) and referencing by $ e.g. "Variable contains $Variable"
 project.ext {
-    checkstyleVersion = '8.1'
-
     libDir = 'lib'
 }
 
 checkstyle {
-    toolVersion = "$checkstyleVersion"
+    toolVersion = '8.1'
 }
 
 jacocoTestReport {

--- a/build.gradle
+++ b/build.gradle
@@ -93,7 +93,6 @@ tasks.coveralls {
 
 class AddressBookTest extends Test {
     public AddressBookTest() {
-    	  forkEvery = 1
         systemProperty 'testfx.setup.timeout', '60000'
 
         /*

--- a/build.gradle
+++ b/build.gradle
@@ -26,12 +26,6 @@ repositories {
     maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
 }
 
-// This part is similar to global variables
-// Access them by using double-quoted strings (GStrings) and referencing by $ e.g. "Variable contains $Variable"
-project.ext {
-    libDir = 'lib'
-}
-
 checkstyle {
     toolVersion = '8.1'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,10 @@
  */
 
 plugins {
+    id 'idea'
+    id 'java'
+    id 'jacoco'
+    id 'checkstyle'
     id "com.github.kt3k.coveralls" version "2.4.0"
     id "com.github.johnrengelman.shadow" version '1.2.3'
     id 'org.asciidoctor.convert' version '1.5.3'
@@ -15,82 +19,74 @@ plugins {
 // Specifies the entry point of the application
 mainClassName = 'seedu.address.MainApp'
 
-allprojects {
-    apply plugin: 'idea'
-    apply plugin: 'java'
-    apply plugin: 'jacoco'
-    apply plugin: 'checkstyle'
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
 
+repositories {
+    jcenter()
+    mavenCentral()
+    maven { url "https://repo.eclipse.org/content/repositories/egit-releases/" }
+    maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
+}
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+// This part is similar to global variables
+// Access them by using double-quoted strings (GStrings) and referencing by $ e.g. "Variable contains $Variable"
+project.ext {
+    controlsFxVersion = '8.40.11'
+    guavaVersion = '19.0'
+    jacksonVersion = '2.7.0'
+    jacksonDataTypeVersion = '2.7.4'
+    junitVersion = '4.12'
+    testFxVersion = '4.0.7-alpha'
+    monocleVersion = '1.8.0_20'
+    checkstyleVersion = '8.1'
 
-    repositories {
-        jcenter()
-        mavenCentral()
-        maven { url "https://repo.eclipse.org/content/repositories/egit-releases/" }
-        maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
+    libDir = 'lib'
+}
+
+checkstyle {
+    toolVersion = "$checkstyleVersion"
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled false
+        csv.enabled false
+        html.destination "${buildDir}/jacocoHtml"
     }
+}
 
-    // This part is similar to global variables
-    // Access them by using double-quoted strings (GStrings) and referencing by $ e.g. "Variable contains $Variable"
-    project.ext {
-        controlsFxVersion = '8.40.11'
-        guavaVersion = '19.0'
-        jacksonVersion = '2.7.0'
-        jacksonDataTypeVersion = '2.7.4'
-        junitVersion = '4.12'
-        testFxVersion = '4.0.7-alpha'
-        monocleVersion = '1.8.0_20'
-        checkstyleVersion = '8.1'
+dependencies {
+    compile group: 'org.fxmisc.easybind', name: 'easybind', version: '1.0.3'
+    compile "org.controlsfx:controlsfx:$controlsFxVersion"
+    compile "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
+    compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonDataTypeVersion"
+    compile "com.google.guava:guava:$guavaVersion"
 
-        libDir = 'lib'
+    testCompile "junit:junit:$junitVersion"
+    testCompile "org.testfx:testfx-core:$testFxVersion"
+    testCompile "org.testfx:testfx-junit:$testFxVersion"
+    testCompile "org.testfx:testfx-legacy:$testFxVersion", {
+        exclude group: "junit", module: "junit"
     }
+    testCompile "org.testfx:openjfx-monocle:$monocleVersion"
+}
 
-    checkstyle {
-        toolVersion = "$checkstyleVersion"
-    }
-
-    jacocoTestReport {
-        reports {
-            xml.enabled false
-            csv.enabled false
-            html.destination "${buildDir}/jacocoHtml"
+sourceSets {
+    main {
+        java {
+            srcDir 'src/main/java'
+        }
+        resources {
+            srcDir 'src/main/resources'
         }
     }
+}
 
-    dependencies {
-        compile group: 'org.fxmisc.easybind', name: 'easybind', version: '1.0.3'
-        compile "org.controlsfx:controlsfx:$controlsFxVersion"
-        compile "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
-        compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonDataTypeVersion"
-        compile "com.google.guava:guava:$guavaVersion"
+shadowJar {
+    archiveName = "addressbook.jar"
 
-        testCompile "junit:junit:$junitVersion"
-        testCompile "org.testfx:testfx-core:$testFxVersion"
-        testCompile "org.testfx:testfx-junit:$testFxVersion"
-        testCompile "org.testfx:testfx-legacy:$testFxVersion", {
-            exclude group: "junit", module: "junit"
-        }
-        testCompile "org.testfx:openjfx-monocle:$monocleVersion"
-    }
-
-    sourceSets {
-        main {
-            java {
-                srcDir 'src/main/java'
-            }
-            resources {
-                srcDir 'src/main/resources'
-            }
-        }
-    }
-
-    shadowJar {
-        archiveName = "addressbook.jar"
-
-        destinationDir = file("${buildDir}/jar/")
-    }
+    destinationDir = file("${buildDir}/jar/")
 }
 
 task wrapper(type: Wrapper) {

--- a/build.gradle
+++ b/build.gradle
@@ -69,17 +69,6 @@ dependencies {
     testCompile "org.testfx:openjfx-monocle:$monocleVersion"
 }
 
-sourceSets {
-    main {
-        java {
-            srcDir 'src/main/java'
-        }
-        resources {
-            srcDir 'src/main/resources'
-        }
-    }
-}
-
 shadowJar {
     archiveName = "addressbook.jar"
 

--- a/build.gradle
+++ b/build.gradle
@@ -29,13 +29,6 @@ repositories {
 // This part is similar to global variables
 // Access them by using double-quoted strings (GStrings) and referencing by $ e.g. "Variable contains $Variable"
 project.ext {
-    controlsFxVersion = '8.40.11'
-    guavaVersion = '19.0'
-    jacksonVersion = '2.7.0'
-    jacksonDataTypeVersion = '2.7.4'
-    junitVersion = '4.12'
-    testFxVersion = '4.0.7-alpha'
-    monocleVersion = '1.8.0_20'
     checkstyleVersion = '8.1'
 
     libDir = 'lib'
@@ -54,19 +47,21 @@ jacocoTestReport {
 }
 
 dependencies {
-    compile group: 'org.fxmisc.easybind', name: 'easybind', version: '1.0.3'
-    compile "org.controlsfx:controlsfx:$controlsFxVersion"
-    compile "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
-    compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonDataTypeVersion"
-    compile "com.google.guava:guava:$guavaVersion"
+    String testFxVersion = '4.0.7-alpha'
 
-    testCompile "junit:junit:$junitVersion"
-    testCompile "org.testfx:testfx-core:$testFxVersion"
-    testCompile "org.testfx:testfx-junit:$testFxVersion"
-    testCompile "org.testfx:testfx-legacy:$testFxVersion", {
-        exclude group: "junit", module: "junit"
+    compile group: 'org.fxmisc.easybind', name: 'easybind', version: '1.0.3'
+    compile group: 'org.controlsfx', name: 'controlsfx', version: '8.40.11'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.7.0'
+    compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.7.4'
+    compile group: 'com.google.guava', name: 'guava', version: '19.0'
+
+    testCompile group: 'junit', name: 'junit', version: '4.12'
+    testCompile group: 'org.testfx', name: 'testfx-core', version: testFxVersion
+    testCompile group: 'org.testfx', name: 'testfx-junit', version: testFxVersion
+    testCompile group: 'org.testfx', name: 'testfx-legacy', version: testFxVersion, {
+        exclude group: 'junit', module: 'junit'
     }
-    testCompile "org.testfx:openjfx-monocle:$monocleVersion"
+    testCompile group: 'org.testfx', name: 'openjfx-monocle', version: '1.8.0_20'
 }
 
 shadowJar {


### PR DESCRIPTION
Fixes #752 
```
Simplify the build.gradle file by removing unnecessary/unused stuff, and
standardizing the code style.
```