### PR TITLE
PersonListPanelTest#createXmlFileWithPersons(): Fix incorrect path

### DIFF
--- a/src/test/java/seedu/address/ui/PersonListPanelTest.java
+++ b/src/test/java/seedu/address/ui/PersonListPanelTest.java
@@ -103,7 +103,7 @@ public class PersonListPanelTest extends GuiUnitTest {
         }
         builder.append("</addressbook>\n");
 
-        Path manyPersonsFile = Paths.get(TEST_DATA_FOLDER + "manyPersons.xml");
+        Path manyPersonsFile = TEST_DATA_FOLDER.resolve("manyPersons.xml");
         FileUtil.createFile(manyPersonsFile);
         FileUtil.writeToFile(manyPersonsFile, builder.toString());
         manyPersonsFile.toFile().deleteOnExit();


### PR DESCRIPTION
```
createXmlFileWithPersons() saves the location of the temporarily
generated .xml file to:

    src/test/data/sandboxmanyPersons.xml

instead of:

    src/test/data/sandbox/manyPersons.xml

It is likely that the original author of the test intended the saving
location to be the latter, given that it has always resolved to the
latter until we revamped the path handling logic in AddressBook to use
java.nio.file.Path API, which introduced this discrepancy (commit
9eac635d9da1a71c81587ba66cab1911977a863b).

Saving the temporary .xml file to the 'sandbox' folder is also ideal as
the folder is git-ignored, so even if JVM crashes and does not clean
up the temporary file, students would not accidentally commit this
potentially _enormous_ .xml file into the repository.

Let's fix the incorrect path.
```