### PR TITLE
Clear browser panel on clear command #731

### DIFF
--- a/src/main/java/seedu/address/commons/events/ui/ClearBrowserPanelEvent.java
+++ b/src/main/java/seedu/address/commons/events/ui/ClearBrowserPanelEvent.java
@@ -1,0 +1,14 @@
+package seedu.address.commons.events.ui;
+
+import seedu.address.commons.events.BaseEvent;
+
+/**
+ * Clears the Browser Panel
+ */
+public class ClearBrowserPanelEvent extends BaseEvent {
+
+    @Override
+    public String toString() {
+        return this.getClass().getSimpleName();
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -2,6 +2,8 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import seedu.address.commons.core.EventsCenter;
+import seedu.address.commons.events.ui.ClearBrowserPanelEvent;
 import seedu.address.model.AddressBook;
 
 /**
@@ -17,6 +19,7 @@ public class ClearCommand extends UndoableCommand {
     public CommandResult executeUndoableCommand() {
         requireNonNull(model);
         model.resetData(new AddressBook());
+        EventsCenter.getInstance().post(new ClearBrowserPanelEvent());
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/address/ui/BrowserPanel.java
+++ b/src/main/java/seedu/address/ui/BrowserPanel.java
@@ -12,6 +12,7 @@ import javafx.scene.layout.Region;
 import javafx.scene.web.WebView;
 import seedu.address.MainApp;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.commons.events.ui.ClearBrowserPanelEvent;
 import seedu.address.commons.events.ui.PersonPanelSelectionChangedEvent;
 import seedu.address.model.person.Person;
 
@@ -69,5 +70,11 @@ public class BrowserPanel extends UiPart<Region> {
     private void handlePersonPanelSelectionChangedEvent(PersonPanelSelectionChangedEvent event) {
         logger.info(LogsCenter.getEventHandlingLogMessage(event));
         loadPersonPage(event.getNewSelection().person);
+    }
+
+    @Subscribe
+    private void handleClearBrowserPanelEvent(ClearBrowserPanelEvent event) {
+        logger.info(LogsCenter.getEventHandlingLogMessage(event));
+        loadDefaultPage();
     }
 }

--- a/src/test/java/systemtests/AddressBookSystemTest.java
+++ b/src/test/java/systemtests/AddressBookSystemTest.java
@@ -206,7 +206,7 @@ public abstract class AddressBookSystemTest {
 
     /**
      * Asserts that the no card is selected and the browser's url is that of the default page
-     * @see BrowserPanelHandle#isUrlChanged()
+     * @see BrowserPanelHandle#getLoadedUrl()
      */
     protected void assertBrowserPanelClear() {
         assertEquals(getBrowserPanel().getLoadedUrl(),

--- a/src/test/java/systemtests/AddressBookSystemTest.java
+++ b/src/test/java/systemtests/AddressBookSystemTest.java
@@ -205,6 +205,16 @@ public abstract class AddressBookSystemTest {
     }
 
     /**
+     * Asserts that the no card is selected and the browser's url is that of the default page
+     * @see BrowserPanelHandle#isUrlChanged()
+     */
+    protected void assertBrowserPanelClear() {
+        assertEquals(getBrowserPanel().getLoadedUrl(),
+                MainApp.class.getResource(FXML_FILE_FOLDER + DEFAULT_PAGE));
+        assertFalse(getPersonListPanel().isAnyCardSelected());
+    }
+
+    /**
      * Asserts that the browser's url is changed to display the details of the person in the person list panel at
      * {@code expectedSelectedCardIndex}, and only the card at {@code expectedSelectedCardIndex} is selected.
      * @see BrowserPanelHandle#isUrlChanged()

--- a/src/test/java/systemtests/ClearCommandSystemTest.java
+++ b/src/test/java/systemtests/ClearCommandSystemTest.java
@@ -40,7 +40,7 @@ public class ClearCommandSystemTest extends AddressBookSystemTest {
         executeCommand(UndoCommand.COMMAND_WORD); // restores the original address book
         selectPerson(Index.fromOneBased(1));
         assertCommandSuccess(ClearCommand.COMMAND_WORD);
-        assertSelectedCardDeselected();
+        assertBrowserPanelClear();
 
         /* Case: filters the person list before clearing -> entire address book cleared */
         executeCommand(UndoCommand.COMMAND_WORD); // restores the original address book


### PR DESCRIPTION
Fixes #731 

Solution:

On execution of `clear` command, an event is triggered which executes the clearing of Browser Panel by calling the `loadDefaultPage()` function.

