### PR TITLE
HelpWindow: multiple help windows can be opened #819

### DIFF
--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -61,4 +61,18 @@ public class HelpWindow extends UiPart<Stage> {
         logger.fine("Showing help page about the application.");
         getRoot().show();
     }
+
+    /**
+     * Returns true if the help window is currently being shown.
+     */
+    public boolean isShowing() {
+        return getRoot().isShowing();
+    }
+
+    /**
+     * Focuses on the help window.
+     */
+    public void focus() {
+        getRoot().requestFocus();
+    }
 }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -38,6 +38,7 @@ public class MainWindow extends UiPart<Stage> {
     private PersonListPanel personListPanel;
     private Config config;
     private UserPrefs prefs;
+    private HelpWindow helpWindow;
 
     @FXML
     private StackPane browserPlaceholder;
@@ -72,6 +73,8 @@ public class MainWindow extends UiPart<Stage> {
 
         setAccelerators();
         registerAsAnEventHandler(this);
+
+        helpWindow = new HelpWindow();
     }
 
     public Stage getPrimaryStage() {
@@ -165,7 +168,6 @@ public class MainWindow extends UiPart<Stage> {
      */
     @FXML
     public void handleHelp() {
-        HelpWindow helpWindow = new HelpWindow();
         helpWindow.show();
     }
 

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -164,11 +164,15 @@ public class MainWindow extends UiPart<Stage> {
     }
 
     /**
-     * Opens the help window.
+     * Opens the help window or focuses on it if it's already opened.
      */
     @FXML
     public void handleHelp() {
-        helpWindow.show();
+        if (!helpWindow.isShowing()) {
+            helpWindow.show();
+        } else {
+            helpWindow.focus();
+        }
     }
 
     void show() {

--- a/src/test/java/guitests/GuiRobot.java
+++ b/src/test/java/guitests/GuiRobot.java
@@ -75,9 +75,16 @@ public class GuiRobot extends FxRobot {
      * Returns true if the window with {@code stageTitle} is currently open.
      */
     public boolean isWindowShown(String stageTitle) {
-        return listTargetWindows().stream()
+        return getNumberOfWindowsShown(stageTitle) >= 1;
+    }
+
+    /**
+     * Returns the number of windows with {@code stageTitle} that are currently open.
+     */
+    public int getNumberOfWindowsShown(String stageTitle) {
+        return (int) listTargetWindows().stream()
                 .filter(window -> window instanceof Stage && ((Stage) window).getTitle().equals(stageTitle))
-                .count() >= 1;
+                .count();
     }
 
     /**

--- a/src/test/java/guitests/guihandles/StageHandle.java
+++ b/src/test/java/guitests/guihandles/StageHandle.java
@@ -44,6 +44,13 @@ public abstract class StageHandle {
     }
 
     /**
+     * Returns true if currently focusing on this stage.
+     */
+    public boolean isFocused() {
+        return stage.isFocused();
+    }
+
+    /**
      * Retrieves the {@code query} node owned by the {@code stage}.
      *
      * @param query name of the CSS selector for the node to retrieve.

--- a/src/test/java/seedu/address/ui/HelpWindowTest.java
+++ b/src/test/java/seedu/address/ui/HelpWindowTest.java
@@ -1,6 +1,8 @@
 package seedu.address.ui;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static seedu.address.ui.HelpWindow.USERGUIDE_FILE_PATH;
 
 import java.net.URL;
@@ -29,5 +31,26 @@ public class HelpWindowTest extends GuiUnitTest {
     public void display() {
         URL expectedHelpPage = HelpWindow.class.getResource(USERGUIDE_FILE_PATH);
         assertEquals(expectedHelpPage, helpWindowHandle.getLoadedUrl());
+    }
+
+    @Test
+    public void isShowing_helpWindowIsShowing_returnsTrue() {
+        guiRobot.interact(helpWindow::show);
+        assertTrue(helpWindow.isShowing());
+    }
+
+    @Test
+    public void isShowing_helpWindowIsHiding_returnsFalse() {
+        guiRobot.interact(helpWindow.getRoot()::hide);
+        assertFalse(helpWindow.isShowing());
+    }
+
+    @Test
+    public void focus_helpWindowNotFocused_focused() {
+        guiRobot.interact(helpWindow::show);
+        assertFalse(helpWindow.getRoot().isFocused());
+
+        guiRobot.interact(helpWindow::focus);
+        assertTrue(helpWindow.getRoot().isFocused());
     }
 }

--- a/src/test/java/systemtests/HelpCommandSystemTest.java
+++ b/src/test/java/systemtests/HelpCommandSystemTest.java
@@ -73,6 +73,19 @@ public class HelpCommandSystemTest extends AddressBookSystemTest {
         assertNotEquals(StatusBarFooter.SYNC_STATUS_INITIAL, getStatusBarFooter().getSyncStatus());
     }
 
+    @Test
+    public void help_multipleCommands_onlyOneHelpWindowOpen() {
+        getMainMenu().openHelpWindowUsingMenu();
+
+        getMainWindowHandle().focus();
+        getMainMenu().openHelpWindowUsingAccelerator();
+
+        getMainWindowHandle().focus();
+        executeCommand(HelpCommand.COMMAND_WORD);
+
+        assertEquals(1, guiRobot.getNumberOfWindowsShown(HelpWindowHandle.HELP_WINDOW_TITLE));
+    }
+
     /**
      * Asserts that the help window is open, and closes it after checking.
      */


### PR DESCRIPTION
Fixes #819.
```
MainWindow creates a new HelpWindow instance and shows it whenever
MainWindow#handleHelp() is called.

This allows multiple help windows to be opened at the same time by
executing HelpCommand, pressing Help menu button or F1 multiple times.

Multiple help windows should be disallowed since each help window
are exactly the same thus having extra copies is unnecessary.

Let's update MainWindow to hold and show a single HelpWindow instance.
```

