### PR TITLE
Storage layer needs proper error handling #749

### DIFF
--- a/src/main/java/seedu/address/storage/XmlAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/XmlAdaptedPerson.java
@@ -101,4 +101,22 @@ public class XmlAdaptedPerson {
         final Set<Tag> tags = new HashSet<>(personTags);
         return new Person(name, phone, email, address, tags);
     }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof XmlAdaptedPerson)) {
+            return false;
+        }
+
+        XmlAdaptedPerson otherPerson = (XmlAdaptedPerson) other;
+        return name.equals(otherPerson.name)
+                && phone.equals(otherPerson.phone)
+                && email.equals(otherPerson.email)
+                && address.equals(otherPerson.address)
+                && tagged.equals(otherPerson.tagged);
+    }
 }

--- a/src/main/java/seedu/address/storage/XmlAdaptedTag.java
+++ b/src/main/java/seedu/address/storage/XmlAdaptedTag.java
@@ -47,4 +47,16 @@ public class XmlAdaptedTag {
         return new Tag(tagName);
     }
 
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof XmlAdaptedTag)) {
+            return false;
+        }
+
+        return tagName.equals(((XmlAdaptedTag) other).tagName);
+    }
 }

--- a/src/main/java/seedu/address/storage/XmlAddressBookStorage.java
+++ b/src/main/java/seedu/address/storage/XmlAddressBookStorage.java
@@ -10,6 +10,7 @@ import java.util.logging.Logger;
 
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.exceptions.DataConversionException;
+import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.commons.util.FileUtil;
 import seedu.address.model.ReadOnlyAddressBook;
 
@@ -51,9 +52,13 @@ public class XmlAddressBookStorage implements AddressBookStorage {
             return Optional.empty();
         }
 
-        ReadOnlyAddressBook addressBookOptional = XmlFileStorage.loadDataFromSaveFile(new File(filePath));
-
-        return Optional.of(addressBookOptional);
+        XmlSerializableAddressBook xmlAddressBook = XmlFileStorage.loadDataFromSaveFile(new File(filePath));
+        try {
+            return Optional.of(xmlAddressBook.toModelType());
+        } catch (IllegalValueException ive) {
+            logger.info("Illegal values found in " + addressBookFile + ": " + ive.getMessage());
+            throw new DataConversionException(ive);
+        }
     }
 
     @Override

--- a/src/main/java/seedu/address/storage/XmlSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/XmlSerializableAddressBook.java
@@ -56,4 +56,18 @@ public class XmlSerializableAddressBook {
         }
         return addressBook;
     }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof XmlSerializableAddressBook)) {
+            return false;
+        }
+
+        XmlSerializableAddressBook otherAb = (XmlSerializableAddressBook) other;
+        return persons.equals(otherAb.persons) && tags.equals(otherAb.tags);
+    }
 }

--- a/src/main/java/seedu/address/storage/XmlSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/XmlSerializableAddressBook.java
@@ -10,6 +10,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Person;
 import seedu.address.model.tag.Tag;
@@ -41,6 +42,23 @@ public class XmlSerializableAddressBook implements ReadOnlyAddressBook {
         this();
         persons.addAll(src.getPersonList().stream().map(XmlAdaptedPerson::new).collect(Collectors.toList()));
         tags.addAll(src.getTagList().stream().map(XmlAdaptedTag::new).collect(Collectors.toList()));
+    }
+
+    /**
+     * Converts this addressbook into the model's {@code AddressBook} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated or duplicates in the
+     * {@code XmlAdaptedPerson} or {@code XmlAdaptedTag}.
+     */
+    public AddressBook toModelType() throws IllegalValueException {
+        AddressBook addressBook = new AddressBook();
+        for (XmlAdaptedTag t : tags) {
+            addressBook.addTag(t.toModelType());
+        }
+        for (XmlAdaptedPerson p : persons) {
+            addressBook.addPerson(p.toModelType());
+        }
+        return addressBook;
     }
 
     @Override

--- a/src/main/java/seedu/address/storage/XmlSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/XmlSerializableAddressBook.java
@@ -7,19 +7,15 @@ import java.util.stream.Collectors;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
-import javafx.collections.FXCollections;
-import javafx.collections.ObservableList;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
-import seedu.address.model.person.Person;
-import seedu.address.model.tag.Tag;
 
 /**
  * An Immutable AddressBook that is serializable to XML format
  */
 @XmlRootElement(name = "addressbook")
-public class XmlSerializableAddressBook implements ReadOnlyAddressBook {
+public class XmlSerializableAddressBook {
 
     @XmlElement
     private List<XmlAdaptedPerson> persons;
@@ -60,33 +56,4 @@ public class XmlSerializableAddressBook implements ReadOnlyAddressBook {
         }
         return addressBook;
     }
-
-    @Override
-    public ObservableList<Person> getPersonList() {
-        final ObservableList<Person> persons = this.persons.stream().map(p -> {
-            try {
-                return p.toModelType();
-            } catch (IllegalValueException e) {
-                e.printStackTrace();
-                //TODO: better error handling
-                return null;
-            }
-        }).collect(Collectors.toCollection(FXCollections::observableArrayList));
-        return FXCollections.unmodifiableObservableList(persons);
-    }
-
-    @Override
-    public ObservableList<Tag> getTagList() {
-        final ObservableList<Tag> tags = this.tags.stream().map(t -> {
-            try {
-                return t.toModelType();
-            } catch (IllegalValueException e) {
-                e.printStackTrace();
-                //TODO: better error handling
-                return null;
-            }
-        }).collect(Collectors.toCollection(FXCollections::observableArrayList));
-        return FXCollections.unmodifiableObservableList(tags);
-    }
-
 }

--- a/src/test/data/XmlAddressBookStorageTest/invalidAndValidPersonAddressBook.xml
+++ b/src/test/data/XmlAddressBookStorageTest/invalidAndValidPersonAddressBook.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<addressbook>
+    <!-- Valid Person -->
+    <persons>
+        <name>Hans Muster</name>
+        <phone isPrivate="false">9482424</phone>
+        <email isPrivate="false">hans@example.com</email>
+        <address isPrivate="false">4th street</address>
+    </persons>
+    <!-- Person with invalid phone field -->
+    <persons>
+        <name>Hans Muster</name>
+        <phone isPrivate="false">948asdf2424</phone>
+        <email isPrivate="false">hans@example.com</email>
+        <address isPrivate="false">4th street</address>
+    </persons>
+</addressbook>

--- a/src/test/data/XmlAddressBookStorageTest/invalidPersonAddressBook.xml
+++ b/src/test/data/XmlAddressBookStorageTest/invalidPersonAddressBook.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<addressbook>
+    <!-- Person with invalid name field -->
+    <persons>
+        <name>Ha!ns Mu@ster</name>
+        <phone isPrivate="false">9482424</phone>
+        <email isPrivate="false">hans@example.com</email>
+        <address isPrivate="false">4th street</address>
+    </persons>
+</addressbook>

--- a/src/test/data/XmlSerializableAddressBookTest/invalidPersonAddressBook.xml
+++ b/src/test/data/XmlSerializableAddressBookTest/invalidPersonAddressBook.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<addressbook>
+    <!-- Person with invalid email field -->
+    <persons>
+        <name>Hans Muster</name>
+        <phone isPrivate="false">9482424</phone>
+        <email isPrivate="false">hans@exam!32ple</email>
+        <address isPrivate="false">4th street</address>
+    </persons>
+</addressbook>

--- a/src/test/data/XmlSerializableAddressBookTest/invalidTagAddressBook.xml
+++ b/src/test/data/XmlSerializableAddressBookTest/invalidTagAddressBook.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<addressbook>
+    <!-- Invalid tag -->
+    <tags>frie!nds</tags>
+</addressbook>

--- a/src/test/data/XmlSerializableAddressBookTest/typicalPersonsAddressBook.xml
+++ b/src/test/data/XmlSerializableAddressBookTest/typicalPersonsAddressBook.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- AddressBook save file which contains the same Person values as in
+{@code TypicalPersons#getTypicalAddressBook()}-->
+<addressbook>
+    <persons>
+        <name>Alice Pauline</name>
+        <phone>85355255</phone>
+        <email>alice@example.com</email>
+        <address>123, Jurong West Ave 6, #08-111</address>
+        <tagged>friends</tagged>
+    </persons>
+    <persons>
+        <name>Benson Meier</name>
+        <phone>98765432</phone>
+        <email>johnd@example.com</email>
+        <address>311, Clementi Ave 2, #02-25</address>
+        <tagged>owesMoney</tagged>
+        <tagged>friends</tagged>
+    </persons>
+    <persons>
+        <name>Carl Kurz</name>
+        <phone>95352563</phone>
+        <email>heinz@example.com</email>
+        <address>wall street</address>
+    </persons>
+    <persons>
+        <name>Daniel Meier</name>
+        <phone>87652533</phone>
+        <email>cornelia@example.com</email>
+        <address>10th street</address>
+    </persons>
+    <persons>
+        <name>Elle Meyer</name>
+        <phone>9482224</phone>
+        <email>werner@example.com</email>
+        <address>michegan ave</address>
+    </persons>
+    <persons>
+        <name>Fiona Kunz</name>
+        <phone>9482427</phone>
+        <email>lydia@example.com</email>
+        <address>little tokyo</address>
+    </persons>
+    <persons>
+        <name>George Best</name>
+        <phone>9482442</phone>
+        <email>anna@example.com</email>
+        <address>4th street</address>
+    </persons>
+    <tags>friends</tags>
+    <tags>owesMoney</tags>
+</addressbook>

--- a/src/test/java/seedu/address/commons/util/XmlUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/XmlUtilTest.java
@@ -83,8 +83,7 @@ public class XmlUtilTest {
         XmlSerializableAddressBook dataToWrite = new XmlSerializableAddressBook(new AddressBook());
         XmlUtil.saveDataToFile(TEMP_FILE, dataToWrite);
         XmlSerializableAddressBook dataFromFile = XmlUtil.getDataFromFile(TEMP_FILE, XmlSerializableAddressBook.class);
-        assertEquals(dataToWrite.toModelType().toString(), dataFromFile.toModelType().toString());
-        //TODO: use equality instead of string comparisons
+        assertEquals(dataToWrite, dataFromFile);
 
         AddressBookBuilder builder = new AddressBookBuilder(new AddressBook());
         dataToWrite = new XmlSerializableAddressBook(
@@ -92,6 +91,6 @@ public class XmlUtilTest {
 
         XmlUtil.saveDataToFile(TEMP_FILE, dataToWrite);
         dataFromFile = XmlUtil.getDataFromFile(TEMP_FILE, XmlSerializableAddressBook.class);
-        assertEquals(dataToWrite.toModelType().toString(), dataFromFile.toModelType().toString());
+        assertEquals(dataToWrite, dataFromFile);
     }
 }

--- a/src/test/java/seedu/address/commons/util/XmlUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/XmlUtilTest.java
@@ -54,7 +54,7 @@ public class XmlUtilTest {
 
     @Test
     public void getDataFromFile_validFile_validResult() throws Exception {
-        XmlSerializableAddressBook dataFromFile = XmlUtil.getDataFromFile(VALID_FILE, XmlSerializableAddressBook.class);
+        AddressBook dataFromFile = XmlUtil.getDataFromFile(VALID_FILE, XmlSerializableAddressBook.class).toModelType();
         assertEquals(9, dataFromFile.getPersonList().size());
         assertEquals(0, dataFromFile.getTagList().size());
     }
@@ -83,7 +83,7 @@ public class XmlUtilTest {
         XmlSerializableAddressBook dataToWrite = new XmlSerializableAddressBook(new AddressBook());
         XmlUtil.saveDataToFile(TEMP_FILE, dataToWrite);
         XmlSerializableAddressBook dataFromFile = XmlUtil.getDataFromFile(TEMP_FILE, XmlSerializableAddressBook.class);
-        assertEquals((new AddressBook(dataToWrite)).toString(), (new AddressBook(dataFromFile)).toString());
+        assertEquals(dataToWrite.toModelType().toString(), dataFromFile.toModelType().toString());
         //TODO: use equality instead of string comparisons
 
         AddressBookBuilder builder = new AddressBookBuilder(new AddressBook());
@@ -92,6 +92,6 @@ public class XmlUtilTest {
 
         XmlUtil.saveDataToFile(TEMP_FILE, dataToWrite);
         dataFromFile = XmlUtil.getDataFromFile(TEMP_FILE, XmlSerializableAddressBook.class);
-        assertEquals((new AddressBook(dataToWrite)).toString(), (new AddressBook(dataFromFile)).toString());
+        assertEquals(dataToWrite.toModelType().toString(), dataFromFile.toModelType().toString());
     }
 }

--- a/src/test/java/seedu/address/storage/XmlAddressBookStorageTest.java
+++ b/src/test/java/seedu/address/storage/XmlAddressBookStorageTest.java
@@ -61,6 +61,18 @@ public class XmlAddressBookStorageTest {
     }
 
     @Test
+    public void readAddressBook_invalidPersonAddressBook_throwDataConversionException() throws Exception {
+        thrown.expect(DataConversionException.class);
+        readAddressBook("invalidPersonAddressBook.xml");
+    }
+
+    @Test
+    public void readAddressBook_invalidAndValidPersonAddressBook_throwDataConversionException() throws Exception {
+        thrown.expect(DataConversionException.class);
+        readAddressBook("invalidAndValidPersonAddressBook.xml");
+    }
+
+    @Test
     public void readAndSaveAddressBook_allInOrder_success() throws Exception {
         String filePath = testFolder.getRoot().getPath() + "TempAddressBook.xml";
         AddressBook original = getTypicalAddressBook();

--- a/src/test/java/seedu/address/storage/XmlAddressBookStorageTest.java
+++ b/src/test/java/seedu/address/storage/XmlAddressBookStorageTest.java
@@ -104,20 +104,6 @@ public class XmlAddressBookStorageTest {
         saveAddressBook(null, "SomeFile.xml");
     }
 
-    @Test
-    public void getPersonList_modifyList_throwsUnsupportedOperationException() {
-        XmlSerializableAddressBook addressBook = new XmlSerializableAddressBook();
-        thrown.expect(UnsupportedOperationException.class);
-        addressBook.getPersonList().remove(0);
-    }
-
-    @Test
-    public void getTagList_modifyList_throwsUnsupportedOperationException() {
-        XmlSerializableAddressBook addressBook = new XmlSerializableAddressBook();
-        thrown.expect(UnsupportedOperationException.class);
-        addressBook.getTagList().remove(0);
-    }
-
     /**
      * Saves {@code addressBook} at the specified {@code filePath}.
      */

--- a/src/test/java/seedu/address/storage/XmlSerializableAddressBookTest.java
+++ b/src/test/java/seedu/address/storage/XmlSerializableAddressBookTest.java
@@ -1,0 +1,51 @@
+package seedu.address.storage;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.commons.util.FileUtil;
+import seedu.address.commons.util.XmlUtil;
+import seedu.address.model.AddressBook;
+import seedu.address.testutil.TypicalPersons;
+
+public class XmlSerializableAddressBookTest {
+
+    private static final String TEST_DATA_FOLDER = FileUtil.getPath("src/test/data/XmlSerializableAddressBookTest/");
+    private static final File TYPICAL_PERSONS_FILE = new File(TEST_DATA_FOLDER + "typicalPersonsAddressBook.xml");
+    private static final File INVALID_PERSON_FILE = new File(TEST_DATA_FOLDER + "invalidPersonAddressBook.xml");
+    private static final File INVALID_TAG_FILE = new File(TEST_DATA_FOLDER + "invalidTagAddressBook.xml");
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void toModelType_typicalPersonsFile_success() throws Exception {
+        XmlSerializableAddressBook dataFromFile = XmlUtil.getDataFromFile(TYPICAL_PERSONS_FILE,
+                XmlSerializableAddressBook.class);
+        AddressBook addressBookFromFile = dataFromFile.toModelType();
+        AddressBook typicalPersonsAddressBook = TypicalPersons.getTypicalAddressBook();
+        assertEquals(addressBookFromFile, typicalPersonsAddressBook);
+    }
+
+    @Test
+    public void toModelType_invalidPersonFile_throwsIllegalValueException() throws Exception {
+        XmlSerializableAddressBook dataFromFile = XmlUtil.getDataFromFile(INVALID_PERSON_FILE,
+                XmlSerializableAddressBook.class);
+        thrown.expect(IllegalValueException.class);
+        dataFromFile.toModelType();
+    }
+
+    @Test
+    public void toModelType_invalidTagFile_throwsIllegalValueException() throws Exception {
+        XmlSerializableAddressBook dataFromFile = XmlUtil.getDataFromFile(INVALID_TAG_FILE,
+                XmlSerializableAddressBook.class);
+        thrown.expect(IllegalValueException.class);
+        dataFromFile.toModelType();
+    }
+}


### PR DESCRIPTION
Fixes #749, and partly fixes #725

```
XmlSerializableAddressBook does not have a method to convert itself to
an AddressBook object. It implements ReadOnlyAddressBook and has
getPersonList() and getTagList() methods, which the caller uses to
create an AddressBook object.

By implementing ReadOnlyAddressBook, the overridden getPersonList()
and getTagList() methods are unable to throw IllegalValueException to
higher level components for error handling if there's errors in the
.xml save file.

Let's implement a toModelType() method in XmlSerializableAddressBook
to allow the XmlSerializableAddressBook to convert itself to an 
AddressBook and remove it's implementation of ReadOnlyAddressBook.
Let's also override the equals(Object) method in XmlAdaptedPerson,
XmlAdaptedTag and XmlSerializableAddressBook
```