### PR TITLE
Use java.nio.file for file/path handling #750

### DIFF
--- a/src/main/java/seedu/address/AppParameters.java
+++ b/src/main/java/seedu/address/AppParameters.java
@@ -1,22 +1,28 @@
 package seedu.address;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Objects;
+import java.util.logging.Logger;
 
 import javafx.application.Application;
+import seedu.address.commons.core.LogsCenter;
+import seedu.address.commons.util.FileUtil;
 
 /**
  * Represents the parsed command-line parameters given to the application.
  */
 public class AppParameters {
+    private static final Logger logger = LogsCenter.getLogger(AppParameters.class);
 
-    private String configPath;
+    private Path configPath;
 
-    public String getConfigPath() {
+    public Path getConfigPath() {
         return configPath;
     }
 
-    public void setConfigPath(String configPath) {
+    public void setConfigPath(Path configPath) {
         this.configPath = configPath;
     }
 
@@ -28,7 +34,11 @@ public class AppParameters {
         Map<String, String> namedParameters = parameters.getNamed();
 
         String configPathParameter = namedParameters.get("config");
-        appParameters.setConfigPath(configPathParameter);
+        if (configPathParameter != null && !FileUtil.isValidPath(configPathParameter)) {
+            logger.warning("Invalid config path " + configPathParameter + ". Using default config path.");
+            configPathParameter = null;
+        }
+        appParameters.setConfigPath(configPathParameter != null ? Paths.get(configPathParameter) : null);
 
         return appParameters;
     }

--- a/src/main/java/seedu/address/AppParameters.java
+++ b/src/main/java/seedu/address/AppParameters.java
@@ -1,0 +1,54 @@
+package seedu.address;
+
+import java.util.Map;
+import java.util.Objects;
+
+import javafx.application.Application;
+
+/**
+ * Represents the parsed command-line parameters given to the application.
+ */
+public class AppParameters {
+
+    private String configPath;
+
+    public String getConfigPath() {
+        return configPath;
+    }
+
+    public void setConfigPath(String configPath) {
+        this.configPath = configPath;
+    }
+
+    /**
+     * Parses the application command-line parameters.
+     */
+    public static AppParameters parse(Application.Parameters parameters) {
+        AppParameters appParameters = new AppParameters();
+        Map<String, String> namedParameters = parameters.getNamed();
+
+        String configPathParameter = namedParameters.get("config");
+        appParameters.setConfigPath(configPathParameter);
+
+        return appParameters;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof AppParameters)) {
+            return false;
+        }
+
+        AppParameters otherAppParameters = (AppParameters) other;
+        return Objects.equals(getConfigPath(), otherAppParameters.getConfigPath());
+    }
+
+    @Override
+    public int hashCode() {
+        return configPath.hashCode();
+    }
+}

--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -1,7 +1,6 @@
 package seedu.address;
 
 import java.io.IOException;
-import java.util.Map;
 import java.util.Optional;
 import java.util.logging.Logger;
 
@@ -57,7 +56,8 @@ public class MainApp extends Application {
         logger.info("=============================[ Initializing AddressBook ]===========================");
         super.init();
 
-        config = initConfig(getApplicationParameter("config"));
+        AppParameters appParameters = AppParameters.parse(getParameters());
+        config = initConfig(appParameters.getConfigPath());
 
         UserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(config.getUserPrefsFilePath());
         userPrefs = initPrefs(userPrefsStorage);
@@ -73,11 +73,6 @@ public class MainApp extends Application {
         ui = new UiManager(logic, config, userPrefs);
 
         initEventsCenter();
-    }
-
-    private String getApplicationParameter(String parameterName) {
-        Map<String, String> applicationParameters = getParameters().getNamed();
-        return applicationParameters.get(parameterName);
     }
 
     /**

--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -1,6 +1,7 @@
 package seedu.address;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Optional;
 import java.util.logging.Logger;
 
@@ -109,9 +110,9 @@ public class MainApp extends Application {
      * The default file path {@code Config#DEFAULT_CONFIG_FILE} will be used instead
      * if {@code configFilePath} is null.
      */
-    protected Config initConfig(String configFilePath) {
+    protected Config initConfig(Path configFilePath) {
         Config initializedConfig;
-        String configFilePathUsed;
+        Path configFilePathUsed;
 
         configFilePathUsed = Config.DEFAULT_CONFIG_FILE;
 
@@ -146,7 +147,7 @@ public class MainApp extends Application {
      * reading from the file.
      */
     protected UserPrefs initPrefs(UserPrefsStorage storage) {
-        String prefsFilePath = storage.getUserPrefsFilePath();
+        Path prefsFilePath = storage.getUserPrefsFilePath();
         logger.info("Using prefs file : " + prefsFilePath);
 
         UserPrefs initializedPrefs;

--- a/src/main/java/seedu/address/commons/core/Config.java
+++ b/src/main/java/seedu/address/commons/core/Config.java
@@ -1,5 +1,7 @@
 package seedu.address.commons.core;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Objects;
 import java.util.logging.Level;
 
@@ -8,12 +10,12 @@ import java.util.logging.Level;
  */
 public class Config {
 
-    public static final String DEFAULT_CONFIG_FILE = "config.json";
+    public static final Path DEFAULT_CONFIG_FILE = Paths.get("config.json");
 
     // Config values customizable through config file
     private String appTitle = "Address App";
     private Level logLevel = Level.INFO;
-    private String userPrefsFilePath = "preferences.json";
+    private Path userPrefsFilePath = Paths.get("preferences.json");
 
     public String getAppTitle() {
         return appTitle;
@@ -31,11 +33,11 @@ public class Config {
         this.logLevel = logLevel;
     }
 
-    public String getUserPrefsFilePath() {
+    public Path getUserPrefsFilePath() {
         return userPrefsFilePath;
     }
 
-    public void setUserPrefsFilePath(String userPrefsFilePath) {
+    public void setUserPrefsFilePath(Path userPrefsFilePath) {
         this.userPrefsFilePath = userPrefsFilePath;
     }
 

--- a/src/main/java/seedu/address/commons/util/ConfigUtil.java
+++ b/src/main/java/seedu/address/commons/util/ConfigUtil.java
@@ -1,6 +1,7 @@
 package seedu.address.commons.util;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Optional;
 
 import seedu.address.commons.core.Config;
@@ -11,11 +12,11 @@ import seedu.address.commons.exceptions.DataConversionException;
  */
 public class ConfigUtil {
 
-    public static Optional<Config> readConfig(String configFilePath) throws DataConversionException {
+    public static Optional<Config> readConfig(Path configFilePath) throws DataConversionException {
         return JsonUtil.readJsonFile(configFilePath, Config.class);
     }
 
-    public static void saveConfig(Config config, String configFilePath) throws IOException {
+    public static void saveConfig(Config config, Path configFilePath) throws IOException {
         JsonUtil.saveJsonFile(config, configFilePath);
     }
 

--- a/src/main/java/seedu/address/commons/util/FileUtil.java
+++ b/src/main/java/seedu/address/commons/util/FileUtil.java
@@ -45,19 +45,16 @@ public class FileUtil {
     }
 
     /**
-     * Creates a file if it does not exist along with its missing parent directories
-     *
-     * @return true if file is created, false if file already exists
+     * Creates a file if it does not exist along with its missing parent directories.
      */
-    public static boolean createFile(Path file) throws IOException {
+    public static void createFile(Path file) throws IOException {
         if (Files.exists(file)) {
-            return false;
+            return;
         }
 
         createParentDirsOfFile(file);
 
         Files.createFile(file);
-        return true;
     }
 
     /**

--- a/src/main/java/seedu/address/commons/util/FileUtil.java
+++ b/src/main/java/seedu/address/commons/util/FileUtil.java
@@ -5,7 +5,9 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 /**
  * Writes and reads files
@@ -16,6 +18,20 @@ public class FileUtil {
 
     public static boolean isFileExists(Path file) {
         return Files.exists(file) && Files.isRegularFile(file);
+    }
+
+    /**
+     * Returns true if {@code path} can be converted into a {@code Path} via {@link Paths#get(String)},
+     * otherwise returns false.
+     * @param path A string representing the file path. Cannot be null.
+     */
+    public static boolean isValidPath(String path) {
+        try {
+            Paths.get(path);
+        } catch (InvalidPathException ipe) {
+            return false;
+        }
+        return true;
     }
 
     /**

--- a/src/main/java/seedu/address/commons/util/FileUtil.java
+++ b/src/main/java/seedu/address/commons/util/FileUtil.java
@@ -5,6 +5,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 
 /**
  * Writes and reads files
@@ -13,15 +14,15 @@ public class FileUtil {
 
     private static final String CHARSET = "UTF-8";
 
-    public static boolean isFileExists(File file) {
-        return file.exists() && file.isFile();
+    public static boolean isFileExists(Path file) {
+        return Files.exists(file) && Files.isRegularFile(file);
     }
 
     /**
      * Creates a file if it does not exist along with its missing parent directories.
      * @throws IOException if the file or directory cannot be created.
      */
-    public static void createIfMissing(File file) throws IOException {
+    public static void createIfMissing(Path file) throws IOException {
         if (!isFileExists(file)) {
             createFile(file);
         }
@@ -32,14 +33,15 @@ public class FileUtil {
      *
      * @return true if file is created, false if file already exists
      */
-    public static boolean createFile(File file) throws IOException {
-        if (file.exists()) {
+    public static boolean createFile(Path file) throws IOException {
+        if (Files.exists(file)) {
             return false;
         }
 
         createParentDirsOfFile(file);
 
-        return file.createNewFile();
+        Files.createFile(file);
+        return true;
     }
 
     /**
@@ -48,36 +50,37 @@ public class FileUtil {
      * @param dir the directory to be created; assumed not null
      * @throws IOException if the directory or a parent directory cannot be created
      */
-    public static void createDirs(File dir) throws IOException {
-        if (!dir.exists() && !dir.mkdirs()) {
-            throw new IOException("Failed to make directories of " + dir.getName());
+    public static void createDirs(Path dir) throws IOException {
+        if (Files.exists(dir)) {
+            return;
         }
+        Files.createDirectories(dir);
     }
 
     /**
      * Creates parent directories of file if it has a parent directory
      */
-    public static void createParentDirsOfFile(File file) throws IOException {
-        File parentDir = file.getParentFile();
+    public static void createParentDirsOfFile(Path file) throws IOException {
+        Path parentDir = file.getParent();
 
         if (parentDir != null) {
-            createDirs(parentDir);
+            Files.createDirectories(parentDir);
         }
     }
 
     /**
      * Assumes file exists
      */
-    public static String readFromFile(File file) throws IOException {
-        return new String(Files.readAllBytes(file.toPath()), CHARSET);
+    public static String readFromFile(Path file) throws IOException {
+        return new String(Files.readAllBytes(file), CHARSET);
     }
 
     /**
      * Writes given string to a file.
      * Will create the file if it does not exist yet.
      */
-    public static void writeToFile(File file, String content) throws IOException {
-        Files.write(file.toPath(), content.getBytes(CHARSET));
+    public static void writeToFile(Path file, String content) throws IOException {
+        Files.write(file, content.getBytes(CHARSET));
     }
 
     /**

--- a/src/main/java/seedu/address/commons/util/FileUtil.java
+++ b/src/main/java/seedu/address/commons/util/FileUtil.java
@@ -1,8 +1,5 @@
 package seedu.address.commons.util;
 
-import static seedu.address.commons.util.AppUtil.checkArgument;
-
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
@@ -58,19 +55,6 @@ public class FileUtil {
     }
 
     /**
-     * Creates the given directory along with its parent directories
-     *
-     * @param dir the directory to be created; assumed not null
-     * @throws IOException if the directory or a parent directory cannot be created
-     */
-    public static void createDirs(Path dir) throws IOException {
-        if (Files.exists(dir)) {
-            return;
-        }
-        Files.createDirectories(dir);
-    }
-
-    /**
      * Creates parent directories of file if it has a parent directory
      */
     public static void createParentDirsOfFile(Path file) throws IOException {
@@ -94,16 +78,6 @@ public class FileUtil {
      */
     public static void writeToFile(Path file, String content) throws IOException {
         Files.write(file, content.getBytes(CHARSET));
-    }
-
-    /**
-     * Converts a string to a platform-specific file path
-     * @param pathWithForwardSlash A String representing a file path but using '/' as the separator
-     * @return {@code pathWithForwardSlash} but '/' replaced with {@code File.separator}
-     */
-    public static String getPath(String pathWithForwardSlash) {
-        checkArgument(pathWithForwardSlash.contains("/"));
-        return pathWithForwardSlash.replace("/", File.separator);
     }
 
 }

--- a/src/main/java/seedu/address/commons/util/JsonUtil.java
+++ b/src/main/java/seedu/address/commons/util/JsonUtil.java
@@ -2,8 +2,10 @@ package seedu.address.commons.util;
 
 import static java.util.Objects.requireNonNull;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -38,11 +40,11 @@ public class JsonUtil {
                     .addSerializer(Level.class, new ToStringSerializer())
                     .addDeserializer(Level.class, new LevelDeserializer(Level.class)));
 
-    static <T> void serializeObjectToJsonFile(File jsonFile, T objectToSerialize) throws IOException {
+    static <T> void serializeObjectToJsonFile(Path jsonFile, T objectToSerialize) throws IOException {
         FileUtil.writeToFile(jsonFile, toJsonString(objectToSerialize));
     }
 
-    static <T> T deserializeObjectFromJsonFile(File jsonFile, Class<T> classOfObjectToDeserialize)
+    static <T> T deserializeObjectFromJsonFile(Path jsonFile, Class<T> classOfObjectToDeserialize)
             throws IOException {
         return fromJsonString(FileUtil.readFromFile(jsonFile), classOfObjectToDeserialize);
     }
@@ -57,9 +59,9 @@ public class JsonUtil {
     public static <T> Optional<T> readJsonFile(
             String filePath, Class<T> classOfObjectToDeserialize) throws DataConversionException {
         requireNonNull(filePath);
-        File file = new File(filePath);
+        Path file = Paths.get(filePath);
 
-        if (!file.exists()) {
+        if (!Files.exists(file)) {
             logger.info("Json file "  + file + " not found");
             return Optional.empty();
         }
@@ -87,7 +89,7 @@ public class JsonUtil {
         requireNonNull(filePath);
         requireNonNull(jsonFile);
 
-        serializeObjectToJsonFile(new File(filePath), jsonFile);
+        serializeObjectToJsonFile(Paths.get(filePath), jsonFile);
     }
 
 

--- a/src/main/java/seedu/address/commons/util/JsonUtil.java
+++ b/src/main/java/seedu/address/commons/util/JsonUtil.java
@@ -5,7 +5,6 @@ import static java.util.Objects.requireNonNull;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -57,21 +56,20 @@ public class JsonUtil {
      * @throws DataConversionException if the file format is not as expected.
      */
     public static <T> Optional<T> readJsonFile(
-            String filePath, Class<T> classOfObjectToDeserialize) throws DataConversionException {
+            Path filePath, Class<T> classOfObjectToDeserialize) throws DataConversionException {
         requireNonNull(filePath);
-        Path file = Paths.get(filePath);
 
-        if (!Files.exists(file)) {
-            logger.info("Json file "  + file + " not found");
+        if (!Files.exists(filePath)) {
+            logger.info("Json file "  + filePath + " not found");
             return Optional.empty();
         }
 
         T jsonFile;
 
         try {
-            jsonFile = deserializeObjectFromJsonFile(file, classOfObjectToDeserialize);
+            jsonFile = deserializeObjectFromJsonFile(filePath, classOfObjectToDeserialize);
         } catch (IOException e) {
-            logger.warning("Error reading from jsonFile file " + file + ": " + e);
+            logger.warning("Error reading from jsonFile file " + filePath + ": " + e);
             throw new DataConversionException(e);
         }
 
@@ -85,11 +83,11 @@ public class JsonUtil {
      * @param filePath cannot be null
      * @throws IOException if there was an error during writing to the file
      */
-    public static <T> void saveJsonFile(T jsonFile, String filePath) throws IOException {
+    public static <T> void saveJsonFile(T jsonFile, Path filePath) throws IOException {
         requireNonNull(filePath);
         requireNonNull(jsonFile);
 
-        serializeObjectToJsonFile(Paths.get(filePath), jsonFile);
+        serializeObjectToJsonFile(filePath, jsonFile);
     }
 
 

--- a/src/main/java/seedu/address/commons/util/XmlUtil.java
+++ b/src/main/java/seedu/address/commons/util/XmlUtil.java
@@ -2,8 +2,9 @@ package seedu.address.commons.util;
 
 import static java.util.Objects.requireNonNull;
 
-import java.io.File;
 import java.io.FileNotFoundException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
@@ -26,20 +27,20 @@ public class XmlUtil {
      * @throws JAXBException         Thrown if the file is empty or does not have the correct format.
      */
     @SuppressWarnings("unchecked")
-    public static <T> T getDataFromFile(File file, Class<T> classToConvert)
+    public static <T> T getDataFromFile(Path file, Class<T> classToConvert)
             throws FileNotFoundException, JAXBException {
 
         requireNonNull(file);
         requireNonNull(classToConvert);
 
         if (!FileUtil.isFileExists(file)) {
-            throw new FileNotFoundException("File not found : " + file.getAbsolutePath());
+            throw new FileNotFoundException("File not found : " + file.toAbsolutePath());
         }
 
         JAXBContext context = JAXBContext.newInstance(classToConvert);
         Unmarshaller um = context.createUnmarshaller();
 
-        return ((T) um.unmarshal(file));
+        return ((T) um.unmarshal(file.toFile()));
     }
 
     /**
@@ -51,20 +52,20 @@ public class XmlUtil {
      * @throws JAXBException         Thrown if there is an error during converting the data
      *                               into xml and writing to the file.
      */
-    public static <T> void saveDataToFile(File file, T data) throws FileNotFoundException, JAXBException {
+    public static <T> void saveDataToFile(Path file, T data) throws FileNotFoundException, JAXBException {
 
         requireNonNull(file);
         requireNonNull(data);
 
-        if (!file.exists()) {
-            throw new FileNotFoundException("File not found : " + file.getAbsolutePath());
+        if (!Files.exists(file)) {
+            throw new FileNotFoundException("File not found : " + file.toAbsolutePath());
         }
 
         JAXBContext context = JAXBContext.newInstance(data.getClass());
         Marshaller m = context.createMarshaller();
         m.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
 
-        m.marshal(data, file);
+        m.marshal(data, file.toFile());
     }
 
 }

--- a/src/main/java/seedu/address/model/UserPrefs.java
+++ b/src/main/java/seedu/address/model/UserPrefs.java
@@ -1,5 +1,7 @@
 package seedu.address.model;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Objects;
 
 import seedu.address.commons.core.GuiSettings;
@@ -10,7 +12,7 @@ import seedu.address.commons.core.GuiSettings;
 public class UserPrefs {
 
     private GuiSettings guiSettings;
-    private String addressBookFilePath = "data/addressbook.xml";
+    private Path addressBookFilePath = Paths.get("data" , "addressbook.xml");
     private String addressBookName = "MyAddressBook";
 
     public UserPrefs() {
@@ -29,11 +31,11 @@ public class UserPrefs {
         guiSettings = new GuiSettings(width, height, x, y);
     }
 
-    public String getAddressBookFilePath() {
+    public Path getAddressBookFilePath() {
         return addressBookFilePath;
     }
 
-    public void setAddressBookFilePath(String addressBookFilePath) {
+    public void setAddressBookFilePath(Path addressBookFilePath) {
         this.addressBookFilePath = addressBookFilePath;
     }
 

--- a/src/main/java/seedu/address/storage/AddressBookStorage.java
+++ b/src/main/java/seedu/address/storage/AddressBookStorage.java
@@ -1,6 +1,7 @@
 package seedu.address.storage;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Optional;
 
 import seedu.address.commons.exceptions.DataConversionException;
@@ -14,7 +15,7 @@ public interface AddressBookStorage {
     /**
      * Returns the file path of the data file.
      */
-    String getAddressBookFilePath();
+    Path getAddressBookFilePath();
 
     /**
      * Returns AddressBook data as a {@link ReadOnlyAddressBook}.
@@ -27,7 +28,7 @@ public interface AddressBookStorage {
     /**
      * @see #getAddressBookFilePath()
      */
-    Optional<ReadOnlyAddressBook> readAddressBook(String filePath) throws DataConversionException, IOException;
+    Optional<ReadOnlyAddressBook> readAddressBook(Path filePath) throws DataConversionException, IOException;
 
     /**
      * Saves the given {@link ReadOnlyAddressBook} to the storage.
@@ -39,6 +40,6 @@ public interface AddressBookStorage {
     /**
      * @see #saveAddressBook(ReadOnlyAddressBook)
      */
-    void saveAddressBook(ReadOnlyAddressBook addressBook, String filePath) throws IOException;
+    void saveAddressBook(ReadOnlyAddressBook addressBook, Path filePath) throws IOException;
 
 }

--- a/src/main/java/seedu/address/storage/JsonUserPrefsStorage.java
+++ b/src/main/java/seedu/address/storage/JsonUserPrefsStorage.java
@@ -1,6 +1,7 @@
 package seedu.address.storage;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Optional;
 
 import seedu.address.commons.exceptions.DataConversionException;
@@ -12,14 +13,14 @@ import seedu.address.model.UserPrefs;
  */
 public class JsonUserPrefsStorage implements UserPrefsStorage {
 
-    private String filePath;
+    private Path filePath;
 
-    public JsonUserPrefsStorage(String filePath) {
+    public JsonUserPrefsStorage(Path filePath) {
         this.filePath = filePath;
     }
 
     @Override
-    public String getUserPrefsFilePath() {
+    public Path getUserPrefsFilePath() {
         return filePath;
     }
 
@@ -33,7 +34,7 @@ public class JsonUserPrefsStorage implements UserPrefsStorage {
      * @param prefsFilePath location of the data. Cannot be null.
      * @throws DataConversionException if the file format is not as expected.
      */
-    public Optional<UserPrefs> readUserPrefs(String prefsFilePath) throws DataConversionException {
+    public Optional<UserPrefs> readUserPrefs(Path prefsFilePath) throws DataConversionException {
         return JsonUtil.readJsonFile(prefsFilePath, UserPrefs.class);
     }
 

--- a/src/main/java/seedu/address/storage/Storage.java
+++ b/src/main/java/seedu/address/storage/Storage.java
@@ -1,6 +1,7 @@
 package seedu.address.storage;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Optional;
 
 import seedu.address.commons.events.model.AddressBookChangedEvent;
@@ -21,7 +22,7 @@ public interface Storage extends AddressBookStorage, UserPrefsStorage {
     void saveUserPrefs(UserPrefs userPrefs) throws IOException;
 
     @Override
-    String getAddressBookFilePath();
+    Path getAddressBookFilePath();
 
     @Override
     Optional<ReadOnlyAddressBook> readAddressBook() throws DataConversionException, IOException;

--- a/src/main/java/seedu/address/storage/StorageManager.java
+++ b/src/main/java/seedu/address/storage/StorageManager.java
@@ -1,6 +1,7 @@
 package seedu.address.storage;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Optional;
 import java.util.logging.Logger;
 
@@ -33,7 +34,7 @@ public class StorageManager extends ComponentManager implements Storage {
     // ================ UserPrefs methods ==============================
 
     @Override
-    public String getUserPrefsFilePath() {
+    public Path getUserPrefsFilePath() {
         return userPrefsStorage.getUserPrefsFilePath();
     }
 
@@ -51,7 +52,7 @@ public class StorageManager extends ComponentManager implements Storage {
     // ================ AddressBook methods ==============================
 
     @Override
-    public String getAddressBookFilePath() {
+    public Path getAddressBookFilePath() {
         return addressBookStorage.getAddressBookFilePath();
     }
 
@@ -61,7 +62,7 @@ public class StorageManager extends ComponentManager implements Storage {
     }
 
     @Override
-    public Optional<ReadOnlyAddressBook> readAddressBook(String filePath) throws DataConversionException, IOException {
+    public Optional<ReadOnlyAddressBook> readAddressBook(Path filePath) throws DataConversionException, IOException {
         logger.fine("Attempting to read data from file: " + filePath);
         return addressBookStorage.readAddressBook(filePath);
     }
@@ -72,7 +73,7 @@ public class StorageManager extends ComponentManager implements Storage {
     }
 
     @Override
-    public void saveAddressBook(ReadOnlyAddressBook addressBook, String filePath) throws IOException {
+    public void saveAddressBook(ReadOnlyAddressBook addressBook, Path filePath) throws IOException {
         logger.fine("Attempting to write to data file: " + filePath);
         addressBookStorage.saveAddressBook(addressBook, filePath);
     }

--- a/src/main/java/seedu/address/storage/UserPrefsStorage.java
+++ b/src/main/java/seedu/address/storage/UserPrefsStorage.java
@@ -1,6 +1,7 @@
 package seedu.address.storage;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Optional;
 
 import seedu.address.commons.exceptions.DataConversionException;
@@ -14,7 +15,7 @@ public interface UserPrefsStorage {
     /**
      * Returns the file path of the UserPrefs data file.
      */
-    String getUserPrefsFilePath();
+    Path getUserPrefsFilePath();
 
     /**
      * Returns UserPrefs data from storage.

--- a/src/main/java/seedu/address/storage/XmlAddressBookStorage.java
+++ b/src/main/java/seedu/address/storage/XmlAddressBookStorage.java
@@ -2,9 +2,11 @@ package seedu.address.storage;
 
 import static java.util.Objects.requireNonNull;
 
-import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Optional;
 import java.util.logging.Logger;
 
@@ -45,14 +47,14 @@ public class XmlAddressBookStorage implements AddressBookStorage {
                                                                                  FileNotFoundException {
         requireNonNull(filePath);
 
-        File addressBookFile = new File(filePath);
+        Path addressBookFile = Paths.get(filePath);
 
-        if (!addressBookFile.exists()) {
+        if (!Files.exists(addressBookFile)) {
             logger.info("AddressBook file "  + addressBookFile + " not found");
             return Optional.empty();
         }
 
-        XmlSerializableAddressBook xmlAddressBook = XmlFileStorage.loadDataFromSaveFile(new File(filePath));
+        XmlSerializableAddressBook xmlAddressBook = XmlFileStorage.loadDataFromSaveFile(Paths.get(filePath));
         try {
             return Optional.of(xmlAddressBook.toModelType());
         } catch (IllegalValueException ive) {
@@ -74,7 +76,7 @@ public class XmlAddressBookStorage implements AddressBookStorage {
         requireNonNull(addressBook);
         requireNonNull(filePath);
 
-        File file = new File(filePath);
+        Path file = Paths.get(filePath);
         FileUtil.createIfMissing(file);
         XmlFileStorage.saveDataToFile(file, new XmlSerializableAddressBook(addressBook));
     }

--- a/src/main/java/seedu/address/storage/XmlAddressBookStorage.java
+++ b/src/main/java/seedu/address/storage/XmlAddressBookStorage.java
@@ -6,7 +6,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Optional;
 import java.util.logging.Logger;
 
@@ -23,13 +22,13 @@ public class XmlAddressBookStorage implements AddressBookStorage {
 
     private static final Logger logger = LogsCenter.getLogger(XmlAddressBookStorage.class);
 
-    private String filePath;
+    private Path filePath;
 
-    public XmlAddressBookStorage(String filePath) {
+    public XmlAddressBookStorage(Path filePath) {
         this.filePath = filePath;
     }
 
-    public String getAddressBookFilePath() {
+    public Path getAddressBookFilePath() {
         return filePath;
     }
 
@@ -43,22 +42,20 @@ public class XmlAddressBookStorage implements AddressBookStorage {
      * @param filePath location of the data. Cannot be null
      * @throws DataConversionException if the file is not in the correct format.
      */
-    public Optional<ReadOnlyAddressBook> readAddressBook(String filePath) throws DataConversionException,
+    public Optional<ReadOnlyAddressBook> readAddressBook(Path filePath) throws DataConversionException,
                                                                                  FileNotFoundException {
         requireNonNull(filePath);
 
-        Path addressBookFile = Paths.get(filePath);
-
-        if (!Files.exists(addressBookFile)) {
-            logger.info("AddressBook file "  + addressBookFile + " not found");
+        if (!Files.exists(filePath)) {
+            logger.info("AddressBook file "  + filePath + " not found");
             return Optional.empty();
         }
 
-        XmlSerializableAddressBook xmlAddressBook = XmlFileStorage.loadDataFromSaveFile(Paths.get(filePath));
+        XmlSerializableAddressBook xmlAddressBook = XmlFileStorage.loadDataFromSaveFile(filePath);
         try {
             return Optional.of(xmlAddressBook.toModelType());
         } catch (IllegalValueException ive) {
-            logger.info("Illegal values found in " + addressBookFile + ": " + ive.getMessage());
+            logger.info("Illegal values found in " + filePath + ": " + ive.getMessage());
             throw new DataConversionException(ive);
         }
     }
@@ -72,13 +69,12 @@ public class XmlAddressBookStorage implements AddressBookStorage {
      * Similar to {@link #saveAddressBook(ReadOnlyAddressBook)}
      * @param filePath location of the data. Cannot be null
      */
-    public void saveAddressBook(ReadOnlyAddressBook addressBook, String filePath) throws IOException {
+    public void saveAddressBook(ReadOnlyAddressBook addressBook, Path filePath) throws IOException {
         requireNonNull(addressBook);
         requireNonNull(filePath);
 
-        Path file = Paths.get(filePath);
-        FileUtil.createIfMissing(file);
-        XmlFileStorage.saveDataToFile(file, new XmlSerializableAddressBook(addressBook));
+        FileUtil.createIfMissing(filePath);
+        XmlFileStorage.saveDataToFile(filePath, new XmlSerializableAddressBook(addressBook));
     }
 
 }

--- a/src/main/java/seedu/address/storage/XmlFileStorage.java
+++ b/src/main/java/seedu/address/storage/XmlFileStorage.java
@@ -1,7 +1,7 @@
 package seedu.address.storage;
 
-import java.io.File;
 import java.io.FileNotFoundException;
+import java.nio.file.Path;
 
 import javax.xml.bind.JAXBException;
 
@@ -15,7 +15,7 @@ public class XmlFileStorage {
     /**
      * Saves the given addressbook data to the specified file.
      */
-    public static void saveDataToFile(File file, XmlSerializableAddressBook addressBook)
+    public static void saveDataToFile(Path file, XmlSerializableAddressBook addressBook)
             throws FileNotFoundException {
         try {
             XmlUtil.saveDataToFile(file, addressBook);
@@ -27,7 +27,7 @@ public class XmlFileStorage {
     /**
      * Returns address book in the file or an empty address book
      */
-    public static XmlSerializableAddressBook loadDataFromSaveFile(File file) throws DataConversionException,
+    public static XmlSerializableAddressBook loadDataFromSaveFile(Path file) throws DataConversionException,
                                                                             FileNotFoundException {
         try {
             return XmlUtil.getDataFromFile(file, XmlSerializableAddressBook.class);

--- a/src/main/java/seedu/address/ui/StatusBarFooter.java
+++ b/src/main/java/seedu/address/ui/StatusBarFooter.java
@@ -1,5 +1,7 @@
 package seedu.address.ui;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Clock;
 import java.util.Date;
 import java.util.logging.Logger;
@@ -42,10 +44,10 @@ public class StatusBarFooter extends UiPart<Region> {
     private StatusBar saveLocationStatus;
 
 
-    public StatusBarFooter(String saveLocation) {
+    public StatusBarFooter(Path saveLocation) {
         super(FXML);
         setSyncStatus(SYNC_STATUS_INITIAL);
-        setSaveLocation("./" + saveLocation);
+        setSaveLocation(Paths.get(".").resolve(saveLocation).toString());
         registerAsAnEventHandler(this);
     }
 

--- a/src/test/data/ConfigUtilTest/ExtraValuesConfig.json
+++ b/src/test/data/ConfigUtilTest/ExtraValuesConfig.json
@@ -1,6 +1,6 @@
 {
   "appTitle" : "Typical App Title",
   "logLevel" : "INFO",
-  "userPrefsFilePath" : "C:\\preferences.json",
+  "userPrefsFilePath" : "preferences.json",
   "extra" : "extra value"
 }

--- a/src/test/data/ConfigUtilTest/TypicalConfig.json
+++ b/src/test/data/ConfigUtilTest/TypicalConfig.json
@@ -1,5 +1,5 @@
 {
   "appTitle" : "Typical App Title",
   "logLevel" : "INFO",
-  "userPrefsFilePath" : "C:\\preferences.json"
+  "userPrefsFilePath" : "preferences.json"
 }

--- a/src/test/java/seedu/address/AppParametersTest.java
+++ b/src/test/java/seedu/address/AppParametersTest.java
@@ -2,6 +2,7 @@ package seedu.address;
 
 import static org.junit.Assert.assertEquals;
 
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -19,13 +20,20 @@ public class AppParametersTest {
     @Test
     public void parse_validConfigPath_success() {
         parametersStub.namedParameters.put("config", "config.json");
-        expected.setConfigPath("config.json");
+        expected.setConfigPath(Paths.get("config.json"));
         assertEquals(expected, AppParameters.parse(parametersStub));
     }
 
     @Test
     public void parse_nullConfigPath_success() {
         parametersStub.namedParameters.put("config", null);
+        assertEquals(expected, AppParameters.parse(parametersStub));
+    }
+
+    @Test
+    public void parse_invalidConfigPath_success() {
+        parametersStub.namedParameters.put("config", "a\0");
+        expected.setConfigPath(null);
         assertEquals(expected, AppParameters.parse(parametersStub));
     }
 

--- a/src/test/java/seedu/address/AppParametersTest.java
+++ b/src/test/java/seedu/address/AppParametersTest.java
@@ -1,0 +1,50 @@
+package seedu.address;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import javafx.application.Application;
+
+public class AppParametersTest {
+
+    private final ParametersStub parametersStub = new ParametersStub();
+    private final AppParameters expected = new AppParameters();
+
+    @Test
+    public void parse_validConfigPath_success() {
+        parametersStub.namedParameters.put("config", "config.json");
+        expected.setConfigPath("config.json");
+        assertEquals(expected, AppParameters.parse(parametersStub));
+    }
+
+    @Test
+    public void parse_nullConfigPath_success() {
+        parametersStub.namedParameters.put("config", null);
+        assertEquals(expected, AppParameters.parse(parametersStub));
+    }
+
+    private static class ParametersStub extends Application.Parameters {
+        private Map<String, String> namedParameters = new HashMap<>();
+
+        @Override
+        public List<String> getRaw() {
+            throw new AssertionError("should not be called");
+        }
+
+        @Override
+        public List<String> getUnnamed() {
+            throw new AssertionError("should not be called");
+        }
+
+        @Override
+        public Map<String, String> getNamed() {
+            return Collections.unmodifiableMap(namedParameters);
+        }
+    }
+}

--- a/src/test/java/seedu/address/TestApp.java
+++ b/src/test/java/seedu/address/TestApp.java
@@ -1,7 +1,8 @@
 package seedu.address;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.function.Supplier;
 
 import javafx.stage.Screen;
@@ -113,7 +114,7 @@ public class TestApp extends MainApp {
      */
     private <T> void createDataFileWithData(T data, String filePath) {
         try {
-            File saveFileForTesting = new File(filePath);
+            Path saveFileForTesting = Paths.get(filePath);
             FileUtil.createIfMissing(saveFileForTesting);
             XmlUtil.saveDataToFile(saveFileForTesting, data);
         } catch (Exception e) {

--- a/src/test/java/seedu/address/TestApp.java
+++ b/src/test/java/seedu/address/TestApp.java
@@ -2,7 +2,6 @@ package seedu.address;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.function.Supplier;
 
 import javafx.stage.Screen;
@@ -28,19 +27,19 @@ import systemtests.ModelHelper;
  */
 public class TestApp extends MainApp {
 
-    public static final String SAVE_LOCATION_FOR_TESTING = TestUtil.getFilePathInSandboxFolder("sampleData.xml");
+    public static final Path SAVE_LOCATION_FOR_TESTING = TestUtil.getFilePathInSandboxFolder("sampleData.xml");
     public static final String APP_TITLE = "Test App";
 
-    protected static final String DEFAULT_PREF_FILE_LOCATION_FOR_TESTING =
+    protected static final Path DEFAULT_PREF_FILE_LOCATION_FOR_TESTING =
             TestUtil.getFilePathInSandboxFolder("pref_testing.json");
     protected static final String ADDRESS_BOOK_NAME = "Test";
     protected Supplier<ReadOnlyAddressBook> initialDataSupplier = () -> null;
-    protected String saveFileLocation = SAVE_LOCATION_FOR_TESTING;
+    protected Path saveFileLocation = SAVE_LOCATION_FOR_TESTING;
 
     public TestApp() {
     }
 
-    public TestApp(Supplier<ReadOnlyAddressBook> initialDataSupplier, String saveFileLocation) {
+    public TestApp(Supplier<ReadOnlyAddressBook> initialDataSupplier, Path saveFileLocation) {
         super();
         this.initialDataSupplier = initialDataSupplier;
         this.saveFileLocation = saveFileLocation;
@@ -53,7 +52,7 @@ public class TestApp extends MainApp {
     }
 
     @Override
-    protected Config initConfig(String configFilePath) {
+    protected Config initConfig(Path configFilePath) {
         Config config = super.initConfig(configFilePath);
         config.setAppTitle(APP_TITLE);
         config.setUserPrefsFilePath(DEFAULT_PREF_FILE_LOCATION_FOR_TESTING);
@@ -87,7 +86,7 @@ public class TestApp extends MainApp {
     /**
      * Returns the file path of the storage file.
      */
-    public String getStorageSaveLocation() {
+    public Path getStorageSaveLocation() {
         return storage.getAddressBookFilePath();
     }
 
@@ -112,11 +111,10 @@ public class TestApp extends MainApp {
     /**
      * Creates an XML file at the {@code filePath} with the {@code data}.
      */
-    private <T> void createDataFileWithData(T data, String filePath) {
+    private <T> void createDataFileWithData(T data, Path filePath) {
         try {
-            Path saveFileForTesting = Paths.get(filePath);
-            FileUtil.createIfMissing(saveFileForTesting);
-            XmlUtil.saveDataToFile(saveFileForTesting, data);
+            FileUtil.createIfMissing(filePath);
+            XmlUtil.saveDataToFile(filePath, data);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/src/test/java/seedu/address/commons/util/ConfigUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/ConfigUtilTest.java
@@ -3,8 +3,9 @@ package seedu.address.commons.util;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Optional;
 import java.util.logging.Level;
 
@@ -18,7 +19,7 @@ import seedu.address.commons.exceptions.DataConversionException;
 
 public class ConfigUtilTest {
 
-    private static final String TEST_DATA_FOLDER = FileUtil.getPath("./src/test/data/ConfigUtilTest/");
+    private static final Path TEST_DATA_FOLDER = Paths.get("src", "test", "data", "ConfigUtilTest");
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
@@ -75,12 +76,12 @@ public class ConfigUtilTest {
         Config config = new Config();
         config.setAppTitle("Typical App Title");
         config.setLogLevel(Level.INFO);
-        config.setUserPrefsFilePath("C:\\preferences.json");
+        config.setUserPrefsFilePath(Paths.get("C:\\preferences.json"));
         return config;
     }
 
     private Optional<Config> read(String configFileInTestDataFolder) throws DataConversionException {
-        String configFilePath = addToTestDataPathIfNotNull(configFileInTestDataFolder);
+        Path configFilePath = addToTestDataPathIfNotNull(configFileInTestDataFolder);
         return ConfigUtil.readConfig(configFilePath);
     }
 
@@ -100,7 +101,7 @@ public class ConfigUtilTest {
     public void saveConfig_allInOrder_success() throws DataConversionException, IOException {
         Config original = getTypicalConfig();
 
-        String configFilePath = testFolder.getRoot() + File.separator + "TempConfig.json";
+        Path configFilePath = testFolder.getRoot().toPath().resolve("TempConfig.json");
 
         //Try writing when the file doesn't exist
         ConfigUtil.saveConfig(original, configFilePath);
@@ -116,13 +117,13 @@ public class ConfigUtilTest {
     }
 
     private void save(Config config, String configFileInTestDataFolder) throws IOException {
-        String configFilePath = addToTestDataPathIfNotNull(configFileInTestDataFolder);
+        Path configFilePath = addToTestDataPathIfNotNull(configFileInTestDataFolder);
         ConfigUtil.saveConfig(config, configFilePath);
     }
 
-    private String addToTestDataPathIfNotNull(String configFileInTestDataFolder) {
+    private Path addToTestDataPathIfNotNull(String configFileInTestDataFolder) {
         return configFileInTestDataFolder != null
-                                  ? TEST_DATA_FOLDER + configFileInTestDataFolder
+                                  ? TEST_DATA_FOLDER.resolve(configFileInTestDataFolder)
                                   : null;
     }
 

--- a/src/test/java/seedu/address/commons/util/ConfigUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/ConfigUtilTest.java
@@ -76,7 +76,7 @@ public class ConfigUtilTest {
         Config config = new Config();
         config.setAppTitle("Typical App Title");
         config.setLogLevel(Level.INFO);
-        config.setUserPrefsFilePath(Paths.get("C:\\preferences.json"));
+        config.setUserPrefsFilePath(Paths.get("preferences.json"));
         return config;
     }
 

--- a/src/test/java/seedu/address/commons/util/FileUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/FileUtilTest.java
@@ -1,12 +1,16 @@
 package seedu.address.commons.util;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
+import seedu.address.testutil.Assert;
 
 public class FileUtilTest {
 
@@ -26,6 +30,18 @@ public class FileUtilTest {
         // no forwards slash -> assertion failure
         thrown.expect(AssertionError.class);
         FileUtil.getPath("folder");
+    }
+
+    @Test
+    public void isValidPath() {
+        // valid path
+        assertTrue(FileUtil.isValidPath("valid/file/path"));
+
+        // invalid path
+        assertFalse(FileUtil.isValidPath("a\0"));
+
+        // null path -> throws NullPointerException
+        Assert.assertThrows(NullPointerException.class, () -> FileUtil.isValidPath(null));
     }
 
 }

--- a/src/test/java/seedu/address/commons/util/FileUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/FileUtilTest.java
@@ -1,36 +1,13 @@
 package seedu.address.commons.util;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.io.File;
-
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import seedu.address.testutil.Assert;
 
 public class FileUtilTest {
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
-    @Test
-    public void getPath() {
-
-        // valid case
-        assertEquals("folder" + File.separator + "sub-folder", FileUtil.getPath("folder/sub-folder"));
-
-        // null parameter -> throws NullPointerException
-        thrown.expect(NullPointerException.class);
-        FileUtil.getPath(null);
-
-        // no forwards slash -> assertion failure
-        thrown.expect(AssertionError.class);
-        FileUtil.getPath("folder");
-    }
 
     @Test
     public void isValidPath() {

--- a/src/test/java/seedu/address/commons/util/JsonUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/JsonUtilTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import org.junit.Test;
 
@@ -16,7 +15,7 @@ import seedu.address.testutil.TestUtil;
  */
 public class JsonUtilTest {
 
-    private static final Path SERIALIZATION_FILE = Paths.get(TestUtil.getFilePathInSandboxFolder("serialize.json"));
+    private static final Path SERIALIZATION_FILE = TestUtil.getFilePathInSandboxFolder("serialize.json");
 
     @Test
     public void serializeObjectToJsonFile_noExceptionThrown() throws IOException {

--- a/src/test/java/seedu/address/commons/util/JsonUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/JsonUtilTest.java
@@ -2,8 +2,9 @@ package seedu.address.commons.util;
 
 import static org.junit.Assert.assertEquals;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.junit.Test;
 
@@ -15,7 +16,7 @@ import seedu.address.testutil.TestUtil;
  */
 public class JsonUtilTest {
 
-    private static final File SERIALIZATION_FILE = new File(TestUtil.getFilePathInSandboxFolder("serialize.json"));
+    private static final Path SERIALIZATION_FILE = Paths.get(TestUtil.getFilePathInSandboxFolder("serialize.json"));
 
     @Test
     public void serializeObjectToJsonFile_noExceptionThrown() throws IOException {

--- a/src/test/java/seedu/address/commons/util/XmlUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/XmlUtilTest.java
@@ -25,14 +25,14 @@ import seedu.address.testutil.TestUtil;
 
 public class XmlUtilTest {
 
-    private static final String TEST_DATA_FOLDER = FileUtil.getPath("src/test/data/XmlUtilTest/");
-    private static final Path EMPTY_FILE = Paths.get(TEST_DATA_FOLDER + "empty.xml");
-    private static final Path MISSING_FILE = Paths.get(TEST_DATA_FOLDER + "missing.xml");
-    private static final Path VALID_FILE = Paths.get(TEST_DATA_FOLDER + "validAddressBook.xml");
-    private static final Path MISSING_PERSON_FIELD_FILE = Paths.get(TEST_DATA_FOLDER + "missingPersonField.xml");
-    private static final Path INVALID_PERSON_FIELD_FILE = Paths.get(TEST_DATA_FOLDER + "invalidPersonField.xml");
-    private static final Path VALID_PERSON_FILE = Paths.get(TEST_DATA_FOLDER + "validPerson.xml");
-    private static final Path TEMP_FILE = Paths.get(TestUtil.getFilePathInSandboxFolder("tempAddressBook.xml"));
+    private static final Path TEST_DATA_FOLDER = Paths.get("src", "test", "data", "XmlUtilTest");
+    private static final Path EMPTY_FILE = TEST_DATA_FOLDER.resolve("empty.xml");
+    private static final Path MISSING_FILE = TEST_DATA_FOLDER.resolve("missing.xml");
+    private static final Path VALID_FILE = TEST_DATA_FOLDER.resolve("validAddressBook.xml");
+    private static final Path MISSING_PERSON_FIELD_FILE = TEST_DATA_FOLDER.resolve("missingPersonField.xml");
+    private static final Path INVALID_PERSON_FIELD_FILE = TEST_DATA_FOLDER.resolve("invalidPersonField.xml");
+    private static final Path VALID_PERSON_FILE = TEST_DATA_FOLDER.resolve("validPerson.xml");
+    private static final Path TEMP_FILE = TestUtil.getFilePathInSandboxFolder("tempAddressBook.xml");
 
     private static final String INVALID_PHONE = "9482asf424";
 

--- a/src/test/java/seedu/address/commons/util/XmlUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/XmlUtilTest.java
@@ -2,8 +2,9 @@ package seedu.address.commons.util;
 
 import static org.junit.Assert.assertEquals;
 
-import java.io.File;
 import java.io.FileNotFoundException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
 
@@ -25,13 +26,13 @@ import seedu.address.testutil.TestUtil;
 public class XmlUtilTest {
 
     private static final String TEST_DATA_FOLDER = FileUtil.getPath("src/test/data/XmlUtilTest/");
-    private static final File EMPTY_FILE = new File(TEST_DATA_FOLDER + "empty.xml");
-    private static final File MISSING_FILE = new File(TEST_DATA_FOLDER + "missing.xml");
-    private static final File VALID_FILE = new File(TEST_DATA_FOLDER + "validAddressBook.xml");
-    private static final File MISSING_PERSON_FIELD_FILE = new File(TEST_DATA_FOLDER + "missingPersonField.xml");
-    private static final File INVALID_PERSON_FIELD_FILE = new File(TEST_DATA_FOLDER + "invalidPersonField.xml");
-    private static final File VALID_PERSON_FILE = new File(TEST_DATA_FOLDER + "validPerson.xml");
-    private static final File TEMP_FILE = new File(TestUtil.getFilePathInSandboxFolder("tempAddressBook.xml"));
+    private static final Path EMPTY_FILE = Paths.get(TEST_DATA_FOLDER + "empty.xml");
+    private static final Path MISSING_FILE = Paths.get(TEST_DATA_FOLDER + "missing.xml");
+    private static final Path VALID_FILE = Paths.get(TEST_DATA_FOLDER + "validAddressBook.xml");
+    private static final Path MISSING_PERSON_FIELD_FILE = Paths.get(TEST_DATA_FOLDER + "missingPersonField.xml");
+    private static final Path INVALID_PERSON_FIELD_FILE = Paths.get(TEST_DATA_FOLDER + "invalidPersonField.xml");
+    private static final Path VALID_PERSON_FILE = Paths.get(TEST_DATA_FOLDER + "validPerson.xml");
+    private static final Path TEMP_FILE = Paths.get(TestUtil.getFilePathInSandboxFolder("tempAddressBook.xml"));
 
     private static final String INVALID_PHONE = "9482asf424";
 
@@ -121,7 +122,7 @@ public class XmlUtilTest {
 
     @Test
     public void saveDataToFile_validFile_dataSaved() throws Exception {
-        TEMP_FILE.createNewFile();
+        FileUtil.createFile(TEMP_FILE);
         XmlSerializableAddressBook dataToWrite = new XmlSerializableAddressBook(new AddressBook());
         XmlUtil.saveDataToFile(TEMP_FILE, dataToWrite);
         XmlSerializableAddressBook dataFromFile = XmlUtil.getDataFromFile(TEMP_FILE, XmlSerializableAddressBook.class);

--- a/src/test/java/seedu/address/storage/JsonUserPrefsStorageTest.java
+++ b/src/test/java/seedu/address/storage/JsonUserPrefsStorageTest.java
@@ -3,8 +3,9 @@ package seedu.address.storage;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Optional;
 
 import org.junit.Rule;
@@ -13,12 +14,11 @@ import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 import seedu.address.commons.exceptions.DataConversionException;
-import seedu.address.commons.util.FileUtil;
 import seedu.address.model.UserPrefs;
 
 public class JsonUserPrefsStorageTest {
 
-    private static final String TEST_DATA_FOLDER = FileUtil.getPath("./src/test/data/JsonUserPrefsStorageTest/");
+    private static final Path TEST_DATA_FOLDER = Paths.get("src", "test", "data", "JsonUserPrefsStorageTest");
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
@@ -33,7 +33,7 @@ public class JsonUserPrefsStorageTest {
     }
 
     private Optional<UserPrefs> readUserPrefs(String userPrefsFileInTestDataFolder) throws DataConversionException {
-        String prefsFilePath = addToTestDataPathIfNotNull(userPrefsFileInTestDataFolder);
+        Path prefsFilePath = addToTestDataPathIfNotNull(userPrefsFileInTestDataFolder);
         return new JsonUserPrefsStorage(prefsFilePath).readUserPrefs(prefsFilePath);
     }
 
@@ -52,9 +52,9 @@ public class JsonUserPrefsStorageTest {
          */
     }
 
-    private String addToTestDataPathIfNotNull(String userPrefsFileInTestDataFolder) {
+    private Path addToTestDataPathIfNotNull(String userPrefsFileInTestDataFolder) {
         return userPrefsFileInTestDataFolder != null
-                ? TEST_DATA_FOLDER + userPrefsFileInTestDataFolder
+                ? TEST_DATA_FOLDER.resolve(userPrefsFileInTestDataFolder)
                 : null;
     }
 
@@ -82,7 +82,7 @@ public class JsonUserPrefsStorageTest {
     private UserPrefs getTypicalUserPrefs() {
         UserPrefs userPrefs = new UserPrefs();
         userPrefs.setGuiSettings(1000, 500, 300, 100);
-        userPrefs.setAddressBookFilePath("addressbook.xml");
+        userPrefs.setAddressBookFilePath(Paths.get("addressbook.xml"));
         userPrefs.setAddressBookName("TypicalAddressBookName");
         return userPrefs;
     }
@@ -117,7 +117,7 @@ public class JsonUserPrefsStorageTest {
         UserPrefs original = new UserPrefs();
         original.setGuiSettings(1200, 200, 0, 2);
 
-        String pefsFilePath = testFolder.getRoot() + File.separator + "TempPrefs.json";
+        Path pefsFilePath = testFolder.getRoot().toPath().resolve("TempPrefs.json");
         JsonUserPrefsStorage jsonUserPrefsStorage = new JsonUserPrefsStorage(pefsFilePath);
 
         //Try writing when the file doesn't exist

--- a/src/test/java/seedu/address/storage/StorageManagerTest.java
+++ b/src/test/java/seedu/address/storage/StorageManagerTest.java
@@ -6,6 +6,8 @@ import static org.junit.Assert.assertTrue;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -35,8 +37,8 @@ public class StorageManagerTest {
         storageManager = new StorageManager(addressBookStorage, userPrefsStorage);
     }
 
-    private String getTempFilePath(String fileName) {
-        return testFolder.getRoot().getPath() + fileName;
+    private Path getTempFilePath(String fileName) {
+        return testFolder.getRoot().toPath().resolve(fileName);
     }
 
 
@@ -75,8 +77,8 @@ public class StorageManagerTest {
     @Test
     public void handleAddressBookChangedEvent_exceptionThrown_eventRaised() {
         // Create a StorageManager while injecting a stub that  throws an exception when the save method is called
-        Storage storage = new StorageManager(new XmlAddressBookStorageExceptionThrowingStub("dummy"),
-                                             new JsonUserPrefsStorage("dummy"));
+        Storage storage = new StorageManager(new XmlAddressBookStorageExceptionThrowingStub(Paths.get("dummy")),
+                                             new JsonUserPrefsStorage(Paths.get("dummy")));
         storage.handleAddressBookChangedEvent(new AddressBookChangedEvent(new AddressBook()));
         assertTrue(eventsCollectorRule.eventsCollector.getMostRecent() instanceof DataSavingExceptionEvent);
     }
@@ -87,12 +89,12 @@ public class StorageManagerTest {
      */
     class XmlAddressBookStorageExceptionThrowingStub extends XmlAddressBookStorage {
 
-        public XmlAddressBookStorageExceptionThrowingStub(String filePath) {
+        public XmlAddressBookStorageExceptionThrowingStub(Path filePath) {
             super(filePath);
         }
 
         @Override
-        public void saveAddressBook(ReadOnlyAddressBook addressBook, String filePath) throws IOException {
+        public void saveAddressBook(ReadOnlyAddressBook addressBook, Path filePath) throws IOException {
             throw new IOException("dummy exception");
         }
     }

--- a/src/test/java/seedu/address/storage/XmlAddressBookStorageTest.java
+++ b/src/test/java/seedu/address/storage/XmlAddressBookStorageTest.java
@@ -8,6 +8,8 @@ import static seedu.address.testutil.TypicalPersons.IDA;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -15,12 +17,11 @@ import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 import seedu.address.commons.exceptions.DataConversionException;
-import seedu.address.commons.util.FileUtil;
 import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
 
 public class XmlAddressBookStorageTest {
-    private static final String TEST_DATA_FOLDER = FileUtil.getPath("./src/test/data/XmlAddressBookStorageTest/");
+    private static final Path TEST_DATA_FOLDER = Paths.get("src", "test", "data", "XmlAddressBookStorageTest");
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
@@ -35,12 +36,12 @@ public class XmlAddressBookStorageTest {
     }
 
     private java.util.Optional<ReadOnlyAddressBook> readAddressBook(String filePath) throws Exception {
-        return new XmlAddressBookStorage(filePath).readAddressBook(addToTestDataPathIfNotNull(filePath));
+        return new XmlAddressBookStorage(Paths.get(filePath)).readAddressBook(addToTestDataPathIfNotNull(filePath));
     }
 
-    private String addToTestDataPathIfNotNull(String prefsFileInTestDataFolder) {
+    private Path addToTestDataPathIfNotNull(String prefsFileInTestDataFolder) {
         return prefsFileInTestDataFolder != null
-                ? TEST_DATA_FOLDER + prefsFileInTestDataFolder
+                ? TEST_DATA_FOLDER.resolve(prefsFileInTestDataFolder)
                 : null;
     }
 
@@ -74,7 +75,7 @@ public class XmlAddressBookStorageTest {
 
     @Test
     public void readAndSaveAddressBook_allInOrder_success() throws Exception {
-        String filePath = testFolder.getRoot().getPath() + "TempAddressBook.xml";
+        Path filePath = testFolder.getRoot().toPath().resolve("TempAddressBook.xml");
         AddressBook original = getTypicalAddressBook();
         XmlAddressBookStorage xmlAddressBookStorage = new XmlAddressBookStorage(filePath);
 
@@ -109,7 +110,8 @@ public class XmlAddressBookStorageTest {
      */
     private void saveAddressBook(ReadOnlyAddressBook addressBook, String filePath) {
         try {
-            new XmlAddressBookStorage(filePath).saveAddressBook(addressBook, addToTestDataPathIfNotNull(filePath));
+            new XmlAddressBookStorage(Paths.get(filePath))
+                    .saveAddressBook(addressBook, addToTestDataPathIfNotNull(filePath));
         } catch (IOException ioe) {
             throw new AssertionError("There should not be an error writing to the file.", ioe);
         }

--- a/src/test/java/seedu/address/storage/XmlSerializableAddressBookTest.java
+++ b/src/test/java/seedu/address/storage/XmlSerializableAddressBookTest.java
@@ -2,7 +2,8 @@ package seedu.address.storage;
 
 import static org.junit.Assert.assertEquals;
 
-import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -17,8 +18,8 @@ import seedu.address.testutil.TypicalPersons;
 public class XmlSerializableAddressBookTest {
 
     private static final String TEST_DATA_FOLDER = FileUtil.getPath("src/test/data/XmlSerializableAddressBookTest/");
-    private static final File TYPICAL_PERSONS_FILE = new File(TEST_DATA_FOLDER + "typicalPersonsAddressBook.xml");
-    private static final File INVALID_PERSON_FILE = new File(TEST_DATA_FOLDER + "invalidPersonAddressBook.xml");
+    private static final Path TYPICAL_PERSONS_FILE = Paths.get(TEST_DATA_FOLDER + "typicalPersonsAddressBook.xml");
+    private static final Path INVALID_PERSON_FILE = Paths.get(TEST_DATA_FOLDER + "invalidPersonAddressBook.xml");
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();

--- a/src/test/java/seedu/address/storage/XmlSerializableAddressBookTest.java
+++ b/src/test/java/seedu/address/storage/XmlSerializableAddressBookTest.java
@@ -10,16 +10,15 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import seedu.address.commons.exceptions.IllegalValueException;
-import seedu.address.commons.util.FileUtil;
 import seedu.address.commons.util.XmlUtil;
 import seedu.address.model.AddressBook;
 import seedu.address.testutil.TypicalPersons;
 
 public class XmlSerializableAddressBookTest {
 
-    private static final String TEST_DATA_FOLDER = FileUtil.getPath("src/test/data/XmlSerializableAddressBookTest/");
-    private static final Path TYPICAL_PERSONS_FILE = Paths.get(TEST_DATA_FOLDER + "typicalPersonsAddressBook.xml");
-    private static final Path INVALID_PERSON_FILE = Paths.get(TEST_DATA_FOLDER + "invalidPersonAddressBook.xml");
+    private static final Path TEST_DATA_FOLDER = Paths.get("src", "test", "data", "XmlSerializableAddressBookTest");
+    private static final Path TYPICAL_PERSONS_FILE = TEST_DATA_FOLDER.resolve("typicalPersonsAddressBook.xml");
+    private static final Path INVALID_PERSON_FILE = TEST_DATA_FOLDER.resolve("invalidPersonAddressBook.xml");
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();

--- a/src/test/java/seedu/address/testutil/TestUtil.java
+++ b/src/test/java/seedu/address/testutil/TestUtil.java
@@ -1,7 +1,7 @@
 package seedu.address.testutil;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.FileUtil;
@@ -24,7 +24,7 @@ public class TestUtil {
      */
     public static String getFilePathInSandboxFolder(String fileName) {
         try {
-            FileUtil.createDirs(new File(SANDBOX_FOLDER));
+            FileUtil.createDirs(Paths.get(SANDBOX_FOLDER));
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/test/java/seedu/address/testutil/TestUtil.java
+++ b/src/test/java/seedu/address/testutil/TestUtil.java
@@ -1,10 +1,11 @@
 package seedu.address.testutil;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.commons.util.FileUtil;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
 
@@ -16,19 +17,19 @@ public class TestUtil {
     /**
      * Folder used for temp files created during testing. Ignored by Git.
      */
-    private static final String SANDBOX_FOLDER = FileUtil.getPath("./src/test/data/sandbox/");
+    private static final Path SANDBOX_FOLDER = Paths.get("src", "test", "data", "sandbox");
 
     /**
-     * Appends {@code fileName} to the sandbox folder path and returns the resulting string.
+     * Appends {@code fileName} to the sandbox folder path and returns the resulting path.
      * Creates the sandbox folder if it doesn't exist.
      */
-    public static String getFilePathInSandboxFolder(String fileName) {
+    public static Path getFilePathInSandboxFolder(String fileName) {
         try {
-            FileUtil.createDirs(Paths.get(SANDBOX_FOLDER));
+            Files.createDirectories(SANDBOX_FOLDER);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-        return SANDBOX_FOLDER + fileName;
+        return SANDBOX_FOLDER.resolve(fileName);
     }
 
     /**

--- a/src/test/java/seedu/address/ui/PersonListPanelTest.java
+++ b/src/test/java/seedu/address/ui/PersonListPanelTest.java
@@ -30,7 +30,7 @@ public class PersonListPanelTest extends GuiUnitTest {
 
     private static final JumpToListRequestEvent JUMP_TO_SECOND_EVENT = new JumpToListRequestEvent(INDEX_SECOND_PERSON);
 
-    private static final String TEST_DATA_FOLDER = FileUtil.getPath("src/test/data/sandbox/");
+    private static final Path TEST_DATA_FOLDER = Paths.get("src", "test", "data", "sandbox");
 
     private static final long CARD_CREATION_AND_DELETION_TIMEOUT = 2500;
 

--- a/src/test/java/seedu/address/ui/PersonListPanelTest.java
+++ b/src/test/java/seedu/address/ui/PersonListPanelTest.java
@@ -9,7 +9,8 @@ import static seedu.address.testutil.TypicalPersons.getTypicalPersons;
 import static seedu.address.ui.testutil.GuiTestAssert.assertCardDisplaysPerson;
 import static seedu.address.ui.testutil.GuiTestAssert.assertCardEquals;
 
-import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.junit.Test;
 
@@ -79,7 +80,7 @@ public class PersonListPanelTest extends GuiUnitTest {
      * {@code PersonListPanel}.
      */
     private ObservableList<Person> createBackingList(int personCount) throws Exception {
-        File xmlFile = createXmlFileWithPersons(personCount);
+        Path xmlFile = createXmlFileWithPersons(personCount);
         XmlSerializableAddressBook xmlAddressBook =
                 XmlUtil.getDataFromFile(xmlFile, XmlSerializableAddressBook.class);
         return FXCollections.observableArrayList(xmlAddressBook.toModelType().getPersonList());
@@ -88,7 +89,7 @@ public class PersonListPanelTest extends GuiUnitTest {
     /**
      * Returns a .xml file containing {@code personCount} persons. This file will be deleted when the JVM terminates.
      */
-    private File createXmlFileWithPersons(int personCount) throws Exception {
+    private Path createXmlFileWithPersons(int personCount) throws Exception {
         StringBuilder builder = new StringBuilder();
         builder.append("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n");
         builder.append("<addressbook>\n");
@@ -102,10 +103,10 @@ public class PersonListPanelTest extends GuiUnitTest {
         }
         builder.append("</addressbook>\n");
 
-        File manyPersonsFile = new File(TEST_DATA_FOLDER + "manyPersons.xml");
+        Path manyPersonsFile = Paths.get(TEST_DATA_FOLDER + "manyPersons.xml");
         FileUtil.createFile(manyPersonsFile);
         FileUtil.writeToFile(manyPersonsFile, builder.toString());
-        manyPersonsFile.deleteOnExit();
+        manyPersonsFile.toFile().deleteOnExit();
         return manyPersonsFile;
     }
 

--- a/src/test/java/seedu/address/ui/StatusBarFooterTest.java
+++ b/src/test/java/seedu/address/ui/StatusBarFooterTest.java
@@ -5,6 +5,8 @@ import static seedu.address.testutil.EventsUtil.postNow;
 import static seedu.address.ui.StatusBarFooter.SYNC_STATUS_INITIAL;
 import static seedu.address.ui.StatusBarFooter.SYNC_STATUS_UPDATED;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -21,8 +23,8 @@ import seedu.address.model.AddressBook;
 
 public class StatusBarFooterTest extends GuiUnitTest {
 
-    private static final String STUB_SAVE_LOCATION = "Stub";
-    private static final String RELATIVE_PATH = "./";
+    private static final Path STUB_SAVE_LOCATION = Paths.get("Stub");
+    private static final Path RELATIVE_PATH = Paths.get(".");
 
     private static final AddressBookChangedEvent EVENT_STUB = new AddressBookChangedEvent(new AddressBook());
 
@@ -54,11 +56,11 @@ public class StatusBarFooterTest extends GuiUnitTest {
     @Test
     public void display() {
         // initial state
-        assertStatusBarContent(RELATIVE_PATH + STUB_SAVE_LOCATION, SYNC_STATUS_INITIAL);
+        assertStatusBarContent(RELATIVE_PATH.resolve(STUB_SAVE_LOCATION).toString(), SYNC_STATUS_INITIAL);
 
         // after address book is updated
         postNow(EVENT_STUB);
-        assertStatusBarContent(RELATIVE_PATH + STUB_SAVE_LOCATION,
+        assertStatusBarContent(RELATIVE_PATH.resolve(STUB_SAVE_LOCATION).toString(),
                 String.format(SYNC_STATUS_UPDATED, new Date(injectedClock.millis()).toString()));
     }
 

--- a/src/test/java/systemtests/AddressBookSystemTest.java
+++ b/src/test/java/systemtests/AddressBookSystemTest.java
@@ -12,6 +12,8 @@ import static seedu.address.ui.testutil.GuiTestAssert.assertListMatching;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
@@ -89,7 +91,7 @@ public abstract class AddressBookSystemTest {
     /**
      * Returns the directory of the data file.
      */
-    protected String getDataFileLocation() {
+    protected Path getDataFileLocation() {
         return TestApp.SAVE_LOCATION_FOR_TESTING;
     }
 
@@ -278,7 +280,8 @@ public abstract class AddressBookSystemTest {
             assertEquals("", getResultDisplay().getText());
             assertListMatching(getPersonListPanel(), getModel().getFilteredPersonList());
             assertEquals(MainApp.class.getResource(FXML_FILE_FOLDER + DEFAULT_PAGE), getBrowserPanel().getLoadedUrl());
-            assertEquals("./" + testApp.getStorageSaveLocation(), getStatusBarFooter().getSaveLocation());
+            assertEquals(Paths.get(".").resolve(testApp.getStorageSaveLocation()).toString(),
+                    getStatusBarFooter().getSaveLocation());
             assertEquals(SYNC_STATUS_INITIAL, getStatusBarFooter().getSyncStatus());
         } catch (Exception e) {
             throw new AssertionError("Starting state is wrong.", e);

--- a/src/test/java/systemtests/SampleDataTest.java
+++ b/src/test/java/systemtests/SampleDataTest.java
@@ -4,7 +4,7 @@ import static seedu.address.ui.testutil.GuiTestAssert.assertListMatching;
 
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 
 import org.junit.Test;
 
@@ -26,8 +26,8 @@ public class SampleDataTest extends AddressBookSystemTest {
      * Returns a non-existent file location to force test app to load sample data.
      */
     @Override
-    protected String getDataFileLocation() {
-        String filePath = TestUtil.getFilePathInSandboxFolder("SomeFileThatDoesNotExist1234567890.xml");
+    protected Path getDataFileLocation() {
+        Path filePath = TestUtil.getFilePathInSandboxFolder("SomeFileThatDoesNotExist1234567890.xml");
         deleteFileIfExists(filePath);
         return filePath;
     }
@@ -35,9 +35,9 @@ public class SampleDataTest extends AddressBookSystemTest {
     /**
      * Deletes the file at {@code filePath} if it exists.
      */
-    private void deleteFileIfExists(String filePath) {
+    private void deleteFileIfExists(Path filePath) {
         try {
-            Files.deleteIfExists(Paths.get(filePath));
+            Files.deleteIfExists(filePath);
         } catch (IOException ioe) {
             throw new AssertionError(ioe);
         }

--- a/src/test/java/systemtests/SystemTestSetupHelper.java
+++ b/src/test/java/systemtests/SystemTestSetupHelper.java
@@ -1,5 +1,6 @@
 package systemtests;
 
+import java.nio.file.Path;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 
@@ -20,7 +21,7 @@ public class SystemTestSetupHelper {
     /**
      * Sets up a new {@code TestApp} and returns it.
      */
-    public TestApp setupApplication(Supplier<ReadOnlyAddressBook> addressBook, String saveFileLocation) {
+    public TestApp setupApplication(Supplier<ReadOnlyAddressBook> addressBook, Path saveFileLocation) {
         try {
             FxToolkit.registerStage(Stage::new);
             FxToolkit.setupApplication(() -> testApp = new TestApp(addressBook, saveFileLocation));


### PR DESCRIPTION
Fixes #750 
Fixes #554 

### Things to take note of
* The performance test in `PersonListPanelTest` is rather fickle. It fails sometimes, while passes in others. As such, `TEST_TIMEOUT` will be set to 12000 as a temporary measure until #863 is merged.
* Even though many classes in the UI component use `String` arguments for file names for `Class#getResource(String)`, the file names were changed to be of type `Path` and then converted to type `String` when needed. Not entirely sure if this is needed, but since using `Strings` for file names is still error prone I refactored it anyway. Do let me know if this shouldn't be the case. 

### Issues to raise
* Many parts of the codebase have methods that declare that they throw an `IOException` even though it is never thrown in the first place. One example is `JsonUserPrefsStorage#readUserPrefs(Path)`.
* A few methods have return values that are never used. One such example is `FileUtil#createFile(File)`.
* Many methods can be made to have a more restrictive access modifier. One such case would be the methods in `AddressBookSystemTest` which could be made to be private. Not sure if this was intended for future use though.
* `UserPrefs#getAddressBookName` is unused.