### PR TITLE
XmlAdaptedPerson#toModelType(): Enforce checking of required parameters #725

### DIFF
--- a/src/main/java/seedu/address/storage/XmlAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/XmlAdaptedPerson.java
@@ -21,6 +21,8 @@ import seedu.address.model.tag.Tag;
  */
 public class XmlAdaptedPerson {
 
+    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Person's %s field is missing!";
+
     @XmlElement(required = true)
     private String name;
     @XmlElement(required = true)
@@ -79,21 +81,33 @@ public class XmlAdaptedPerson {
             personTags.add(tag.toModelType());
         }
 
+        if (this.name == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName()));
+        }
         if (!Name.isValidName(this.name)) {
             throw new IllegalValueException(Name.MESSAGE_NAME_CONSTRAINTS);
         }
         final Name name = new Name(this.name);
 
+        if (this.phone == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName()));
+        }
         if (!Phone.isValidPhone(this.phone)) {
             throw new IllegalValueException(Phone.MESSAGE_PHONE_CONSTRAINTS);
         }
         final Phone phone = new Phone(this.phone);
 
+        if (this.email == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName()));
+        }
         if (!Email.isValidEmail(this.email)) {
             throw new IllegalValueException(Email.MESSAGE_EMAIL_CONSTRAINTS);
         }
         final Email email = new Email(this.email);
 
+        if (this.address == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName()));
+        }
         if (!Address.isValidAddress(this.address)) {
             throw new IllegalValueException(Address.MESSAGE_ADDRESS_CONSTRAINTS);
         }

--- a/src/main/java/seedu/address/storage/XmlAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/XmlAdaptedPerson.java
@@ -3,6 +3,7 @@ package seedu.address.storage;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import javax.xml.bind.annotation.XmlElement;
@@ -113,10 +114,10 @@ public class XmlAdaptedPerson {
         }
 
         XmlAdaptedPerson otherPerson = (XmlAdaptedPerson) other;
-        return name.equals(otherPerson.name)
-                && phone.equals(otherPerson.phone)
-                && email.equals(otherPerson.email)
-                && address.equals(otherPerson.address)
+        return Objects.equals(name, otherPerson.name)
+                && Objects.equals(phone, otherPerson.phone)
+                && Objects.equals(email, otherPerson.email)
+                && Objects.equals(address, otherPerson.address)
                 && tagged.equals(otherPerson.tagged);
     }
 }

--- a/src/test/data/XmlUtilTest/invalidPersonField.xml
+++ b/src/test/data/XmlUtilTest/invalidPersonField.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Person with an invalid phone field -->
+<person>
+    <name>Hans Muster</name>
+    <phone>9482asf424</phone>
+    <email>hans@example</email>
+    <address>4th street</address>
+    <tagged>friends</tagged>
+</person>

--- a/src/test/data/XmlUtilTest/missingPersonField.xml
+++ b/src/test/data/XmlUtilTest/missingPersonField.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Person with missing name field -->
+<person>
+    <phone>9482424</phone>
+    <email>hans@example</email>
+    <address>4th street</address>
+    <tagged>friends</tagged>
+</person>

--- a/src/test/data/XmlUtilTest/validPerson.xml
+++ b/src/test/data/XmlUtilTest/validPerson.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<person>
+    <name>Hans Muster</name>
+    <phone>9482424</phone>
+    <email>hans@example</email>
+    <address>4th street</address>
+    <tagged>friends</tagged>
+</person>

--- a/src/test/java/seedu/address/commons/util/XmlUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/XmlUtilTest.java
@@ -4,14 +4,19 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.util.Collections;
+import java.util.List;
 
 import javax.xml.bind.JAXBException;
+import javax.xml.bind.annotation.XmlRootElement;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import seedu.address.model.AddressBook;
+import seedu.address.storage.XmlAdaptedPerson;
+import seedu.address.storage.XmlAdaptedTag;
 import seedu.address.storage.XmlSerializableAddressBook;
 import seedu.address.testutil.AddressBookBuilder;
 import seedu.address.testutil.PersonBuilder;
@@ -23,7 +28,18 @@ public class XmlUtilTest {
     private static final File EMPTY_FILE = new File(TEST_DATA_FOLDER + "empty.xml");
     private static final File MISSING_FILE = new File(TEST_DATA_FOLDER + "missing.xml");
     private static final File VALID_FILE = new File(TEST_DATA_FOLDER + "validAddressBook.xml");
+    private static final File MISSING_PERSON_FIELD_FILE = new File(TEST_DATA_FOLDER + "missingPersonField.xml");
+    private static final File INVALID_PERSON_FIELD_FILE = new File(TEST_DATA_FOLDER + "invalidPersonField.xml");
+    private static final File VALID_PERSON_FILE = new File(TEST_DATA_FOLDER + "validPerson.xml");
     private static final File TEMP_FILE = new File(TestUtil.getFilePathInSandboxFolder("tempAddressBook.xml"));
+
+    private static final String INVALID_PHONE = "9482asf424";
+
+    private static final String VALID_NAME = "Hans Muster";
+    private static final String VALID_PHONE = "9482424";
+    private static final String VALID_EMAIL = "hans@example";
+    private static final String VALID_ADDRESS = "4th street";
+    private static final List<XmlAdaptedTag> VALID_TAGS = Collections.singletonList(new XmlAdaptedTag("friends"));
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
@@ -60,6 +76,33 @@ public class XmlUtilTest {
     }
 
     @Test
+    public void xmlAdaptedPersonFromFile_fileWithMissingPersonField_validResult() throws Exception {
+        XmlAdaptedPerson actualPerson = XmlUtil.getDataFromFile(
+                MISSING_PERSON_FIELD_FILE, XmlAdaptedPersonWithRootElement.class);
+        XmlAdaptedPerson expectedPerson = new XmlAdaptedPerson(
+                null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        assertEquals(expectedPerson, actualPerson);
+    }
+
+    @Test
+    public void xmlAdaptedPersonFromFile_fileWithInvalidPersonField_validResult() throws Exception {
+        XmlAdaptedPerson actualPerson = XmlUtil.getDataFromFile(
+                INVALID_PERSON_FIELD_FILE, XmlAdaptedPersonWithRootElement.class);
+        XmlAdaptedPerson expectedPerson = new XmlAdaptedPerson(
+                VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        assertEquals(expectedPerson, actualPerson);
+    }
+
+    @Test
+    public void xmlAdaptedPersonFromFile_fileWithValidPerson_validResult() throws Exception {
+        XmlAdaptedPerson actualPerson = XmlUtil.getDataFromFile(
+                VALID_PERSON_FILE, XmlAdaptedPersonWithRootElement.class);
+        XmlAdaptedPerson expectedPerson = new XmlAdaptedPerson(
+                VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        assertEquals(expectedPerson, actualPerson);
+    }
+
+    @Test
     public void saveDataToFile_nullFile_throwsNullPointerException() throws Exception {
         thrown.expect(NullPointerException.class);
         XmlUtil.saveDataToFile(null, new AddressBook());
@@ -93,4 +136,11 @@ public class XmlUtilTest {
         dataFromFile = XmlUtil.getDataFromFile(TEMP_FILE, XmlSerializableAddressBook.class);
         assertEquals(dataToWrite, dataFromFile);
     }
+
+    /**
+     * Test class annotated with {@code XmlRootElement} to allow unmarshalling of .xml data to {@code XmlAdaptedPerson}
+     * objects.
+     */
+    @XmlRootElement(name = "person")
+    private static class XmlAdaptedPersonWithRootElement extends XmlAdaptedPerson {}
 }

--- a/src/test/java/seedu/address/storage/XmlAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/XmlAdaptedPersonTest.java
@@ -1,6 +1,7 @@
 package seedu.address.storage;
 
 import static org.junit.Assert.assertEquals;
+import static seedu.address.storage.XmlAdaptedPerson.MISSING_FIELD_MESSAGE_FORMAT;
 import static seedu.address.testutil.TypicalPersons.BENSON;
 
 import java.util.ArrayList;
@@ -10,6 +11,10 @@ import java.util.stream.Collectors;
 import org.junit.Test;
 
 import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Phone;
 import seedu.address.testutil.Assert;
 
 public class XmlAdaptedPersonTest {
@@ -37,28 +42,60 @@ public class XmlAdaptedPersonTest {
     public void toModelType_invalidName_throwsIllegalValueException() {
         XmlAdaptedPerson person =
                 new XmlAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
-        Assert.assertThrows(IllegalValueException.class, person::toModelType);
+        String expectedMessage = Name.MESSAGE_NAME_CONSTRAINTS;
+        Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullName_throwsIllegalValueException() {
+        XmlAdaptedPerson person = new XmlAdaptedPerson(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
+        Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         XmlAdaptedPerson person =
                 new XmlAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
-        Assert.assertThrows(IllegalValueException.class, person::toModelType);
+        String expectedMessage = Phone.MESSAGE_PHONE_CONSTRAINTS;
+        Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullPhone_throwsIllegalValueException() {
+        XmlAdaptedPerson person = new XmlAdaptedPerson(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
+        Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         XmlAdaptedPerson person =
                 new XmlAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
-        Assert.assertThrows(IllegalValueException.class, person::toModelType);
+        String expectedMessage = Email.MESSAGE_EMAIL_CONSTRAINTS;
+        Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullEmail_throwsIllegalValueException() {
+        XmlAdaptedPerson person = new XmlAdaptedPerson(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS, VALID_TAGS);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
+        Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_invalidAddress_throwsIllegalValueException() {
         XmlAdaptedPerson person =
                 new XmlAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_TAGS);
-        Assert.assertThrows(IllegalValueException.class, person::toModelType);
+        String expectedMessage = Address.MESSAGE_ADDRESS_CONSTRAINTS;
+        Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullAddress_throwsIllegalValueException() {
+        XmlAdaptedPerson person = new XmlAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_TAGS);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
+        Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/Assert.java
+++ b/src/test/java/seedu/address/testutil/Assert.java
@@ -11,18 +11,37 @@ public class Assert {
      * Asserts that the {@code callable} throws the {@code expected} Exception.
      */
     public static void assertThrows(Class<? extends Throwable> expected, VoidCallable callable) {
+        assertThrows(expected, null, callable);
+    }
+
+    /**
+     * Asserts that the {@code callable} throws the {@code expectedException} and the {@code expectedMessage}.
+     * If there's no need for the verification of the exception's error message, call
+     * {@code assertThrows(Class<? extends Throwable>, VoidCallable)} instead.
+     * {@see assertThrows(Class<? extends Throwable>, VoidCallable}
+     */
+    public static void assertThrows(Class<? extends Throwable> expectedException, String expectedMessage,
+                                    VoidCallable callable) {
         try {
             callable.call();
         } catch (Throwable actualException) {
-            if (actualException.getClass().isAssignableFrom(expected)) {
+            String errorMessage;
+
+            if (!actualException.getClass().isAssignableFrom(expectedException)) {
+                errorMessage = String.format("Expected exception thrown: %s, actual: %s",
+                        expectedException.getName(), actualException.getClass().getName());
+            } else if (expectedMessage != null && !expectedMessage.equals(actualException.getMessage())) {
+                errorMessage = String.format(
+                        "Expected message thrown: %s, actual: %s", expectedMessage, actualException.getMessage());
+            } else {
                 return;
             }
-            String message = String.format("Expected thrown: %s, actual: %s", expected.getName(),
-                    actualException.getClass().getName());
-            throw new AssertionFailedError(message);
+
+            throw new AssertionFailedError(errorMessage);
         }
-        throw new AssertionFailedError(
-                String.format("Expected %s to be thrown, but nothing was thrown.", expected.getName()));
+
+        throw new AssertionFailedError(String.format(
+                "Expected %s to be thrown, but nothing was thrown.", expectedException.getName()));
     }
 
     /**


### PR DESCRIPTION
Fixes #725

```
XmlAdaptedPerson#toModelType() does not have a non-null check for each
parameter in person before the isValid*(String).

When null value is passed into the parameter's isValid*(String) check,
a NullPointerException is thrown, causing the app to crash.

Let's update XmlAdaptedPerson#toModelType() to have a separate non-null
check for each parameter before passing them into the isValid*(String)
check.
```