### PR TITLE
Edit the addresses of DTD files used for checkstyle

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE module PUBLIC
-    "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-    "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+    "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+    "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
 <!--
     This configuration file enforces rules for a modified version of the module's code standard at

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 
 <!DOCTYPE suppressions PUBLIC
-"-//Puppy Crawl//DTD Suppressions 1.1//EN"
-"http://checkstyle.sourceforge.net/dtds/suppressions_1_1.dtd">
+    "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+    "https://checkstyle.org/dtds/suppressions_1_2.dtd">
 
 <suppressions>
   <suppress checks="JavadocType" files=".*Test\.java"/>


### PR DESCRIPTION
We are currently using the DTD files from `http://checkstyle.sourceforge.net/`
and `http://puppycrawl.com/` in our config file of checkstyle.

However, due to security reason, checkstyle decided to remove DTDs from
above websites and ask users to use the DTD files from
`https://checkstyle.org/`[1].

Let's update the addresses of DTD files correspondingly.

Meanwhile, update the version of suppression DTD file to 1.2 because it is
the version suggested from checkstyle. [2]

[1] https://github.com/checkstyle/checkstyle/issues/6478
[2] https://checkstyle.org/config_filters.html#SuppressionFilter_Examples