### PR TITLE
ClearCommandTest: fix tautological tests

### DIFF
--- a/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
@@ -6,6 +6,7 @@ import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 import org.junit.Test;
 
 import seedu.address.logic.CommandHistory;
+import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -15,13 +16,20 @@ public class ClearCommandTest {
     @Test
     public void execute_emptyAddressBook_success() {
         Model model = new ModelManager();
-        assertCommandSuccess(prepareCommand(model), model, ClearCommand.MESSAGE_SUCCESS, model);
+        Model expectedModel = new ModelManager();
+        expectedModel.commitAddressBook();
+
+        assertCommandSuccess(prepareCommand(model), model, ClearCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     @Test
     public void execute_nonEmptyAddressBook_success() {
         Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-        assertCommandSuccess(prepareCommand(model), model, ClearCommand.MESSAGE_SUCCESS, model);
+        Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        expectedModel.resetData(new AddressBook());
+        expectedModel.commitAddressBook();
+
+        assertCommandSuccess(prepareCommand(model), model, ClearCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     /**


### PR DESCRIPTION
```
Tests in ClearCommandTest always pass because the actual and expected
model refer to the same instance;
`assertEquals(expectedModel, actualModel)` is always true.

As a result, the model's state isn't correctly verified.

Let's update these tests to correctly verify the model's state.
```