### PR TITLE
LogicManager: constructor does not follow coding standard's usage of 'this' #729

### DIFF
--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -26,9 +26,9 @@ public class LogicManager extends ComponentManager implements Logic {
 
     public LogicManager(Model model) {
         this.model = model;
-        this.history = new CommandHistory();
-        this.addressBookParser = new AddressBookParser();
-        this.undoRedoStack = new UndoRedoStack();
+        history = new CommandHistory();
+        addressBookParser = new AddressBookParser();
+        undoRedoStack = new UndoRedoStack();
     }
 
     @Override


### PR DESCRIPTION
Fixes #729 

Proposed commit message:
```
The LogicManager constructor initialises several fields using 
the 'this' keyword.

Using 'this' keyword for some fields is unnecessary as these 
fields are not shadowed by a method or constructor parameter.

Let's remove unnecessary 'this' keywords from LogicManager
constructor to reduce noise and conform to coding standards.
```