### PR TITLE
VersionTest, VersionedAddressBookTest: Use 8-spaces indent for parameter lists

### DIFF
--- a/src/test/java/seedu/address/commons/core/VersionTest.java
+++ b/src/test/java/seedu/address/commons/core/VersionTest.java
@@ -133,7 +133,7 @@ public class VersionTest {
     }
 
     private void verifyVersionParsedCorrectly(String versionString,
-                                              int major, int minor, int patch, boolean isEarlyAccess) {
+            int major, int minor, int patch, boolean isEarlyAccess) {
         assertEquals(new Version(major, minor, patch, isEarlyAccess), Version.fromString(versionString));
     }
 }

--- a/src/test/java/seedu/address/model/VersionedAddressBookTest.java
+++ b/src/test/java/seedu/address/model/VersionedAddressBookTest.java
@@ -241,9 +241,9 @@ public class VersionedAddressBookTest {
      * and states after {@code versionedAddressBook#currentStatePointer} is equal to {@code expectedStatesAfterPointer}.
      */
     private void assertAddressBookListStatus(VersionedAddressBook versionedAddressBook,
-                                             List<ReadOnlyAddressBook> expectedStatesBeforePointer,
-                                             ReadOnlyAddressBook expectedCurrentState,
-                                             List<ReadOnlyAddressBook> expectedStatesAfterPointer) {
+            List<ReadOnlyAddressBook> expectedStatesBeforePointer,
+            ReadOnlyAddressBook expectedCurrentState,
+            List<ReadOnlyAddressBook> expectedStatesAfterPointer) {
         // check state currently pointing at is correct
         assertEquals(new AddressBook(versionedAddressBook), expectedCurrentState);
 


### PR DESCRIPTION
VersionTest and VersionedAddressBookTest contain tests that align
multi-line parameter lists instead of using 8-spaces to indent the
lines.

Let's bring them in line with our coding style and use 8-spaces.