### PR TITLE
FileUtilTest: Add test for Windows path

### DIFF
--- a/src/test/java/seedu/address/commons/util/FileUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/FileUtilTest.java
@@ -12,7 +12,8 @@ public class FileUtilTest {
     @Test
     public void isValidPath() {
         // valid path
-        assertTrue(FileUtil.isValidPath("valid/file/path"));
+        assertTrue(FileUtil.isValidPath("valid/file/path")); //Linux
+        assertTrue(FileUtil.isValidPath("valid\\file\\path")); //Windows
 
         // invalid path
         assertFalse(FileUtil.isValidPath("a\0"));


### PR DESCRIPTION
Currently, FileUtilTest#isValidPath() only tests for isValidPath for a linux path. However, our users can also develop and use AB4 on a Windows PC. To provide assurance that our FileUtil#isValidPath(String) method works on Windows computers as well, we should add coverage to test for paths on Windows.

Hence, let's add another test to ensure that FileUtil#isValidPath returns the correct result for a valid path in the Windows naming convention.