### PR TITLE
StringUtilTest: Remove Hamcrest String matcher

### DIFF
--- a/src/test/java/seedu/address/commons/util/StringUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/StringUtilTest.java
@@ -1,7 +1,5 @@
 package seedu.address.commons.util;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -145,8 +143,8 @@ public class StringUtilTest {
 
     @Test
     public void getDetails_exceptionGiven() {
-        assertThat(StringUtil.getDetails(new FileNotFoundException("file not found")),
-                   containsString("java.io.FileNotFoundException: file not found"));
+        assertTrue(StringUtil.getDetails(new FileNotFoundException("file not found"))
+            .contains("java.io.FileNotFoundException: file not found"));
     }
 
     @Test


### PR DESCRIPTION
Currently, in StringUtilTest#getDetails_exceptionGiven, we use
Hamcrest's string matching and assert libraries.
This library was introduced in [1], however no documentation was
logged on why we specifically used these Hamcrest libraries. In fact,
this is the only instance in the entire project where we use this
dependency.

We are only using the contains API of the Hamcrest library, whose
corresponding functionality is already implemented in Java standard
String library. Hence, the Hamcrest library serves little extra
benefit, and introuduces extra dependencies for our tests.

Hence, let's remove the Hamcrest libraries and replace them with the
equivalent Java and JUnit APIs.

[1] https://github.com/se-edu/addressbook-level4/commit/75942c90c04ff0469d5bb26873b85cd094f37797