### PR TITLE
TemporaryFolder: Remove unnecessary call to TemporaryFolder#newFile

### DIFF
--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -49,8 +49,10 @@ public class LogicManagerTest {
 
     @Before
     public void setUp() throws Exception {
-        JsonAddressBookStorage addressBookStorage = new JsonAddressBookStorage(temporaryFolder.newFile().toPath());
-        JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(temporaryFolder.newFile().toPath());
+        JsonAddressBookStorage addressBookStorage =
+                new JsonAddressBookStorage(temporaryFolder.getRoot().toPath().resolve("addressBook.json"));
+        JsonUserPrefsStorage userPrefsStorage =
+                new JsonUserPrefsStorage(temporaryFolder.getRoot().toPath().resolve("userPrefs.json"));
         StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage);
         logic = new LogicManager(model, storage);
     }
@@ -79,9 +81,10 @@ public class LogicManagerTest {
     @Test
     public void execute_storageThrowsIoException_throwsCommandException() throws Exception {
         // Setup LogicManager with JsonAddressBookIoExceptionThrowingStub
-        JsonAddressBookStorage addressBookStorage =
-                new JsonAddressBookIoExceptionThrowingStub(temporaryFolder.newFile().toPath());
-        JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(temporaryFolder.newFile().toPath());
+        JsonAddressBookStorage addressBookStorage = new JsonAddressBookIoExceptionThrowingStub(
+                temporaryFolder.getRoot().toPath().resolve("ioExceptionAddressBook.json"));
+        JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(
+                temporaryFolder.getRoot().toPath().resolve("ioExceptionUserPrefs.json"));
         StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage);
         logic = new LogicManager(model, storage);
 

--- a/src/test/java/seedu/address/ui/MainWindowCloseTest.java
+++ b/src/test/java/seedu/address/ui/MainWindowCloseTest.java
@@ -34,8 +34,10 @@ public class MainWindowCloseTest extends GuiUnitTest {
 
     @Before
     public void setUp() throws Exception {
-        JsonAddressBookStorage jsonAddressBookStorage = new JsonAddressBookStorage(temporaryFolder.newFile().toPath());
-        JsonUserPrefsStorage jsonUserPrefsStorage = new JsonUserPrefsStorage(temporaryFolder.newFile().toPath());
+        JsonAddressBookStorage jsonAddressBookStorage =
+                new JsonAddressBookStorage(temporaryFolder.getRoot().toPath().resolve("addressBook.json"));
+        JsonUserPrefsStorage jsonUserPrefsStorage =
+                new JsonUserPrefsStorage(temporaryFolder.getRoot().toPath().resolve("userPrefs.json"));
         StorageManager storageManager = new StorageManager(jsonAddressBookStorage, jsonUserPrefsStorage);
         FxToolkit.setupStage(stage -> {
             this.stage = stage;


### PR DESCRIPTION
LogicManagerTest and MainWindowCloseTest calls newFile() on a
temporary folder to initialize an empty file for the AddressBoook and
UserPrefs storage.

This is unnecessary, as the file is automatically created the first
time it is written to.

Instead of explicitly creating a new file, let's simply reference a
file path with Path#resolve instead.

Reference: https://github.com/se-edu/addressbook-level4/pull/959#discussion_r276946591