### PR TITLE
UiPartTest: remove unused ExpectedException

### DIFF
--- a/src/test/java/seedu/address/ui/UiPartTest.java
+++ b/src/test/java/seedu/address/ui/UiPartTest.java
@@ -7,7 +7,6 @@ import java.net.URL;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 import javafx.fxml.FXML;
@@ -21,9 +20,6 @@ public class UiPartTest {
     private static final String VALID_FILE_PATH = "UiPartTest/validFile.fxml";
     private static final String VALID_FILE_WITH_FX_ROOT_PATH = "UiPartTest/validFileWithFxRoot.fxml";
     private static final TestFxmlObject VALID_FILE_ROOT = new TestFxmlObject("Hello World!");
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
 
     @Rule
     public TemporaryFolder testFolder = new TemporaryFolder();


### PR DESCRIPTION
The tests in UiPartTest do not use the ExpectedException.

Let's remove it.


P. S. Somehow didn't notice this until now...