### PR TITLE
HelpWindow: help window stays open even after exiting by clicking the close button #826

### DIFF
--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -12,7 +12,7 @@
 <?import javafx.scene.layout.VBox?>
 
 <fx:root type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1"
-         minWidth="450" minHeight="600">
+         minWidth="450" minHeight="600" onCloseRequest="#handleExit">
   <icons>
     <Image url="@/images/address_book_32.png" />
   </icons>

--- a/src/test/java/seedu/address/ui/MainWindowCloseTest.java
+++ b/src/test/java/seedu/address/ui/MainWindowCloseTest.java
@@ -1,0 +1,83 @@
+package seedu.address.ui;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.testfx.api.FxToolkit;
+
+import guitests.guihandles.StageHandle;
+import javafx.stage.Stage;
+import javafx.stage.WindowEvent;
+import seedu.address.commons.core.Config;
+import seedu.address.commons.events.ui.ExitAppRequestEvent;
+import seedu.address.logic.LogicManager;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.ui.testutil.EventsCollectorRule;
+
+/**
+ * Contains tests for closing of the {@code MainWindow}.
+ */
+public class MainWindowCloseTest extends GuiUnitTest {
+    @Rule
+    public final EventsCollectorRule eventsCollectorRule = new EventsCollectorRule();
+
+    private MainWindow mainWindow;
+    private EmptyMainWindowHandle mainWindowHandle;
+    private Stage stage;
+
+    @Before
+    public void setUp() throws Exception {
+        FxToolkit.setupStage(stage -> {
+            this.stage = stage;
+            mainWindow = new MainWindow(stage, new Config(), new UserPrefs(), new LogicManager(new ModelManager()));
+            mainWindowHandle = new EmptyMainWindowHandle(stage);
+
+            stage.setScene(mainWindow.getRoot().getScene());
+            mainWindowHandle.focus();
+        });
+        FxToolkit.showStage();
+    }
+
+    @Test
+    public void close_menuBarExitButton_exitAppRequestEventPosted() {
+        mainWindowHandle.clickOnMenuExitButton();
+        assertTrue(eventsCollectorRule.eventsCollector.getMostRecent() instanceof ExitAppRequestEvent);
+        assertTrue(eventsCollectorRule.eventsCollector.getSize() == 1);
+    }
+
+    @Test
+    public void close_externalRequest_exitAppRequestEventPosted() {
+        mainWindowHandle.closeMainWindowExternally();
+        assertTrue(eventsCollectorRule.eventsCollector.getMostRecent() instanceof ExitAppRequestEvent);
+        assertTrue(eventsCollectorRule.eventsCollector.getSize() == 1);
+    }
+
+    /**
+     * A handle for an empty {@code MainWindow}. The components in {@code MainWindow} are not initialized.
+     */
+    private class EmptyMainWindowHandle extends StageHandle {
+
+        private EmptyMainWindowHandle(Stage stage) {
+            super(stage);
+        }
+
+        /**
+         * Closes the {@code MainWindow} by clicking on the menu bar's exit button.
+         */
+        private void clickOnMenuExitButton() {
+            guiRobot.clickOn("File");
+            guiRobot.clickOn("Exit");
+        }
+
+        /**
+         * Closes the {@code MainWindow} through an external request {@code MainWindow} (e.g pressing the 'X' button on
+         * the {@code MainWindow} or closing the app through the taskbar).
+         */
+        private void closeMainWindowExternally() {
+            guiRobot.interact(() -> stage.fireEvent(new WindowEvent(stage, WindowEvent.WINDOW_CLOSE_REQUEST)));
+        }
+    }
+}


### PR DESCRIPTION
Fixes #826 
```
The MainWindow does not have an event handler to handle external
requests (such as the close button or through the taskbar) to close
the MainWindow.

This may cause the app to not close properly since MainApp#stop() is
not called as the ExitAppRequestEvent is not raised. MainApp#stop() is
the method used to call Platform#exit() and System#exit(int) which
closes our app and all remaining open windows. Thus, if MainApp#stop()
is not called, the app may continue to run even after the MainWindow is
closed, causing existing HelpWindows to remain open even when the user
expects the app to stop.

According to the life-cycle section in the documentation on JavaFX
Application[1], the app will only finish and call MainApp#stop() when
the app either calls Platform#exit() or when the last window has been
closed. Thus, should there be any HelpWindows still opened, the app
will continue running, causing those HelpWindows to remain open.

Let's add an event handler for the onCloseRequest event in the root of
MainWindow.fxml. This event will call MainWindow#handleExit(), which
raises an ExitAppRequestEvent, when there is an external request to
close the app.

EmptyMainWindowHandle does not contain a close button, thus to test if
an ExitAppRequestEvent was raised, we fire a
WindowEvent#WINDOW_CLOSE_REQUEST event which will trigger the
onCloseRequest event.

[1] JavaFx documentation for Application:
https://docs.oracle.com/javafx/2/api/javafx/application/Application.html
```