### PR TITLE
Email regex validation does not accept `+` #743

### DIFF
--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -4,14 +4,28 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
 /**
- * Represents a Person's phone number in the address book.
+ * Represents a Person's email in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidEmail(String)}
  */
 public class Email {
 
-    public static final String MESSAGE_EMAIL_CONSTRAINTS =
-            "Person emails should be 2 alphanumeric/period strings separated by '@'";
-    public static final String EMAIL_VALIDATION_REGEX = "[\\w\\.]+@[\\w\\.]+";
+    private static  final String SPECIAL_CHARACTERS = "!#$%&'*+/=?`{|}~^.-";
+    public static final String MESSAGE_EMAIL_CONSTRAINTS = "Person emails should be of the format local-part@domain "
+            + "and adhere to the following constraints:\n"
+            + "1. The local-part should only contain alphanumeric characters and these special characters, excluding "
+            + "the parentheses, (" + SPECIAL_CHARACTERS + ") .\n"
+            + "2. This is followed by a '@' and then a domain name. "
+            + "The domain name must:\n"
+            + "    - be at least 2 characters long\n"
+            + "    - start and end with alphanumeric characters\n"
+            + "    - consist of alphanumeric characters, a period or a hyphen for the characters in between, if any.";
+    // alphanumeric and special characters
+    private static final String LOCAL_PART_REGEX = "^[\\w" + SPECIAL_CHARACTERS + "]+";
+    private static final String DOMAIN_FIRST_CHARACTER_REGEX = "[^\\W_]"; // alphanumeric characters except underscore
+    private static final String DOMAIN_MIDDLE_REGEX = "[a-zA-Z0-9.-]*"; // alphanumeric, period and hyphen
+    private static final String DOMAIN_LAST_CHARACTER_REGEX = "[^\\W_]$";
+    public static final String EMAIL_VALIDATION_REGEX = LOCAL_PART_REGEX + "@"
+            + DOMAIN_FIRST_CHARACTER_REGEX + DOMAIN_MIDDLE_REGEX + DOMAIN_LAST_CHARACTER_REGEX;
 
     public final String value;
 

--- a/src/test/java/seedu/address/model/person/EmailTest.java
+++ b/src/test/java/seedu/address/model/person/EmailTest.java
@@ -35,22 +35,28 @@ public class EmailTest {
         assertFalse(Email.isValidEmail("peterjack@")); // missing domain name
 
         // invalid parts
-        assertFalse(Email.isValidEmail("-@example.com")); // invalid local part
         assertFalse(Email.isValidEmail("peterjack@-")); // invalid domain name
+        assertFalse(Email.isValidEmail("peterjack@exam_ple.com")); // underscore in domain name
         assertFalse(Email.isValidEmail("peter jack@example.com")); // spaces in local part
         assertFalse(Email.isValidEmail("peterjack@exam ple.com")); // spaces in domain name
+        assertFalse(Email.isValidEmail(" peterjack@example.com")); // leading space
+        assertFalse(Email.isValidEmail("peterjack@example.com ")); // trailing space
         assertFalse(Email.isValidEmail("peterjack@@example.com")); // double '@' symbol
         assertFalse(Email.isValidEmail("peter@jack@example.com")); // '@' symbol in local part
         assertFalse(Email.isValidEmail("peterjack@example@com")); // '@' symbol in domain name
+        assertFalse(Email.isValidEmail("peterjack@.example.com")); // domain name starts with a period
+        assertFalse(Email.isValidEmail("peterjack@example.com.")); // domain name ends with a period
+        assertFalse(Email.isValidEmail("peterjack@-example.com")); // domain name starts with a hyphen
+        assertFalse(Email.isValidEmail("peterjack@example.com-")); // domain name ends with a hyphen
 
         // valid email
         assertTrue(Email.isValidEmail("PeterJack_1190@example.com"));
-        assertTrue(Email.isValidEmail("a@b"));  // minimal
+        assertTrue(Email.isValidEmail("a@bc"));  // minimal
         assertTrue(Email.isValidEmail("test@localhost"));   // alphabets only
+        assertTrue(Email.isValidEmail("!#$%&'*+/=?`{|}~^.-@example.org")); // special characters local part
         assertTrue(Email.isValidEmail("123@145"));  // numeric local part and domain name
-        assertTrue(Email.isValidEmail("a1@example1.com"));  // mixture of alphanumeric and dot characters
-        assertTrue(Email.isValidEmail("_user_@_e_x_a_m_p_l_e_.com_"));    // underscores
-        assertTrue(Email.isValidEmail("peter_jack@very_very_very_long_example.com"));   // long domain name
+        assertTrue(Email.isValidEmail("a1+be!@example1.com")); // mixture of alphanumeric and special characters
+        assertTrue(Email.isValidEmail("peter_jack@very-very-very-long-example.com"));   // long domain name
         assertTrue(Email.isValidEmail("if.you.dream.it_you.can.do.it@example.com"));    // long local part
     }
 }


### PR DESCRIPTION
Fixes #743 

Do note that the domain name has to be 2 characters long so that it does not start and end with dots or hyphens.
 
On a side note, the updated email regex just allows the use of more characters to solve the issue. Should a more restrictive validation be used instead?

For instance this regex,
```
^[\\w!#$%&’*+/=?`{|}~^-]+(?:\\.[\\w!#$%&’*+/=?`{|}~^-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,6}$
```
sets a predefined length for the top-level domain name (which would be **edu** in someone@u.nus.edu) and restricts trailing and consecutive dots.