### PR TITLE
ConfigTest: Remove unused ExpectedException

### DIFF
--- a/src/test/java/seedu/address/commons/core/ConfigTest.java
+++ b/src/test/java/seedu/address/commons/core/ConfigTest.java
@@ -4,13 +4,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class ConfigTest {
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void toString_defaultObject_stringReturned() {


### PR DESCRIPTION
ConfigTest contains an unused ExpectedException. It appears that the
ExpectedException was first introduced in [1].
However, since its introduction, there have been no tests within
ConfigTest that potentially throws an expected exception.

Hence, to make our code tidier and to remove unnecessary code, let's
remove the ExpectedException together with their imports.

[1] https://github.com/se-edu/addressbook-level4/commit/75942c90c04ff0469d5bb26873b85cd094f37797