### PR TITLE
CommandBox: Add lines to ignore enter key on empty input

### DIFF
--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -99,6 +99,10 @@ public class CommandBox extends UiPart<Region> {
      */
     @FXML
     private void handleCommandEntered() {
+        if (commandTextField.getText().equals("")) {
+            return;
+        }
+        
         try {
             CommandResult commandResult = logic.execute(commandTextField.getText());
             initHistory();

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -102,7 +102,7 @@ public class CommandBox extends UiPart<Region> {
         if (commandTextField.getText().equals("")) {
             return;
         }
-        
+
         try {
             CommandResult commandResult = logic.execute(commandTextField.getText());
             initHistory();


### PR DESCRIPTION
Quick fix for empty string and enter key pressed. Fixes issue #635 