### PR TITLE
Provide faster feedback for execution by Parallel Build

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.parallel=false
+org.gradle.parallel=true
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Xmx1024m -Dfile.encoding=utf-8
 
 # TODO: This is a workaround for a JDK11 bug which causes test coverage upload to fail.


### PR DESCRIPTION

[Parallel builds](https://docs.gradle.org/current/userguide/multi_project_configuration_and_execution.html#sec:parallel_execution). This project contains multiple modules. Parallel builds can improve the build speed by executing tasks in parallel. We can enable this feature by setting `org.gradle.parallel=true`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
