### PR TITLE
build.gradle: update to build project using Java 9 #374

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 matrix:
   include:
-    - jdk: oraclejdk8
+    - jdk: oraclejdk9
 
 script: >-
     ./config/travis/run-checks.sh &&
@@ -17,7 +17,7 @@ deploy:
 addons:
   apt:
     packages:
-      - oracle-java8-installer
+      - oracle-java9-installer
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ test_script:
     - appveyor-retry gradlew.bat --no-daemon headless allTests
 
 environment:
-    JAVA_HOME: C:\Program Files\Java\jdk1.8.0  # Use 64-bit Java
+    JAVA_HOME: C:\Program Files\Java\jdk9  # Use 64-bit Java
 
 # Files/folders to preserve between builds to speed them up
 cache:

--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ shadowJar {
 }
 
 task wrapper(type: Wrapper) {
-    gradleVersion = '2.12'
+    gradleVersion = '4.6'
 }
 
 task coverage(type: JacocoReport) {

--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,8 @@ plugins {
 // Specifies the entry point of the application
 mainClassName = 'seedu.address.MainApp'
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
+sourceCompatibility = JavaVersion.VERSION_1_9
+targetCompatibility = JavaVersion.VERSION_1_9
 
 repositories {
     mavenCentral()
@@ -39,21 +39,29 @@ jacocoTestReport {
 }
 
 dependencies {
-    String testFxVersion = '4.0.7-alpha'
+    String testFxVersion = '4.0.12-alpha'
 
     compile group: 'org.fxmisc.easybind', name: 'easybind', version: '1.0.3'
     compile group: 'org.controlsfx', name: 'controlsfx', version: '8.40.11'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.7.0'
     compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.7.4'
     compile group: 'com.google.guava', name: 'guava', version: '19.0'
+    compile group: 'javax.xml.bind', name: 'jaxb-api', version: '2.2.8'
+    compile group: 'com.sun.xml.bind', name: 'jaxb-impl', version: '2.3.0'
+    compile group: 'com.sun.xml.bind', name: 'jaxb-core', version: '2.3.0'
+    compile group: 'javax.activation', name: 'activation', version: '1.1.1'
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
-    testCompile group: 'org.testfx', name: 'testfx-core', version: testFxVersion
+    testCompile group: 'org.testfx', name: 'testfx-core', version: testFxVersion, {
+        exclude group: 'org.testfx', module: 'testfx-internal-java8'
+    }
     testCompile group: 'org.testfx', name: 'testfx-junit', version: testFxVersion
-    testCompile group: 'org.testfx', name: 'testfx-legacy', version: testFxVersion, {
+    testCompile group: 'org.testfx', name: 'testfx-legacy', version: '4.0.8-alpha', {
         exclude group: 'junit', module: 'junit'
     }
-    testCompile group: 'org.testfx', name: 'openjfx-monocle', version: '1.8.0_20'
+
+    testRuntime group: 'org.testfx', name: 'testfx-internal-java9', version: testFxVersion
+    testRuntime group: 'org.testfx', name: 'openjfx-monocle', version: 'jdk-9+181'
 }
 
 shadowJar {

--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -18,13 +18,7 @@ By: `Team SE-EDU`      Since: `Jun 2016`      Licence: `MIT`
 
 === Prerequisites
 
-. *JDK `1.8.0_60`* or later
-+
-[NOTE]
-Having any Java 8 version is not enough. +
-This app will not work with earlier versions of Java 8.
-+
-
+. *JDK `9`* or later
 . *IntelliJ* IDE
 +
 [NOTE]
@@ -849,7 +843,7 @@ _{More to be added}_
 [appendix]
 == Non Functional Requirements
 
-.  Should work on any <<mainstream-os,mainstream OS>> as long as it has Java `1.8.0_60` or higher installed.
+.  Should work on any <<mainstream-os,mainstream OS>> as long as it has Java `9` or higher installed.
 .  Should be able to hold up to 1000 persons without a noticeable sluggishness in performance for typical usage.
 .  A user with above average typing speed for regular English text (i.e. not code, not system admin commands) should be able to accomplish most of the tasks faster using commands than using the mouse.
 

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -21,12 +21,7 @@ AddressBook Level 4 (AB4) is for those who *prefer to use a desktop app for mana
 
 == Quick Start
 
-.  Ensure you have Java version `1.8.0_60` or later installed in your Computer.
-+
-[NOTE]
-Having any Java 8 version is not enough. +
-This app will not work with earlier versions of Java 8.
-+
+.  Ensure you have Java version `9` or later installed in your Computer.
 .  Download the latest `addressbook.jar` link:{repoURL}/releases[here].
 .  Copy the file to the folder you want to use as the home folder for your Address Book.
 .  Double-click the file to start the app. The GUI should appear in a few seconds.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 org.gradle.daemon=true
 org.gradle.parallel=false
-org.gradle.jvmargs=-XX:MaxPermSize=512m -XX:+CMSClassUnloadingEnabled -XX:+CMSPermGenSweepingEnabled -XX:+HeapDumpOnOutOfMemoryError -Xmx1024m -Dfile.encoding=utf-8
+org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Xmx1024m -Dfile.encoding=utf-8

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.12-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip


### PR DESCRIPTION
Fixes #374, part of #681 and #706.

Proposed merge commit message:
```
build.gradle: upgrade to use Java 9

The project currently runs on Java 8.

We should ensure compatibility with the latest public version as soon
as it is out.

Let's upgrade the project to run on Java 9.
```