### PR TITLE
JUnit: Update to use latest version #707

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,8 +38,13 @@ jacocoTestReport {
     }
 }
 
+test {
+    useJUnitPlatform()
+}
+
 dependencies {
     String testFxVersion = '4.0.12-alpha'
+    String jUnitVersion = '5.1.0'
 
     compile group: 'org.controlsfx', name: 'controlsfx', version: '8.40.11'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.7.0'
@@ -59,8 +64,12 @@ dependencies {
         exclude group: 'junit', module: 'junit'
     }
 
+    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: jUnitVersion
+
     testRuntime group: 'org.testfx', name: 'testfx-internal-java9', version: testFxVersion
     testRuntime group: 'org.testfx', name: 'openjfx-monocle', version: 'jdk-9+181'
+    testRuntimeOnly group:'org.junit.vintage', name:'junit-vintage-engine', version: jUnitVersion
+    testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: jUnitVersion
 }
 
 shadowJar {


### PR DESCRIPTION
fixes #707 (eventually, right now it just starts to fix it)

This is a start towards upgrading towards JUnit5. It does not changes any tests, but it makes it such that Gradle is able to read JUnit5 tests and execute them.

One thing to keep in consideration if we want to change the tests to be JUnit5 tests:
Right now there is no easy way to do the temporary folder rule, it might be messy to create our own version.