### PR TITLE
docs: remove env-github outfilesuffix boilerplate

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,5 @@
 = Address Book (Level 4)
 ifdef::env-github,env-browser[:relfileprefix: docs/]
-ifdef::env-github,env-browser[:outfilesuffix: .adoc]
 
 https://travis-ci.org/se-edu/addressbook-level4[image:https://travis-ci.org/se-edu/addressbook-level4.svg?branch=master[Build Status]]
 https://ci.appveyor.com/project/damithc/addressbook-level4[image:https://ci.appveyor.com/api/projects/status/3boko2x2vr5cc3w2?svg=true[Build status]]

--- a/docs/AboutUs.adoc
+++ b/docs/AboutUs.adoc
@@ -1,6 +1,5 @@
 = About Us
 :relfileprefix: team/
-ifdef::env-github,env-browser[:outfilesuffix: .adoc]
 :imagesDir: images
 :stylesDir: stylesheets
 

--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -9,7 +9,6 @@ ifdef::env-github[]
 :tip-caption: :bulb:
 :note-caption: :information_source:
 endif::[]
-ifdef::env-github,env-browser[:outfilesuffix: .adoc]
 :repoURL: https://github.com/se-edu/addressbook-level4/tree/master
 
 By: `Team SE-EDU`      Since: `Jun 2016`      Licence: `MIT`

--- a/docs/LearningOutcomes.adoc
+++ b/docs/LearningOutcomes.adoc
@@ -6,7 +6,6 @@
 :sectnumlevels: 1
 :imagesDir: images
 :stylesDir: stylesheets
-ifdef::env-github,env-browser[:outfilesuffix: .adoc]
 :repoURL: https://github.com/se-edu/addressbook-level4/tree/master
 
 After studying this code and completing the corresponding exercises, you should be able to,

--- a/docs/UsingTravis.adoc
+++ b/docs/UsingTravis.adoc
@@ -1,7 +1,6 @@
 = Travis CI
 :imagesDir: images
 :stylesDir: stylesheets
-ifdef::env-github,env-browser[:outfilesuffix: .adoc]
 
 https://travis-ci.org/[Travis CI] is a _Continuous Integration_ platform for GitHub projects.
 

--- a/docs/team/johndoe.adoc
+++ b/docs/team/johndoe.adoc
@@ -1,5 +1,4 @@
 = John Doe - Project Portfolio
-ifdef::env-github,env-browser[:outfilesuffix: .adoc]
 :imagesDir: ../images
 :stylesDir: ../stylesheets
 


### PR DESCRIPTION
```
Many of our adoc files have the following boilerplate:

    ifdef::env-github,env-browser[:outfilesuffix: .adoc]

This boilerplate used to be required in order for inter-document cross
references to work when viewing the adoc files directly on GitHub. This
was because GitHub errnously set the outfilesuffix as `.html` instead of
`.adoc`, which resulted in broken links.

However, as the asciidoctor user guide[1] states:

    This configuration is no longer necessary on GitHub since GitHub now
    sets the value of outfilesuffix to match the file extension of the
    source file. However, it’s still required in GitHub-like
    environments such as GitLab.

Indeed, this seems to be the case on GitHub. As our project is unlikely
to be hosted on other "GitHub-like environments such as GitLab" in the
near future, let's remove this boilerplate.

[1] http://asciidoctor.org/docs/user-manual/#navigating-between-source-files
```