### PR TITLE
DeveloperGuide: Update Undo/Redo numbering

### DIFF
--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -226,7 +226,8 @@ Classes used by multiple components are in the `seedu.addressbook.commons` packa
 This section describes some noteworthy details on how certain features are implemented.
 
 // tag::undoredo[]
-=== Undo/Redo mechanism
+=== Undo/Redo feature
+==== Current Implementation
 
 The undo/redo mechanism is facilitated by an `UndoRedoStack`, which resides inside `LogicManager`. It supports undoing and redoing of commands that modifies the state of the address book (e.g. `add`, `edit`). Such commands will inherit from `UndoableCommand`.
 


### PR DESCRIPTION
Fixes #682.
```
There's `3.1.1. Design Considerations`, but there aren’t any further
numberings such as 3.1.2.

Let’s update the header `Undo/Redo mechanism` to be simply `Undo/Redo`,
and let’s segment this section to have 2 sub-headers `Mechanism` and
`Design Considerations`.
```