### PR TITLE
build.gradle: upgrade TestFX dependency to 4.0.15-alpha

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ test {
 }
 
 dependencies {
-    String testFxVersion = '4.0.12-alpha'
+    String testFxVersion = '4.0.15-alpha'
     String jUnitVersion = '5.1.0'
 
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.7.0'


### PR DESCRIPTION
The current version of TestFX dependency we are using is 4.0.12-alpha.

TestFX version 4.0.15-alpha has been announced for a while and it gives
better support for JDK11[1], which we may wish to upgrade to in the
future.

To keep us updated with TestFX's development, let's upgrade TestFX
dependency to its latest stable version 4.0.15-alpha.

[1] https://github.com/TestFX/TestFX/issues/640#issuecomment-436079910