### PR TITLE
Replace use of `assert false` with `throw new AssertionError()` #264

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -43,7 +43,7 @@ public class DeleteCommand extends UndoableCommand {
         try {
             model.deletePerson(personToDelete);
         } catch (PersonNotFoundException pnfe) {
-            assert false : "The target person cannot be missing";
+            throw new AssertionError("The target person cannot be missing");
         }
 
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete));

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -67,7 +67,7 @@ public class AddressBook implements ReadOnlyAddressBook {
         try {
             setPersons(newData.getPersonList());
         } catch (DuplicatePersonException e) {
-            assert false : "AddressBooks should not have duplicate persons";
+            throw new AssertionError("AddressBooks should not have duplicate persons");
         }
 
         setTags(new HashSet<>(newData.getTagList()));

--- a/src/main/java/seedu/address/storage/XmlFileStorage.java
+++ b/src/main/java/seedu/address/storage/XmlFileStorage.java
@@ -20,7 +20,7 @@ public class XmlFileStorage {
         try {
             XmlUtil.saveDataToFile(file, addressBook);
         } catch (JAXBException e) {
-            assert false : "Unexpected exception " + e.getMessage();
+            throw new AssertionError("Unexpected exception " + e.getMessage());
         }
     }
 

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -69,7 +69,7 @@ public class TypicalPersons {
             try {
                 ab.addPerson(person);
             } catch (DuplicatePersonException e) {
-                assert false : "not possible";
+                throw new AssertionError("not possible");
             }
         }
         return ab;


### PR DESCRIPTION
Fixes #264 

Hi, I'm Jun An here. Working on this issue as my first contribution 
to this project
 
In some places of the code we use `assert false` to indicate the
execution has reached an unacceptable state.

This is not compliant with our code style (as revised by [1])  which
states `throw new AssertionError()` is preferred for such situations.

Let's replace `assert false` with `throw new AssertionError()` where
applicable.

[1] oss-generic/process#19
  