### PR TITLE
Fix improper usage of `an`

### DIFF
--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -13,7 +13,7 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
 
     /**
      * Parses the given {@code String} of arguments in the context of the DeleteCommand
-     * and returns an DeleteCommand object for execution.
+     * and returns a DeleteCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
     public DeleteCommand parse(String args) throws ParseException {

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -15,7 +15,7 @@ public class FindCommandParser implements Parser<FindCommand> {
 
     /**
      * Parses the given {@code String} of arguments in the context of the FindCommand
-     * and returns an FindCommand object for execution.
+     * and returns a FindCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
     public FindCommand parse(String args) throws ParseException {

--- a/src/main/java/seedu/address/logic/parser/SelectCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SelectCommandParser.java
@@ -13,7 +13,7 @@ public class SelectCommandParser implements Parser<SelectCommand> {
 
     /**
      * Parses the given {@code String} of arguments in the context of the SelectCommand
-     * and returns an SelectCommand object for execution.
+     * and returns a SelectCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
     public SelectCommand parse(String args) throws ParseException {

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -20,7 +20,7 @@ public class AddressBook implements ReadOnlyAddressBook {
     private final InvalidationListenerManager invalidationListenerManager = new InvalidationListenerManager();
 
     /*
-     * The 'unusual' code block below is an non-static initialization block, sometimes used to avoid duplication
+     * The 'unusual' code block below is a non-static initialization block, sometimes used to avoid duplication
      * between constructors. See https://docs.oracle.com/javase/tutorial/java/javaOO/initial.html
      *
      * Note that non-static init blocks are not recommended to use. There are other ways to avoid duplication

--- a/src/main/java/seedu/address/ui/ListElementPointer.java
+++ b/src/main/java/seedu/address/ui/ListElementPointer.java
@@ -33,7 +33,7 @@ public class ListElementPointer {
     }
 
     /**
-     * Returns true if calling {@code #next()} does not throw an {@code NoSuchElementException}.
+     * Returns true if calling {@code #next()} does not throw a {@code NoSuchElementException}.
      */
     public boolean hasNext() {
         int nextIndex = index + 1;
@@ -41,7 +41,7 @@ public class ListElementPointer {
     }
 
     /**
-     * Returns true if calling {@code #previous()} does not throw an {@code NoSuchElementException}.
+     * Returns true if calling {@code #previous()} does not throw a {@code NoSuchElementException}.
      */
     public boolean hasPrevious() {
         int previousIndex = index - 1;
@@ -49,7 +49,7 @@ public class ListElementPointer {
     }
 
     /**
-     * Returns true if calling {@code #current()} does not throw an {@code NoSuchElementException}.
+     * Returns true if calling {@code #current()} does not throw a {@code NoSuchElementException}.
      */
     public boolean hasCurrent() {
         return isWithinBounds(index);


### PR DESCRIPTION
Fixes #357. 

There are some typos in our codebase related to the usage of `an`.

Let's fix the improper usage of `an` to solve the problem.