### PR TITLE
UiManager: delete duplicate code  #734

### DIFF
--- a/src/main/java/seedu/address/ui/UiManager.java
+++ b/src/main/java/seedu/address/ui/UiManager.java
@@ -47,7 +47,6 @@ public class UiManager extends ComponentManager implements Ui {
     @Override
     public void start(Stage primaryStage) {
         logger.info("Starting UI...");
-        primaryStage.setTitle(config.getAppTitle());
 
         //Set the application icon.
         primaryStage.getIcons().add(getImage(ICON_APPLICATION));


### PR DESCRIPTION
Fixes #734 

```
UiManager calls primaryStage.setTitle(). This is called by MainWindow as
well.

The setting of the title should not be the job of UiManager as different
Windows may have different titles; each Window should be responsible for
assigning its own title.

Let's remove the duplicate code in UiManager.
```