### PR TITLE
build.gradle: remove unused testfx-legacy dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,9 +55,6 @@ dependencies {
         exclude group: 'org.testfx', module: 'testfx-internal-java8'
     }
     testCompile group: 'org.testfx', name: 'testfx-junit', version: testFxVersion
-    testCompile group: 'org.testfx', name: 'testfx-legacy', version: '4.0.8-alpha', {
-        exclude group: 'junit', module: 'junit'
-    }
 
     testRuntime group: 'org.testfx', name: 'testfx-internal-java9', version: testFxVersion
     testRuntime group: 'org.testfx', name: 'openjfx-monocle', version: 'jdk-9+181'


### PR DESCRIPTION
`Testfx-legacy is depreciated and no longer supported. We use
testfx-core version 4.0.12-alpha, which is past the supported
testfx-legacy version of 4.0.8-alpha, and breaks it, according to
https://github.com/TestFX/TestFX#testfx-legacy-deprecated.`

`Let's remove the unused testfx-legacy dependency.`