### PR TITLE
TestApp: code quality cleanups

### DIFF
--- a/src/test/java/seedu/address/TestApp.java
+++ b/src/test/java/seedu/address/TestApp.java
@@ -25,12 +25,11 @@ import systemtests.ModelHelper;
  */
 public class TestApp extends MainApp {
 
-    public static final Path SAVE_LOCATION_FOR_TESTING = TestUtil.getFilePathInSandboxFolder("sampleData.json");
 
     protected static final Path DEFAULT_PREF_FILE_LOCATION_FOR_TESTING =
             TestUtil.getFilePathInSandboxFolder("pref_testing.json");
     protected Supplier<ReadOnlyAddressBook> initialDataSupplier = () -> null;
-    protected Path saveFileLocation = SAVE_LOCATION_FOR_TESTING;
+    private Path saveFileLocation;
 
     public TestApp() {
     }

--- a/src/test/java/seedu/address/TestApp.java
+++ b/src/test/java/seedu/address/TestApp.java
@@ -28,9 +28,6 @@ public class TestApp extends MainApp {
     private Path saveFileLocation;
     private Path prefFileLocation;
 
-    public TestApp() {
-    }
-
     public TestApp(Supplier<ReadOnlyAddressBook> initialDataSupplier, Path saveFileLocation, Path prefFileLocation) {
         super();
         this.initialDataSupplier = initialDataSupplier;

--- a/src/test/java/seedu/address/TestApp.java
+++ b/src/test/java/seedu/address/TestApp.java
@@ -16,7 +16,6 @@ import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.UserPrefs;
 import seedu.address.storage.JsonAddressBookStorage;
 import seedu.address.storage.UserPrefsStorage;
-import seedu.address.testutil.TestUtil;
 import systemtests.ModelHelper;
 
 /**
@@ -25,19 +24,18 @@ import systemtests.ModelHelper;
  */
 public class TestApp extends MainApp {
 
-
-    protected static final Path DEFAULT_PREF_FILE_LOCATION_FOR_TESTING =
-            TestUtil.getFilePathInSandboxFolder("pref_testing.json");
     protected Supplier<ReadOnlyAddressBook> initialDataSupplier = () -> null;
     private Path saveFileLocation;
+    private Path prefFileLocation;
 
     public TestApp() {
     }
 
-    public TestApp(Supplier<ReadOnlyAddressBook> initialDataSupplier, Path saveFileLocation) {
+    public TestApp(Supplier<ReadOnlyAddressBook> initialDataSupplier, Path saveFileLocation, Path prefFileLocation) {
         super();
         this.initialDataSupplier = initialDataSupplier;
         this.saveFileLocation = saveFileLocation;
+        this.prefFileLocation = prefFileLocation;
 
         // If some initial local data has been provided, write those to the file
         if (initialDataSupplier.get() != null) {
@@ -53,7 +51,7 @@ public class TestApp extends MainApp {
     @Override
     protected Config initConfig(Path configFilePath) {
         Config config = super.initConfig(configFilePath);
-        config.setUserPrefsFilePath(DEFAULT_PREF_FILE_LOCATION_FOR_TESTING);
+        config.setUserPrefsFilePath(prefFileLocation);
         return config;
     }
 

--- a/src/test/java/seedu/address/TestApp.java
+++ b/src/test/java/seedu/address/TestApp.java
@@ -24,7 +24,7 @@ import systemtests.ModelHelper;
  */
 public class TestApp extends MainApp {
 
-    protected Supplier<ReadOnlyAddressBook> initialDataSupplier = () -> null;
+    private Supplier<ReadOnlyAddressBook> initialDataSupplier = () -> null;
     private Path saveFileLocation;
     private Path prefFileLocation;
 

--- a/src/test/java/seedu/address/TestApp.java
+++ b/src/test/java/seedu/address/TestApp.java
@@ -24,7 +24,7 @@ import systemtests.ModelHelper;
  */
 public class TestApp extends MainApp {
 
-    private Supplier<ReadOnlyAddressBook> initialDataSupplier = () -> null;
+    private Supplier<ReadOnlyAddressBook> initialDataSupplier;
     private Path saveFileLocation;
     private Path prefFileLocation;
 

--- a/src/test/java/systemtests/AddressBookSystemTest.java
+++ b/src/test/java/systemtests/AddressBookSystemTest.java
@@ -36,6 +36,7 @@ import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.SelectCommand;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
+import seedu.address.testutil.TestUtil;
 import seedu.address.testutil.TypicalPersons;
 import seedu.address.ui.BrowserPanel;
 import seedu.address.ui.CommandBox;
@@ -47,6 +48,8 @@ import seedu.address.ui.CommandBox;
 public abstract class AddressBookSystemTest {
     @ClassRule
     public static ClockRule clockRule = new ClockRule();
+
+    private static final Path SAVE_LOCATION_FOR_TESTING = TestUtil.getFilePathInSandboxFolder("sampleData.json");
 
     private static final List<String> COMMAND_BOX_DEFAULT_STYLE = Arrays.asList("text-input", "text-field");
     private static final List<String> COMMAND_BOX_ERROR_STYLE =
@@ -87,7 +90,7 @@ public abstract class AddressBookSystemTest {
      * Returns the directory of the data file.
      */
     protected Path getDataFileLocation() {
-        return TestApp.SAVE_LOCATION_FOR_TESTING;
+        return SAVE_LOCATION_FOR_TESTING;
     }
 
     public MainWindowHandle getMainWindowHandle() {

--- a/src/test/java/systemtests/AddressBookSystemTest.java
+++ b/src/test/java/systemtests/AddressBookSystemTest.java
@@ -50,6 +50,7 @@ public abstract class AddressBookSystemTest {
     public static ClockRule clockRule = new ClockRule();
 
     private static final Path SAVE_LOCATION_FOR_TESTING = TestUtil.getFilePathInSandboxFolder("sampleData.json");
+    private static final Path PREF_LOCATION_FOR_TESTING = TestUtil.getFilePathInSandboxFolder("pref_testing.json");
 
     private static final List<String> COMMAND_BOX_DEFAULT_STYLE = Arrays.asList("text-input", "text-field");
     private static final List<String> COMMAND_BOX_ERROR_STYLE =
@@ -67,7 +68,8 @@ public abstract class AddressBookSystemTest {
     @Before
     public void setUp() {
         setupHelper = new SystemTestSetupHelper();
-        testApp = setupHelper.setupApplication(this::getInitialData, getDataFileLocation());
+        testApp = setupHelper.setupApplication(this::getInitialData, getDataFileLocation(),
+                getPrefFileLocation());
         mainWindowHandle = setupHelper.setupMainWindowHandle();
 
         waitUntilBrowserLoaded(getBrowserPanel());
@@ -91,6 +93,10 @@ public abstract class AddressBookSystemTest {
      */
     protected Path getDataFileLocation() {
         return SAVE_LOCATION_FOR_TESTING;
+    }
+
+    protected Path getPrefFileLocation() {
+        return PREF_LOCATION_FOR_TESTING;
     }
 
     public MainWindowHandle getMainWindowHandle() {

--- a/src/test/java/systemtests/SystemTestSetupHelper.java
+++ b/src/test/java/systemtests/SystemTestSetupHelper.java
@@ -21,10 +21,11 @@ public class SystemTestSetupHelper {
     /**
      * Sets up a new {@code TestApp} and returns it.
      */
-    public TestApp setupApplication(Supplier<ReadOnlyAddressBook> addressBook, Path saveFileLocation) {
+    public TestApp setupApplication(Supplier<ReadOnlyAddressBook> addressBook, Path saveFileLocation,
+            Path prefFileLocation) {
         try {
             FxToolkit.registerStage(Stage::new);
-            FxToolkit.setupApplication(() -> testApp = new TestApp(addressBook, saveFileLocation));
+            FxToolkit.setupApplication(() -> testApp = new TestApp(addressBook, saveFileLocation, prefFileLocation));
         } catch (TimeoutException te) {
             throw new AssertionError("Application takes too long to set up.", te);
         }


### PR DESCRIPTION
Constants SAVE_LOCATION_FOR_TESTING and DEFAULT_PREF_LOCATION_FOR_TESTING exist within TestApp. This reduces our flexibility for testing as test drivers like AddressBookSystemTest cannot configure the values. This design also violates the tell-don't-ask principle as AddressBookSystemTest has to retrieve the constant value from within TestApp, then initialise TestApp with these default values.

TestApp also has an unused default constructor. Additionally, we can also set its initialDataSupplier variable to private and remove the its redundant default null supplier.

To improve the code quality within our code base, let's clean up TestApp.