### PR TITLE
StringUtilTest: Rename test method name

### DIFF
--- a/src/test/java/seedu/address/commons/util/StringUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/StringUtilTest.java
@@ -17,10 +17,10 @@ public class StringUtilTest {
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
-    //---------------- Tests for isUnsignedPositiveInteger --------------------------------------
+    //---------------- Tests for isNonZeroUnsignedInteger --------------------------------------
 
     @Test
-    public void isUnsignedPositiveInteger() {
+    public void isNonZeroUnsignedInteger() {
 
         // EP: empty strings
         assertFalse(StringUtil.isNonZeroUnsignedInteger("")); // Boundary value


### PR DESCRIPTION
Currently, StringUtilTest has a method named
isUnsignedPositiveInteger. However, the method tested is actually
named isNonZeroUnsignedInteger. This can cause confusion in the
naming.

It appears that the tested method was renamed to
isNonZeroUnsignedInteger in #460, however the test was not renamed
then.

To maintain consistent naming convention, lets rename the test method
to isNonZeroUnsignedInteger too.