### PR TITLE
BrowserPanel: load dummy page #733

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
 
 script: >-
     ./config/travis/run-checks.sh &&
-    travis_retry ./gradlew clean checkstyleMain checkstyleTest headless allTests coverage coveralls asciidoctor
+    travis_retry ./gradlew clean checkstyleMain checkstyleTest headless allTests coverage coveralls asciidoctor copyDummySearchPage
 
 deploy:
   skip_cleanup: true

--- a/build.gradle
+++ b/build.gradle
@@ -196,6 +196,11 @@ task deployOfflineDocs(type: Copy) {
     }
 }
 
+task copyDummySearchPage(type: Copy) {
+    from 'docs/DummySearchPage.html'
+    into "${buildDir}/docs/html5"
+}
+
 deployOfflineDocs.dependsOn asciidoctor
 processResources.dependsOn deployOfflineDocs
 

--- a/docs/DummySearchPage.html
+++ b/docs/DummySearchPage.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Dummy Search Page</title>
+  <script type="text/javascript">
+    function getJsonFromUrl() {
+      var query = location.search.substr(1);
+      var result = {};
+      query.split("&").forEach(function(part) {
+        var item = part.split("=");
+        result[item[0]] = decodeURIComponent(item[1]);
+      });
+      return result;
+    }
+
+    document.addEventListener("DOMContentLoaded", function(event) {
+      document.getElementById("name").innerHTML=getJsonFromUrl().name;
+    });
+  </script>
+</head>
+<body>
+  Hi <span id="name"></span>: This is a placeholder page for se-edu/addressbook-level4.<br>
+  You may update the code to load a page from a real service (e.g., Google search).<br>
+  This dummy page is used here because, given the high number of forks of this repo, loading a page from a real third-party service by default can result in that service taking counter-measures (e.g., redirecting to captcha pages) due to the high number of rapid requests received from a single IP.<br>
+  When you have made the change, please remove:
+  <ol>
+    <li>This file (<code>docs/DummySearchPage.html</code>).</li>
+    <li>Task <code>copyDummySearchPage</code> in both <code>build.gradle</code> and <code>.travis.yml</code>.</li>
+  </ol>
+</body>
+</html>

--- a/src/main/java/seedu/address/ui/BrowserPanel.java
+++ b/src/main/java/seedu/address/ui/BrowserPanel.java
@@ -21,8 +21,8 @@ import seedu.address.model.person.Person;
 public class BrowserPanel extends UiPart<Region> {
 
     public static final String DEFAULT_PAGE = "default.html";
-    public static final String GOOGLE_SEARCH_URL_PREFIX = "https://www.google.com.sg/search?safe=off&q=";
-    public static final String GOOGLE_SEARCH_URL_SUFFIX = "&cad=h";
+    public static final String SEARCH_PAGE_URL =
+            "https://se-edu.github.io/addressbook-level4/DummySearchPage.html?name=";
 
     private static final String FXML = "BrowserPanel.fxml";
 
@@ -42,8 +42,7 @@ public class BrowserPanel extends UiPart<Region> {
     }
 
     private void loadPersonPage(Person person) {
-        loadPage(GOOGLE_SEARCH_URL_PREFIX + person.getName().fullName.replaceAll(" ", "+")
-                + GOOGLE_SEARCH_URL_SUFFIX);
+        loadPage(SEARCH_PAGE_URL + person.getName().fullName);
     }
 
     public void loadPage(String url) {

--- a/src/test/java/seedu/address/ui/BrowserPanelTest.java
+++ b/src/test/java/seedu/address/ui/BrowserPanelTest.java
@@ -5,8 +5,6 @@ import static org.junit.Assert.assertEquals;
 import static seedu.address.testutil.EventsUtil.postNow;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.ui.BrowserPanel.DEFAULT_PAGE;
-import static seedu.address.ui.BrowserPanel.GOOGLE_SEARCH_URL_PREFIX;
-import static seedu.address.ui.BrowserPanel.GOOGLE_SEARCH_URL_SUFFIX;
 import static seedu.address.ui.UiPart.FXML_FILE_FOLDER;
 
 import java.net.URL;
@@ -42,8 +40,7 @@ public class BrowserPanelTest extends GuiUnitTest {
 
         // associated web page of a person
         postNow(selectionChangedEventStub);
-        URL expectedPersonUrl = new URL(GOOGLE_SEARCH_URL_PREFIX
-                + ALICE.getName().fullName.replaceAll(" ", "+") + GOOGLE_SEARCH_URL_SUFFIX);
+        URL expectedPersonUrl = new URL(BrowserPanel.SEARCH_PAGE_URL + ALICE.getName().fullName.replaceAll(" ", "%20"));
 
         waitUntilBrowserLoaded(browserPanelHandle);
         assertEquals(expectedPersonUrl, browserPanelHandle.getLoadedUrl());

--- a/src/test/java/systemtests/AddressBookSystemTest.java
+++ b/src/test/java/systemtests/AddressBookSystemTest.java
@@ -5,8 +5,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static seedu.address.ui.BrowserPanel.DEFAULT_PAGE;
-import static seedu.address.ui.BrowserPanel.GOOGLE_SEARCH_URL_PREFIX;
-import static seedu.address.ui.BrowserPanel.GOOGLE_SEARCH_URL_SUFFIX;
 import static seedu.address.ui.StatusBarFooter.SYNC_STATUS_INITIAL;
 import static seedu.address.ui.StatusBarFooter.SYNC_STATUS_UPDATED;
 import static seedu.address.ui.UiPart.FXML_FILE_FOLDER;
@@ -41,6 +39,7 @@ import seedu.address.logic.commands.SelectCommand;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.testutil.TypicalPersons;
+import seedu.address.ui.BrowserPanel;
 import seedu.address.ui.CommandBox;
 
 /**
@@ -215,8 +214,7 @@ public abstract class AddressBookSystemTest {
         String selectedCardName = getPersonListPanel().getHandleToSelectedCard().getName();
         URL expectedUrl;
         try {
-            expectedUrl = new URL(GOOGLE_SEARCH_URL_PREFIX + selectedCardName.replaceAll(" ", "+")
-                    + GOOGLE_SEARCH_URL_SUFFIX);
+            expectedUrl = new URL(BrowserPanel.SEARCH_PAGE_URL + selectedCardName.replaceAll(" ", "%20"));
         } catch (MalformedURLException mue) {
             throw new AssertionError("URL expected to be valid.");
         }


### PR DESCRIPTION
Fixes #733 

```
BrowserPanel loads the Google search page whenever a person card
is selected. The tests written for this feature verifies that the
loaded web page is indeed the Google search page with the person's
name.

When many forks of this project are running automated tests, too many
search requests are sent to Google, causing us to exceed the search
service’s rate limits. This is an abuse of Google’s search service.
Also, this causes our tests to fail as the loaded web page will be
redirected to a captcha page.

Let’s update BrowserPanel to load DummySearchPage.html which is hosted
on GitHub Pages. GitHub Pages serve static web pages which requires
much less processing power, thus it is more unlikely for us to exceed
the search service’s rate limits.
```