### PR TITLE
build.gradle: remove field with default value #857

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,2 @@
-org.gradle.daemon=true
 org.gradle.parallel=false
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Xmx1024m -Dfile.encoding=utf-8


### PR DESCRIPTION
fixes #857

The line `org.gradle.daemon=true` in gradle.properties is a default
value as seen in
https://docs.gradle.org/4.6/userguide/gradle_daemon.html

It is unnecessary to specify default values.

Let's remove it.