### PR TITLE
.gitignore: standardize and specify entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,20 +1,21 @@
-build/
-.gradle/
-.checkstyle
-.settings/
-.idea/
-lib/*
-*.iml
-*.log
-*.log.*
-*.csv
-config.json
-src/test/data/sandbox/
-preferences.json
-.DS_Store
-./screenshot*.png
-classes/
-/data/
-/bin/
+# Gradle build files
+/.gradle/
+/build/
 src/main/resources/docs/
-out/
+
+# IDEA files
+/.idea/
+/out/
+/*.iml
+
+# Storage/log files
+/data/
+/config.json
+/preferences.json
+/*.log.*
+
+# Test sandbox files
+src/test/data/sandbox/
+
+# MacOS custom attributes files created by Finder
+.DS_Store


### PR DESCRIPTION
Fixes #926.

We ignore config.json and preferences.json by adding entries in
.gitignore.

The entries added are too general so git will also ignore other files
with same name, which is an unwanted behavior.

Let's specific the entries in .gitignore to solve the problem.