### PR TITLE
.gitattributes: treat all *.pdf files as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.pdf binary


### PR DESCRIPTION
Fixes #878 