### PR TITLE
Ui: Show total persons in status bar

### DIFF
--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -128,7 +128,8 @@ public class MainWindow extends UiPart<Stage> {
         ResultDisplay resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());
 
-        StatusBarFooter statusBarFooter = new StatusBarFooter(prefs.getAddressBookFilePath());
+        StatusBarFooter statusBarFooter = new StatusBarFooter(prefs.getAddressBookFilePath(),
+                logic.getFilteredPersonList().size());
         statusbarPlaceholder.getChildren().add(statusBarFooter.getRoot());
 
         CommandBox commandBox = new CommandBox(logic);

--- a/src/main/java/seedu/address/ui/StatusBarFooter.java
+++ b/src/main/java/seedu/address/ui/StatusBarFooter.java
@@ -24,6 +24,8 @@ public class StatusBarFooter extends UiPart<Region> {
     public static final String SYNC_STATUS_INITIAL = "Not updated yet in this session";
     public static final String SYNC_STATUS_UPDATED = "Last Updated: %s";
 
+    public static final String TOTAL_PERSONS_STATUS = "%d person(s) total";
+
     /**
      * Used to generate time stamps.
      *
@@ -41,13 +43,15 @@ public class StatusBarFooter extends UiPart<Region> {
     @FXML
     private StatusBar syncStatus;
     @FXML
+    private StatusBar totalPersonsStatus;
+    @FXML
     private StatusBar saveLocationStatus;
 
-
-    public StatusBarFooter(Path saveLocation) {
+    public StatusBarFooter(Path saveLocation, int totalPersons) {
         super(FXML);
         setSyncStatus(SYNC_STATUS_INITIAL);
         setSaveLocation(Paths.get(".").resolve(saveLocation).toString());
+        setTotalPersons(totalPersons);
         registerAsAnEventHandler(this);
     }
 
@@ -73,11 +77,16 @@ public class StatusBarFooter extends UiPart<Region> {
         Platform.runLater(() -> syncStatus.setText(status));
     }
 
+    private void setTotalPersons(int totalPersons) {
+        Platform.runLater(() -> totalPersonsStatus.setText(String.format(TOTAL_PERSONS_STATUS, totalPersons)));
+    }
+
     @Subscribe
     public void handleAddressBookChangedEvent(AddressBookChangedEvent abce) {
         long now = clock.millis();
         String lastUpdated = new Date(now).toString();
         logger.info(LogsCenter.getEventHandlingLogMessage(abce, "Setting last updated status to " + lastUpdated));
         setSyncStatus(String.format(SYNC_STATUS_UPDATED, lastUpdated));
+        setTotalPersons(abce.data.getPersonList().size());
     }
 }

--- a/src/main/resources/view/StatusBarFooter.fxml
+++ b/src/main/resources/view/StatusBarFooter.fxml
@@ -10,5 +10,6 @@
     <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="100" />
   </columnConstraints>
   <StatusBar styleClass="stack-pane" fx:id="syncStatus" />
-  <StatusBar styleClass="stack-pane" fx:id="saveLocationStatus" GridPane.columnIndex="1" nodeOrientation="RIGHT_TO_LEFT" />
+  <StatusBar styleClass="stack-pane" fx:id="totalPersonsStatus" GridPane.columnIndex="1" />
+  <StatusBar styleClass="stack-pane" fx:id="saveLocationStatus" GridPane.columnIndex="2" nodeOrientation="RIGHT_TO_LEFT" />
 </GridPane>

--- a/src/test/java/guitests/guihandles/StatusBarFooterHandle.java
+++ b/src/test/java/guitests/guihandles/StatusBarFooterHandle.java
@@ -11,18 +11,22 @@ public class StatusBarFooterHandle extends NodeHandle<Node> {
     public static final String STATUS_BAR_PLACEHOLDER = "#statusbarPlaceholder";
 
     private static final String SYNC_STATUS_ID = "#syncStatus";
+    private static final String TOTAL_PERSONS_STATUS_ID = "#totalPersonsStatus";
     private static final String SAVE_LOCATION_STATUS_ID = "#saveLocationStatus";
 
     private final StatusBar syncStatusNode;
+    private final StatusBar totalPersonsStatusNode;
     private final StatusBar saveLocationNode;
 
     private String lastRememberedSyncStatus;
+    private String lastRememberedTotalPersonsStatus;
     private String lastRememberedSaveLocation;
 
     public StatusBarFooterHandle(Node statusBarFooterNode) {
         super(statusBarFooterNode);
 
         syncStatusNode = getChildNode(SYNC_STATUS_ID);
+        totalPersonsStatusNode = getChildNode(TOTAL_PERSONS_STATUS_ID);
         saveLocationNode = getChildNode(SAVE_LOCATION_STATUS_ID);
     }
 
@@ -31,6 +35,13 @@ public class StatusBarFooterHandle extends NodeHandle<Node> {
      */
     public String getSyncStatus() {
         return syncStatusNode.getText();
+    }
+
+    /**
+     * Returns the text of the 'total persons' portion of the status bar.
+     */
+    public String getTotalPersonsStatus() {
+        return totalPersonsStatusNode.getText();
     }
 
     /**
@@ -53,6 +64,22 @@ public class StatusBarFooterHandle extends NodeHandle<Node> {
      */
     public boolean isSyncStatusChanged() {
         return !lastRememberedSyncStatus.equals(getSyncStatus());
+    }
+
+
+    /**
+     * Remembers the content of the 'total persons' portion of the status bar.
+     */
+    public void rememberTotalPersonsStatus() {
+        lastRememberedTotalPersonsStatus = getTotalPersonsStatus();
+    }
+
+    /**
+     * Returns true if the current content of the 'total persons' is different from the value remembered by the most
+     * recent {@code rememberTotalPersonsStatus()} call.
+     */
+    public boolean isTotalPersonsStatusChanged() {
+        return !lastRememberedTotalPersonsStatus.equals(getTotalPersonsStatus());
     }
 
     /**

--- a/src/test/java/seedu/address/ui/StatusBarFooterTest.java
+++ b/src/test/java/seedu/address/ui/StatusBarFooterTest.java
@@ -2,8 +2,10 @@ package seedu.address.ui;
 
 import static org.junit.Assert.assertEquals;
 import static seedu.address.testutil.EventsUtil.postNow;
+import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.ui.StatusBarFooter.SYNC_STATUS_INITIAL;
 import static seedu.address.ui.StatusBarFooter.SYNC_STATUS_UPDATED;
+import static seedu.address.ui.StatusBarFooter.TOTAL_PERSONS_STATUS;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -19,14 +21,17 @@ import org.junit.Test;
 
 import guitests.guihandles.StatusBarFooterHandle;
 import seedu.address.commons.events.model.AddressBookChangedEvent;
-import seedu.address.model.AddressBook;
+import seedu.address.testutil.AddressBookBuilder;
 
 public class StatusBarFooterTest extends GuiUnitTest {
 
     private static final Path STUB_SAVE_LOCATION = Paths.get("Stub");
     private static final Path RELATIVE_PATH = Paths.get(".");
 
-    private static final AddressBookChangedEvent EVENT_STUB = new AddressBookChangedEvent(new AddressBook());
+    private static final AddressBookChangedEvent EVENT_STUB = new AddressBookChangedEvent(
+            new AddressBookBuilder().withPerson(ALICE).build());
+
+    private static final int INITIAL_TOTAL_PERSONS = 0;
 
     private static final Clock originalClock = StatusBarFooter.getClock();
     private static final Clock injectedClock = Clock.fixed(Instant.now(), ZoneId.systemDefault());
@@ -47,7 +52,7 @@ public class StatusBarFooterTest extends GuiUnitTest {
 
     @Before
     public void setUp() {
-        StatusBarFooter statusBarFooter = new StatusBarFooter(STUB_SAVE_LOCATION);
+        StatusBarFooter statusBarFooter = new StatusBarFooter(STUB_SAVE_LOCATION, INITIAL_TOTAL_PERSONS);
         uiPartRule.setUiPart(statusBarFooter);
 
         statusBarFooterHandle = new StatusBarFooterHandle(statusBarFooter.getRoot());
@@ -56,21 +61,26 @@ public class StatusBarFooterTest extends GuiUnitTest {
     @Test
     public void display() {
         // initial state
-        assertStatusBarContent(RELATIVE_PATH.resolve(STUB_SAVE_LOCATION).toString(), SYNC_STATUS_INITIAL);
+        assertStatusBarContent(RELATIVE_PATH.resolve(STUB_SAVE_LOCATION).toString(), SYNC_STATUS_INITIAL,
+                String.format(TOTAL_PERSONS_STATUS, INITIAL_TOTAL_PERSONS));
 
         // after address book is updated
         postNow(EVENT_STUB);
         assertStatusBarContent(RELATIVE_PATH.resolve(STUB_SAVE_LOCATION).toString(),
-                String.format(SYNC_STATUS_UPDATED, new Date(injectedClock.millis()).toString()));
+                String.format(SYNC_STATUS_UPDATED, new Date(injectedClock.millis()).toString()),
+                String.format(TOTAL_PERSONS_STATUS, EVENT_STUB.data.getPersonList().size()));
     }
 
     /**
-     * Asserts that the save location matches that of {@code expectedSaveLocation}, and the
-     * sync status matches that of {@code expectedSyncStatus}.
+     * Asserts that the save location matches that of {@code expectedSaveLocation}, the
+     * sync status matches that of {@code expectedSyncStatus}, and the total persons matches that of
+     * {@code expectedTotalPersonsStatus}.
      */
-    private void assertStatusBarContent(String expectedSaveLocation, String expectedSyncStatus) {
+    private void assertStatusBarContent(String expectedSaveLocation, String expectedSyncStatus,
+                                        String expectedTotalPersonsStatus) {
         assertEquals(expectedSaveLocation, statusBarFooterHandle.getSaveLocation());
         assertEquals(expectedSyncStatus, statusBarFooterHandle.getSyncStatus());
+        assertEquals(expectedTotalPersonsStatus, statusBarFooterHandle.getTotalPersonsStatus());
         guiRobot.pauseForHuman();
     }
 

--- a/src/test/java/systemtests/AddCommandSystemTest.java
+++ b/src/test/java/systemtests/AddCommandSystemTest.java
@@ -222,7 +222,7 @@ public class AddCommandSystemTest extends AddressBookSystemTest {
         assertApplicationDisplaysExpected("", expectedResultMessage, expectedModel);
         assertSelectedCardUnchanged();
         assertCommandBoxShowsDefaultStyle();
-        assertStatusBarUnchangedExceptSyncStatus();
+        assertStatusBarChangedExceptSaveLocation();
     }
 
     /**

--- a/src/test/java/systemtests/AddressBookSystemTest.java
+++ b/src/test/java/systemtests/AddressBookSystemTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertTrue;
 import static seedu.address.ui.BrowserPanel.DEFAULT_PAGE;
 import static seedu.address.ui.StatusBarFooter.SYNC_STATUS_INITIAL;
 import static seedu.address.ui.StatusBarFooter.SYNC_STATUS_UPDATED;
+import static seedu.address.ui.StatusBarFooter.TOTAL_PERSONS_STATUS;
 import static seedu.address.ui.UiPart.FXML_FILE_FOLDER;
 import static seedu.address.ui.testutil.GuiTestAssert.assertListMatching;
 
@@ -191,6 +192,7 @@ public abstract class AddressBookSystemTest {
         StatusBarFooterHandle statusBarFooterHandle = getStatusBarFooter();
         getBrowserPanel().rememberUrl();
         statusBarFooterHandle.rememberSaveLocation();
+        statusBarFooterHandle.rememberTotalPersonsStatus();
         statusBarFooterHandle.rememberSyncStatus();
         getPersonListPanel().rememberSelectedPersonCard();
     }
@@ -255,18 +257,39 @@ public abstract class AddressBookSystemTest {
     protected void assertStatusBarUnchanged() {
         StatusBarFooterHandle handle = getStatusBarFooter();
         assertFalse(handle.isSaveLocationChanged());
+        assertFalse(handle.isTotalPersonsStatusChanged());
         assertFalse(handle.isSyncStatusChanged());
     }
 
     /**
      * Asserts that only the sync status in the status bar was changed to the timing of
-     * {@code ClockRule#getInjectedClock()}, while the save location remains the same.
+     * {@code ClockRule#getInjectedClock()}, while the save location and the total person
+     * list remains the same.
      */
     protected void assertStatusBarUnchangedExceptSyncStatus() {
         StatusBarFooterHandle handle = getStatusBarFooter();
         String timestamp = new Date(clockRule.getInjectedClock().millis()).toString();
         String expectedSyncStatus = String.format(SYNC_STATUS_UPDATED, timestamp);
         assertEquals(expectedSyncStatus, handle.getSyncStatus());
+        assertFalse(handle.isSaveLocationChanged());
+        assertFalse(handle.isTotalPersonsStatusChanged());
+    }
+
+    /**
+     * Asserts that the sync status in the status bar was changed to the timing of
+     * {@code ClockRule#getInjectedClock()}, and total persons was changed to match the total
+     * number of persons in the address book, while the save location remains the same.
+     */
+    protected void assertStatusBarChangedExceptSaveLocation() {
+        StatusBarFooterHandle handle = getStatusBarFooter();
+
+        String timestamp = new Date(clockRule.getInjectedClock().millis()).toString();
+        String expectedSyncStatus = String.format(SYNC_STATUS_UPDATED, timestamp);
+        assertEquals(expectedSyncStatus, handle.getSyncStatus());
+
+        final int totalPersons = testApp.getModel().getAddressBook().getPersonList().size();
+        assertEquals(String.format(TOTAL_PERSONS_STATUS, totalPersons), handle.getTotalPersonsStatus());
+
         assertFalse(handle.isSaveLocationChanged());
     }
 
@@ -281,6 +304,8 @@ public abstract class AddressBookSystemTest {
         assertEquals(Paths.get(".").resolve(testApp.getStorageSaveLocation()).toString(),
                 getStatusBarFooter().getSaveLocation());
         assertEquals(SYNC_STATUS_INITIAL, getStatusBarFooter().getSyncStatus());
+        assertEquals(String.format(TOTAL_PERSONS_STATUS, getModel().getAddressBook().getPersonList().size()),
+                getStatusBarFooter().getTotalPersonsStatus());
     }
 
     /**

--- a/src/test/java/systemtests/ClearCommandSystemTest.java
+++ b/src/test/java/systemtests/ClearCommandSystemTest.java
@@ -77,7 +77,7 @@ public class ClearCommandSystemTest extends AddressBookSystemTest {
         executeCommand(command);
         assertApplicationDisplaysExpected("", expectedResultMessage, expectedModel);
         assertCommandBoxShowsDefaultStyle();
-        assertStatusBarUnchangedExceptSyncStatus();
+        assertStatusBarChangedExceptSaveLocation();
     }
 
     /**

--- a/src/test/java/systemtests/DeleteCommandSystemTest.java
+++ b/src/test/java/systemtests/DeleteCommandSystemTest.java
@@ -168,7 +168,7 @@ public class DeleteCommandSystemTest extends AddressBookSystemTest {
         }
 
         assertCommandBoxShowsDefaultStyle();
-        assertStatusBarUnchangedExceptSyncStatus();
+        assertStatusBarChangedExceptSaveLocation();
     }
 
     /**


### PR DESCRIPTION
Part of #784. Rebased, and added tests.

Proposed merge commit message:

```
The status bar does not show how many people are in the address book.
This information could be useful for the user when the user wants to
judge the size of the address book.

Let's modify the status bar to include the total amount of people in the
address book.
```

_Note:_ For demo purpose, don't merge this to master!