### PR TITLE
CommandBox: update handleCommandEntered() for empty strings

### DIFF
--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -97,8 +97,13 @@ public class CommandBox extends UiPart<Region> {
      */
     @FXML
     private void handleCommandEntered() {
+        String commandText = commandTextField.getText();
+        if (commandText.equals("")) {
+            return;
+        }
+
         try {
-            commandExecutor.execute(commandTextField.getText());
+            commandExecutor.execute(commandText);
             initHistory();
             historySnapshot.next();
             commandTextField.setText("");


### PR DESCRIPTION
Fixes #635.

Update handleCommandEntered() to return once an empty string is encountered.