### PR TITLE
build.gradle: Remove TestFX-JUnit dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,6 @@ dependencies {
 
     testImplementation group: 'junit', name: 'junit', version: '4.12'
     testImplementation group: 'org.testfx', name: 'testfx-core', version: testFxVersion
-    testImplementation group: 'org.testfx', name: 'testfx-junit', version: testFxVersion
 
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: jUnitVersion
 


### PR DESCRIPTION
We include the TestFX-JUnit dependency in our build.gradle since [1].
However, we also implement our own StageRule and SystemTestSetupHelper
to setup the UI environment for unit tests and system tests
respectively. These classes replicate TestFX-JUnit's ApplicationTest
behavior [2], so our tests do not need to extend from ApplicationTest.

According to TestFX's documentation [3], TestFX-JUnit provides the
ApplicationTest class that we can inherit from. Since we already
implement the necessary setup routine, we do not need to inherit from
ApplicationTest. TestFX-JUnit thus adds no value to our project now.

Let's remove the TestFX-JUnit dependency.

[1]: https://github.com/se-edu/addressbook-level4/commit/7916322fad9d11ef3fa7ca67574062bb6de3e950
[2]: https://github.com/TestFX/TestFX/blob/master/subprojects/testfx-junit/src/main/java/org/testfx/framework/junit/ApplicationTest.java
[3]: https://github.com/TestFX/TestFX#junit-5-2