### PR TITLE
DeveloperGuide: use labeled list for glossary

### DIFF
--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -781,19 +781,11 @@ Use case resumes at step 2.
 [appendix]
 == Glossary
 
-[[mainstream-os]]
-Mainstream OS
-
-....
+[[mainstream-os]] Mainstream OS::
 Windows, Linux, Unix, OS-X
-....
 
-[[private-contact-detail]]
-Private contact detail
-
-....
+[[private-contact-detail]] Private contact detail::
 A contact detail that is not meant to be shared with others
-....
 
 [appendix]
 == Product Survey


### PR DESCRIPTION
```
The glossary uses literal blocks for formatting definitions, which looks
strange because literal blocks are usually used for preformatted text
such as source code.

Instead, let's use a labeled list, which has a formatting that is more
in line with a glossary definition list.

Convert the paragraph anchors into inline anchors[1], so that the items
are joined into one single labeled list with two items, rather than
being chopped into two separate labeled lists with one item each.

[1] See http://asciidoctor.org/docs/user-manual/#anchordef for the
    difference between a paragraph anchor and an inline anchor.
```
---
![2c984135-fe9f-4bb8-ac09-730c0ea370e5](https://user-images.githubusercontent.com/109479/33697131-5e7ed390-db40-11e7-8e2c-20ca4243d419.png)
